### PR TITLE
Updating Reserve structs

### DIFF
--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -4199,6 +4199,18 @@
                     "validation_action": "error"
                 },
                 {
+                    "name": "requirement",
+                    "comment": "the static value of required reserves in system p.u.",
+                    "null_value": "0.0",
+                    "data_type": "Float64",
+                    "valid_range": {
+                        "min": 0,
+                        "max": null
+                    },
+                    "validation_action": "error",
+                    "needs_conversion": true
+                },
+                {
                     "name": "sustained_time",
                     "comment": "the time in secounds reserve contribution must sustained at a specified level",
                     "null_value": "0.0",
@@ -4207,6 +4219,7 @@
                         "min": 0,
                         "max": null
                     },
+                    "default": "3600.0",
                     "validation_action": "error"
                 },
                 {
@@ -4220,18 +4233,6 @@
                     },
                     "default": "1.0",
                     "validation_action": "error"
-                },
-                {
-                    "name": "requirement",
-                    "comment": "the static value of required reserves in system p.u.",
-                    "null_value": "0.0",
-                    "data_type": "Float64",
-                    "valid_range": {
-                        "min": 0,
-                        "max": null
-                    },
-                    "validation_action": "error",
-                    "needs_conversion": true
                 },
                 {
                     "name": "ext",
@@ -4276,6 +4277,18 @@
                     "validation_action": "error"
                 },
                 {
+                    "name": "requirement",
+                    "comment": "the static value of required reserves in system p.u.",
+                    "null_value": "0.0",
+                    "data_type": "Float64",
+                    "valid_range": {
+                        "min": 0,
+                        "max": null
+                    },
+                    "validation_action": "error",
+                    "needs_conversion": true
+                },
+                {
                     "name": "sustained_time",
                     "comment": "the time in secounds reserve contribution must sustained at a specified level",
                     "null_value": "0.0",
@@ -4284,6 +4297,7 @@
                         "min": 0,
                         "max": null
                     },
+                    "default": "3600.0",
                     "validation_action": "error"
                 },
                 {
@@ -4297,18 +4311,6 @@
                     },
                     "default": "1.0",
                     "validation_action": "error"
-                },
-                {
-                    "name": "requirement",
-                    "comment": "the static value of required reserves in system p.u.",
-                    "null_value": "0.0",
-                    "data_type": "Float64",
-                    "valid_range": {
-                        "min": 0,
-                        "max": null
-                    },
-                    "validation_action": "error",
-                    "needs_conversion": true
                 },
                 {
                     "name": "ext",
@@ -4485,6 +4487,12 @@
                     "validation_action": "error"
                 },
                 {
+                    "name": "requirement",
+                    "comment": "the required quantity of the product should be scaled by a TimeSeriesData",
+                    "null_value": "0.0",
+                    "data_type": "Float64"
+                },
+                {
                     "name": "sustained_time",
                     "comment": "the time in secounds reserve contribution must sustained at a specified level",
                     "null_value": "0.0",
@@ -4493,6 +4501,7 @@
                         "min": 0,
                         "max": null
                     },
+                    "default": "3600.0",
                     "validation_action": "error"
                 },
                 {
@@ -4506,12 +4515,6 @@
                     },
                     "default": "1.0",
                     "validation_action": "error"
-                },
-                {
-                    "name": "requirement",
-                    "comment": "the required quantity of the product should be scaled by a TimeSeriesData",
-                    "null_value": "0.0",
-                    "data_type": "Float64"
                 },
                 {
                     "name": "ext",
@@ -4563,6 +4566,13 @@
                     "validation_action": "error"
                 },
                 {
+                    "name": "requirement",
+                    "comment": "the required quantity of the product should be scaled by a TimeSeriesData",
+                    "null_value": "0.0",
+                    "data_type": "Float64",
+                    "needs_conversion": true
+                },
+                {
                     "name": "sustained_time",
                     "comment": "the time in secounds reserve contribution must sustained at a specified level",
                     "null_value": "0.0",
@@ -4571,6 +4581,7 @@
                         "min": 0,
                         "max": null
                     },
+                    "default": "14400.0",
                     "validation_action": "error"
                 },
                 {
@@ -4584,13 +4595,6 @@
                     },
                     "default": "1.0",
                     "validation_action": "error"
-                },
-                {
-                    "name": "requirement",
-                    "comment": "the required quantity of the product should be scaled by a TimeSeriesData",
-                    "null_value": "0.0",
-                    "data_type": "Float64",
-                    "needs_conversion": true
                 },
                 {
                     "name": "ext",

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -4189,13 +4189,36 @@
                 },
                 {
                     "name": "time_frame",
-                    "comment": "the relative saturation time_frame",
+                    "comment": "the saturation time_frame in minutes to provide reserve contribution",
                     "null_value": "0.0",
                     "data_type": "Float64",
                     "valid_range": {
                         "min": 0,
                         "max": null
                     },
+                    "validation_action": "error"
+                },
+                {
+                    "name": "sustained_time",
+                    "comment": "the time in secounds reserve contribution must sustained at a specified level",
+                    "null_value": "0.0",
+                    "data_type": "Float64",
+                    "valid_range": {
+                        "min": 0,
+                        "max": null
+                    },
+                    "validation_action": "error"
+                },
+                {
+                    "name": "max_participation_factor",
+                    "comment": "the maximum limit of reserve contribution per device",
+                    "null_value": "1.0",
+                    "data_type": "Float64",
+                    "valid_range": {
+                        "min": 0,
+                        "max": 1
+                    },
+                    "default": "1.0",
                     "validation_action": "error"
                 },
                 {
@@ -4243,13 +4266,36 @@
                 },
                 {
                     "name": "time_frame",
-                    "comment": "the relative saturation time_frame",
+                    "comment": "the saturation time_frame in minutes to provide reserve contribution",
                     "null_value": "0.0",
                     "data_type": "Float64",
                     "valid_range": {
                         "min": 0,
                         "max": null
                     },
+                    "validation_action": "error"
+                },
+                {
+                    "name": "sustained_time",
+                    "comment": "the time in secounds reserve contribution must sustained at a specified level",
+                    "null_value": "0.0",
+                    "data_type": "Float64",
+                    "valid_range": {
+                        "min": 0,
+                        "max": null
+                    },
+                    "validation_action": "error"
+                },
+                {
+                    "name": "max_participation_factor",
+                    "comment": "the maximum limit of reserve contribution per device",
+                    "null_value": "1.0",
+                    "data_type": "Float64",
+                    "valid_range": {
+                        "min": 0,
+                        "max": 1
+                    },
+                    "default": "1.0",
                     "validation_action": "error"
                 },
                 {
@@ -4356,13 +4402,36 @@
                 },
                 {
                     "name": "time_frame",
-                    "comment": "the relative saturation time_frame",
+                    "comment": "the saturation time_frame in minutes to provide reserve contribution",
                     "null_value": "0.0",
                     "data_type": "Float64",
                     "valid_range": {
                         "min": 0,
                         "max": null
                     },
+                    "validation_action": "error"
+                },
+                {
+                    "name": "sustained_time",
+                    "comment": "the time in secounds reserve contribution must sustained at a specified level",
+                    "null_value": "0.0",
+                    "data_type": "Float64",
+                    "valid_range": {
+                        "min": 0,
+                        "max": null
+                    },
+                    "validation_action": "error"
+                },
+                {
+                    "name": "max_participation_factor",
+                    "comment": "the maximum limit of reserve contribution per device",
+                    "null_value": "1.0",
+                    "data_type": "Float64",
+                    "valid_range": {
+                        "min": 0,
+                        "max": 1
+                    },
+                    "default": "1.0",
                     "validation_action": "error"
                 },
                 {
@@ -4406,15 +4475,37 @@
                 },
                 {
                     "name": "time_frame",
-                    "comment": "the relative saturation time_frame",
+                    "comment": "the saturation time_frame in minutes to provide reserve contribution",
                     "null_value": "0.0",
                     "data_type": "Float64",
                     "valid_range": {
                         "min": 0,
                         "max": null
                     },
-                    "validation_action": "error",
-                    "needs_conversion": true
+                    "validation_action": "error"
+                },
+                {
+                    "name": "sustained_time",
+                    "comment": "the time in secounds reserve contribution must sustained at a specified level",
+                    "null_value": "0.0",
+                    "data_type": "Float64",
+                    "valid_range": {
+                        "min": 0,
+                        "max": null
+                    },
+                    "validation_action": "error"
+                },
+                {
+                    "name": "max_participation_factor",
+                    "comment": "the maximum limit of reserve contribution per device",
+                    "null_value": "1.0",
+                    "data_type": "Float64",
+                    "valid_range": {
+                        "min": 0,
+                        "max": 1
+                    },
+                    "default": "1.0",
+                    "validation_action": "error"
                 },
                 {
                     "name": "requirement",
@@ -4462,13 +4553,36 @@
                 },
                 {
                     "name": "time_frame",
-                    "comment": "the relative saturation time_frame",
+                    "comment": "the saturation time_frame in minutes to provide reserve contribution",
                     "null_value": "0.0",
                     "data_type": "Float64",
                     "valid_range": {
                         "min": 0,
                         "max": null
                     },
+                    "validation_action": "error"
+                },
+                {
+                    "name": "sustained_time",
+                    "comment": "the time in secounds reserve contribution must sustained at a specified level",
+                    "null_value": "0.0",
+                    "data_type": "Float64",
+                    "valid_range": {
+                        "min": 0,
+                        "max": null
+                    },
+                    "validation_action": "error"
+                },
+                {
+                    "name": "max_participation_factor",
+                    "comment": "the maximum limit of reserve contribution per device",
+                    "null_value": "1.0",
+                    "data_type": "Float64",
+                    "valid_range": {
+                        "min": 0,
+                        "max": 1
+                    },
+                    "default": "1.0",
                     "validation_action": "error"
                 },
                 {

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -4422,6 +4422,7 @@
                         "min": 0,
                         "max": null
                     },
+                    "default": "3600.0",
                     "validation_action": "error"
                 },
                 {

--- a/src/models/generated/ReserveDemandCurve.jl
+++ b/src/models/generated/ReserveDemandCurve.jl
@@ -10,6 +10,8 @@ This file is auto-generated. Do not edit.
         name::String
         available::Bool
         time_frame::Float64
+        sustained_time::Float64
+        max_participation_factor::Float64
         ext::Dict{String, Any}
         time_series_container::InfrastructureSystems.TimeSeriesContainer
         internal::InfrastructureSystemsInternal
@@ -21,7 +23,9 @@ Data Structure for a operating reserve with demand curve product for system simu
 - `variable::Union{Nothing, IS.TimeSeriesKey}`: Variable Cost TimeSeriesKey
 - `name::String`
 - `available::Bool`
-- `time_frame::Float64`: the relative saturation time_frame, validation range: `(0, nothing)`, action if invalid: `error`
+- `time_frame::Float64`: the saturation time_frame in minutes to provide reserve contribution, validation range: `(0, nothing)`, action if invalid: `error`
+- `sustained_time::Float64`: the time in secounds reserve contribution must sustained at a specified level, validation range: `(0, nothing)`, action if invalid: `error`
+- `max_participation_factor::Float64`: the maximum limit of reserve contribution per device, validation range: `(0, 1)`, action if invalid: `error`
 - `ext::Dict{String, Any}`
 - `time_series_container::InfrastructureSystems.TimeSeriesContainer`: internal time_series storage
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
@@ -31,8 +35,12 @@ mutable struct ReserveDemandCurve{T <: ReserveDirection} <: Reserve{T}
     variable::Union{Nothing, IS.TimeSeriesKey}
     name::String
     available::Bool
-    "the relative saturation time_frame"
+    "the saturation time_frame in minutes to provide reserve contribution"
     time_frame::Float64
+    "the time in secounds reserve contribution must sustained at a specified level"
+    sustained_time::Float64
+    "the maximum limit of reserve contribution per device"
+    max_participation_factor::Float64
     ext::Dict{String, Any}
     "internal time_series storage"
     time_series_container::InfrastructureSystems.TimeSeriesContainer
@@ -40,12 +48,12 @@ mutable struct ReserveDemandCurve{T <: ReserveDirection} <: Reserve{T}
     internal::InfrastructureSystemsInternal
 end
 
-function ReserveDemandCurve{T}(variable, name, available, time_frame, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), ) where T <: ReserveDirection
-    ReserveDemandCurve{T}(variable, name, available, time_frame, ext, time_series_container, InfrastructureSystemsInternal(), )
+function ReserveDemandCurve{T}(variable, name, available, time_frame, sustained_time, max_participation_factor=1.0, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), ) where T <: ReserveDirection
+    ReserveDemandCurve{T}(variable, name, available, time_frame, sustained_time, max_participation_factor, ext, time_series_container, InfrastructureSystemsInternal(), )
 end
 
-function ReserveDemandCurve{T}(; variable, name, available, time_frame, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), internal=InfrastructureSystemsInternal(), ) where T <: ReserveDirection
-    ReserveDemandCurve{T}(variable, name, available, time_frame, ext, time_series_container, internal, )
+function ReserveDemandCurve{T}(; variable, name, available, time_frame, sustained_time, max_participation_factor=1.0, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), internal=InfrastructureSystemsInternal(), ) where T <: ReserveDirection
+    ReserveDemandCurve{T}(variable, name, available, time_frame, sustained_time, max_participation_factor, ext, time_series_container, internal, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -55,6 +63,8 @@ function ReserveDemandCurve{T}(::Nothing) where T <: ReserveDirection
         name="init",
         available=false,
         time_frame=0.0,
+        sustained_time=0.0,
+        max_participation_factor=1.0,
         ext=Dict{String, Any}(),
         time_series_container=InfrastructureSystems.TimeSeriesContainer(),
     )
@@ -68,6 +78,10 @@ get_name(value::ReserveDemandCurve) = value.name
 get_available(value::ReserveDemandCurve) = value.available
 """Get [`ReserveDemandCurve`](@ref) `time_frame`."""
 get_time_frame(value::ReserveDemandCurve) = value.time_frame
+"""Get [`ReserveDemandCurve`](@ref) `sustained_time`."""
+get_sustained_time(value::ReserveDemandCurve) = value.sustained_time
+"""Get [`ReserveDemandCurve`](@ref) `max_participation_factor`."""
+get_max_participation_factor(value::ReserveDemandCurve) = value.max_participation_factor
 """Get [`ReserveDemandCurve`](@ref) `ext`."""
 get_ext(value::ReserveDemandCurve) = value.ext
 """Get [`ReserveDemandCurve`](@ref) `time_series_container`."""
@@ -81,6 +95,10 @@ set_variable!(value::ReserveDemandCurve, val) = value.variable = val
 set_available!(value::ReserveDemandCurve, val) = value.available = val
 """Set [`ReserveDemandCurve`](@ref) `time_frame`."""
 set_time_frame!(value::ReserveDemandCurve, val) = value.time_frame = val
+"""Set [`ReserveDemandCurve`](@ref) `sustained_time`."""
+set_sustained_time!(value::ReserveDemandCurve, val) = value.sustained_time = val
+"""Set [`ReserveDemandCurve`](@ref) `max_participation_factor`."""
+set_max_participation_factor!(value::ReserveDemandCurve, val) = value.max_participation_factor = val
 """Set [`ReserveDemandCurve`](@ref) `ext`."""
 set_ext!(value::ReserveDemandCurve, val) = value.ext = val
 """Set [`ReserveDemandCurve`](@ref) `time_series_container`."""

--- a/src/models/generated/ReserveDemandCurve.jl
+++ b/src/models/generated/ReserveDemandCurve.jl
@@ -48,11 +48,11 @@ mutable struct ReserveDemandCurve{T <: ReserveDirection} <: Reserve{T}
     internal::InfrastructureSystemsInternal
 end
 
-function ReserveDemandCurve{T}(variable, name, available, time_frame, sustained_time, max_participation_factor=1.0, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), ) where T <: ReserveDirection
+function ReserveDemandCurve{T}(variable, name, available, time_frame, sustained_time=3600.0, max_participation_factor=1.0, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), ) where T <: ReserveDirection
     ReserveDemandCurve{T}(variable, name, available, time_frame, sustained_time, max_participation_factor, ext, time_series_container, InfrastructureSystemsInternal(), )
 end
 
-function ReserveDemandCurve{T}(; variable, name, available, time_frame, sustained_time, max_participation_factor=1.0, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), internal=InfrastructureSystemsInternal(), ) where T <: ReserveDirection
+function ReserveDemandCurve{T}(; variable, name, available, time_frame, sustained_time=3600.0, max_participation_factor=1.0, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), internal=InfrastructureSystemsInternal(), ) where T <: ReserveDirection
     ReserveDemandCurve{T}(variable, name, available, time_frame, sustained_time, max_participation_factor, ext, time_series_container, internal, )
 end
 

--- a/src/models/generated/StaticReserve.jl
+++ b/src/models/generated/StaticReserve.jl
@@ -9,9 +9,9 @@ This file is auto-generated. Do not edit.
         name::String
         available::Bool
         time_frame::Float64
+        requirement::Float64
         sustained_time::Float64
         max_participation_factor::Float64
-        requirement::Float64
         ext::Dict{String, Any}
         internal::InfrastructureSystemsInternal
     end
@@ -22,9 +22,9 @@ Data Structure for a proportional reserve product for system simulations.
 - `name::String`
 - `available::Bool`
 - `time_frame::Float64`: the saturation time_frame in minutes to provide reserve contribution, validation range: `(0, nothing)`, action if invalid: `error`
+- `requirement::Float64`: the static value of required reserves in system p.u., validation range: `(0, nothing)`, action if invalid: `error`
 - `sustained_time::Float64`: the time in secounds reserve contribution must sustained at a specified level, validation range: `(0, nothing)`, action if invalid: `error`
 - `max_participation_factor::Float64`: the maximum limit of reserve contribution per device, validation range: `(0, 1)`, action if invalid: `error`
-- `requirement::Float64`: the static value of required reserves in system p.u., validation range: `(0, nothing)`, action if invalid: `error`
 - `ext::Dict{String, Any}`
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
@@ -33,23 +33,23 @@ mutable struct StaticReserve{T <: ReserveDirection} <: Reserve{T}
     available::Bool
     "the saturation time_frame in minutes to provide reserve contribution"
     time_frame::Float64
+    "the static value of required reserves in system p.u."
+    requirement::Float64
     "the time in secounds reserve contribution must sustained at a specified level"
     sustained_time::Float64
     "the maximum limit of reserve contribution per device"
     max_participation_factor::Float64
-    "the static value of required reserves in system p.u."
-    requirement::Float64
     ext::Dict{String, Any}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end
 
-function StaticReserve{T}(name, available, time_frame, sustained_time, max_participation_factor=1.0, requirement, ext=Dict{String, Any}(), ) where T <: ReserveDirection
-    StaticReserve{T}(name, available, time_frame, sustained_time, max_participation_factor, requirement, ext, InfrastructureSystemsInternal(), )
+function StaticReserve{T}(name, available, time_frame, requirement, sustained_time=3600.0, max_participation_factor=1.0, ext=Dict{String, Any}(), ) where T <: ReserveDirection
+    StaticReserve{T}(name, available, time_frame, requirement, sustained_time, max_participation_factor, ext, InfrastructureSystemsInternal(), )
 end
 
-function StaticReserve{T}(; name, available, time_frame, sustained_time, max_participation_factor=1.0, requirement, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), ) where T <: ReserveDirection
-    StaticReserve{T}(name, available, time_frame, sustained_time, max_participation_factor, requirement, ext, internal, )
+function StaticReserve{T}(; name, available, time_frame, requirement, sustained_time=3600.0, max_participation_factor=1.0, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), ) where T <: ReserveDirection
+    StaticReserve{T}(name, available, time_frame, requirement, sustained_time, max_participation_factor, ext, internal, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -58,9 +58,9 @@ function StaticReserve{T}(::Nothing) where T <: ReserveDirection
         name="init",
         available=false,
         time_frame=0.0,
+        requirement=0.0,
         sustained_time=0.0,
         max_participation_factor=1.0,
-        requirement=0.0,
         ext=Dict{String, Any}(),
     )
 end
@@ -71,12 +71,12 @@ get_name(value::StaticReserve) = value.name
 get_available(value::StaticReserve) = value.available
 """Get [`StaticReserve`](@ref) `time_frame`."""
 get_time_frame(value::StaticReserve) = value.time_frame
+"""Get [`StaticReserve`](@ref) `requirement`."""
+get_requirement(value::StaticReserve) = get_value(value, value.requirement)
 """Get [`StaticReserve`](@ref) `sustained_time`."""
 get_sustained_time(value::StaticReserve) = value.sustained_time
 """Get [`StaticReserve`](@ref) `max_participation_factor`."""
 get_max_participation_factor(value::StaticReserve) = value.max_participation_factor
-"""Get [`StaticReserve`](@ref) `requirement`."""
-get_requirement(value::StaticReserve) = get_value(value, value.requirement)
 """Get [`StaticReserve`](@ref) `ext`."""
 get_ext(value::StaticReserve) = value.ext
 """Get [`StaticReserve`](@ref) `internal`."""
@@ -86,11 +86,11 @@ get_internal(value::StaticReserve) = value.internal
 set_available!(value::StaticReserve, val) = value.available = val
 """Set [`StaticReserve`](@ref) `time_frame`."""
 set_time_frame!(value::StaticReserve, val) = value.time_frame = val
+"""Set [`StaticReserve`](@ref) `requirement`."""
+set_requirement!(value::StaticReserve, val) = value.requirement = set_value(value, val)
 """Set [`StaticReserve`](@ref) `sustained_time`."""
 set_sustained_time!(value::StaticReserve, val) = value.sustained_time = val
 """Set [`StaticReserve`](@ref) `max_participation_factor`."""
 set_max_participation_factor!(value::StaticReserve, val) = value.max_participation_factor = val
-"""Set [`StaticReserve`](@ref) `requirement`."""
-set_requirement!(value::StaticReserve, val) = value.requirement = set_value(value, val)
 """Set [`StaticReserve`](@ref) `ext`."""
 set_ext!(value::StaticReserve, val) = value.ext = val

--- a/src/models/generated/StaticReserve.jl
+++ b/src/models/generated/StaticReserve.jl
@@ -9,6 +9,8 @@ This file is auto-generated. Do not edit.
         name::String
         available::Bool
         time_frame::Float64
+        sustained_time::Float64
+        max_participation_factor::Float64
         requirement::Float64
         ext::Dict{String, Any}
         internal::InfrastructureSystemsInternal
@@ -19,7 +21,9 @@ Data Structure for a proportional reserve product for system simulations.
 # Arguments
 - `name::String`
 - `available::Bool`
-- `time_frame::Float64`: the relative saturation time_frame, validation range: `(0, nothing)`, action if invalid: `error`
+- `time_frame::Float64`: the saturation time_frame in minutes to provide reserve contribution, validation range: `(0, nothing)`, action if invalid: `error`
+- `sustained_time::Float64`: the time in secounds reserve contribution must sustained at a specified level, validation range: `(0, nothing)`, action if invalid: `error`
+- `max_participation_factor::Float64`: the maximum limit of reserve contribution per device, validation range: `(0, 1)`, action if invalid: `error`
 - `requirement::Float64`: the static value of required reserves in system p.u., validation range: `(0, nothing)`, action if invalid: `error`
 - `ext::Dict{String, Any}`
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
@@ -27,8 +31,12 @@ Data Structure for a proportional reserve product for system simulations.
 mutable struct StaticReserve{T <: ReserveDirection} <: Reserve{T}
     name::String
     available::Bool
-    "the relative saturation time_frame"
+    "the saturation time_frame in minutes to provide reserve contribution"
     time_frame::Float64
+    "the time in secounds reserve contribution must sustained at a specified level"
+    sustained_time::Float64
+    "the maximum limit of reserve contribution per device"
+    max_participation_factor::Float64
     "the static value of required reserves in system p.u."
     requirement::Float64
     ext::Dict{String, Any}
@@ -36,12 +44,12 @@ mutable struct StaticReserve{T <: ReserveDirection} <: Reserve{T}
     internal::InfrastructureSystemsInternal
 end
 
-function StaticReserve{T}(name, available, time_frame, requirement, ext=Dict{String, Any}(), ) where T <: ReserveDirection
-    StaticReserve{T}(name, available, time_frame, requirement, ext, InfrastructureSystemsInternal(), )
+function StaticReserve{T}(name, available, time_frame, sustained_time, max_participation_factor=1.0, requirement, ext=Dict{String, Any}(), ) where T <: ReserveDirection
+    StaticReserve{T}(name, available, time_frame, sustained_time, max_participation_factor, requirement, ext, InfrastructureSystemsInternal(), )
 end
 
-function StaticReserve{T}(; name, available, time_frame, requirement, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), ) where T <: ReserveDirection
-    StaticReserve{T}(name, available, time_frame, requirement, ext, internal, )
+function StaticReserve{T}(; name, available, time_frame, sustained_time, max_participation_factor=1.0, requirement, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), ) where T <: ReserveDirection
+    StaticReserve{T}(name, available, time_frame, sustained_time, max_participation_factor, requirement, ext, internal, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -50,6 +58,8 @@ function StaticReserve{T}(::Nothing) where T <: ReserveDirection
         name="init",
         available=false,
         time_frame=0.0,
+        sustained_time=0.0,
+        max_participation_factor=1.0,
         requirement=0.0,
         ext=Dict{String, Any}(),
     )
@@ -61,6 +71,10 @@ get_name(value::StaticReserve) = value.name
 get_available(value::StaticReserve) = value.available
 """Get [`StaticReserve`](@ref) `time_frame`."""
 get_time_frame(value::StaticReserve) = value.time_frame
+"""Get [`StaticReserve`](@ref) `sustained_time`."""
+get_sustained_time(value::StaticReserve) = value.sustained_time
+"""Get [`StaticReserve`](@ref) `max_participation_factor`."""
+get_max_participation_factor(value::StaticReserve) = value.max_participation_factor
 """Get [`StaticReserve`](@ref) `requirement`."""
 get_requirement(value::StaticReserve) = get_value(value, value.requirement)
 """Get [`StaticReserve`](@ref) `ext`."""
@@ -72,6 +86,10 @@ get_internal(value::StaticReserve) = value.internal
 set_available!(value::StaticReserve, val) = value.available = val
 """Set [`StaticReserve`](@ref) `time_frame`."""
 set_time_frame!(value::StaticReserve, val) = value.time_frame = val
+"""Set [`StaticReserve`](@ref) `sustained_time`."""
+set_sustained_time!(value::StaticReserve, val) = value.sustained_time = val
+"""Set [`StaticReserve`](@ref) `max_participation_factor`."""
+set_max_participation_factor!(value::StaticReserve, val) = value.max_participation_factor = val
 """Set [`StaticReserve`](@ref) `requirement`."""
 set_requirement!(value::StaticReserve, val) = value.requirement = set_value(value, val)
 """Set [`StaticReserve`](@ref) `ext`."""

--- a/src/models/generated/StaticReserveNonSpinning.jl
+++ b/src/models/generated/StaticReserveNonSpinning.jl
@@ -9,6 +9,8 @@ This file is auto-generated. Do not edit.
         name::String
         available::Bool
         time_frame::Float64
+        sustained_time::Float64
+        max_participation_factor::Float64
         requirement::Float64
         ext::Dict{String, Any}
         internal::InfrastructureSystemsInternal
@@ -19,7 +21,9 @@ Data Structure for a non-spinning reserve product for system simulations.
 # Arguments
 - `name::String`
 - `available::Bool`
-- `time_frame::Float64`: the relative saturation time_frame, validation range: `(0, nothing)`, action if invalid: `error`
+- `time_frame::Float64`: the saturation time_frame in minutes to provide reserve contribution, validation range: `(0, nothing)`, action if invalid: `error`
+- `sustained_time::Float64`: the time in secounds reserve contribution must sustained at a specified level, validation range: `(0, nothing)`, action if invalid: `error`
+- `max_participation_factor::Float64`: the maximum limit of reserve contribution per device, validation range: `(0, 1)`, action if invalid: `error`
 - `requirement::Float64`: the static value of required reserves in system p.u., validation range: `(0, nothing)`, action if invalid: `error`
 - `ext::Dict{String, Any}`
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
@@ -27,8 +31,12 @@ Data Structure for a non-spinning reserve product for system simulations.
 mutable struct StaticReserveNonSpinning <: ReserveNonSpinning
     name::String
     available::Bool
-    "the relative saturation time_frame"
+    "the saturation time_frame in minutes to provide reserve contribution"
     time_frame::Float64
+    "the time in secounds reserve contribution must sustained at a specified level"
+    sustained_time::Float64
+    "the maximum limit of reserve contribution per device"
+    max_participation_factor::Float64
     "the static value of required reserves in system p.u."
     requirement::Float64
     ext::Dict{String, Any}
@@ -36,12 +44,12 @@ mutable struct StaticReserveNonSpinning <: ReserveNonSpinning
     internal::InfrastructureSystemsInternal
 end
 
-function StaticReserveNonSpinning(name, available, time_frame, requirement, ext=Dict{String, Any}(), )
-    StaticReserveNonSpinning(name, available, time_frame, requirement, ext, InfrastructureSystemsInternal(), )
+function StaticReserveNonSpinning(name, available, time_frame, sustained_time, max_participation_factor=1.0, requirement, ext=Dict{String, Any}(), )
+    StaticReserveNonSpinning(name, available, time_frame, sustained_time, max_participation_factor, requirement, ext, InfrastructureSystemsInternal(), )
 end
 
-function StaticReserveNonSpinning(; name, available, time_frame, requirement, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
-    StaticReserveNonSpinning(name, available, time_frame, requirement, ext, internal, )
+function StaticReserveNonSpinning(; name, available, time_frame, sustained_time, max_participation_factor=1.0, requirement, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+    StaticReserveNonSpinning(name, available, time_frame, sustained_time, max_participation_factor, requirement, ext, internal, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -50,6 +58,8 @@ function StaticReserveNonSpinning(::Nothing)
         name="init",
         available=false,
         time_frame=0.0,
+        sustained_time=0.0,
+        max_participation_factor=1.0,
         requirement=0.0,
         ext=Dict{String, Any}(),
     )
@@ -61,6 +71,10 @@ get_name(value::StaticReserveNonSpinning) = value.name
 get_available(value::StaticReserveNonSpinning) = value.available
 """Get [`StaticReserveNonSpinning`](@ref) `time_frame`."""
 get_time_frame(value::StaticReserveNonSpinning) = value.time_frame
+"""Get [`StaticReserveNonSpinning`](@ref) `sustained_time`."""
+get_sustained_time(value::StaticReserveNonSpinning) = value.sustained_time
+"""Get [`StaticReserveNonSpinning`](@ref) `max_participation_factor`."""
+get_max_participation_factor(value::StaticReserveNonSpinning) = value.max_participation_factor
 """Get [`StaticReserveNonSpinning`](@ref) `requirement`."""
 get_requirement(value::StaticReserveNonSpinning) = get_value(value, value.requirement)
 """Get [`StaticReserveNonSpinning`](@ref) `ext`."""
@@ -72,6 +86,10 @@ get_internal(value::StaticReserveNonSpinning) = value.internal
 set_available!(value::StaticReserveNonSpinning, val) = value.available = val
 """Set [`StaticReserveNonSpinning`](@ref) `time_frame`."""
 set_time_frame!(value::StaticReserveNonSpinning, val) = value.time_frame = val
+"""Set [`StaticReserveNonSpinning`](@ref) `sustained_time`."""
+set_sustained_time!(value::StaticReserveNonSpinning, val) = value.sustained_time = val
+"""Set [`StaticReserveNonSpinning`](@ref) `max_participation_factor`."""
+set_max_participation_factor!(value::StaticReserveNonSpinning, val) = value.max_participation_factor = val
 """Set [`StaticReserveNonSpinning`](@ref) `requirement`."""
 set_requirement!(value::StaticReserveNonSpinning, val) = value.requirement = set_value(value, val)
 """Set [`StaticReserveNonSpinning`](@ref) `ext`."""

--- a/src/models/generated/StaticReserveNonSpinning.jl
+++ b/src/models/generated/StaticReserveNonSpinning.jl
@@ -9,9 +9,9 @@ This file is auto-generated. Do not edit.
         name::String
         available::Bool
         time_frame::Float64
+        requirement::Float64
         sustained_time::Float64
         max_participation_factor::Float64
-        requirement::Float64
         ext::Dict{String, Any}
         internal::InfrastructureSystemsInternal
     end
@@ -22,9 +22,9 @@ Data Structure for a non-spinning reserve product for system simulations.
 - `name::String`
 - `available::Bool`
 - `time_frame::Float64`: the saturation time_frame in minutes to provide reserve contribution, validation range: `(0, nothing)`, action if invalid: `error`
+- `requirement::Float64`: the static value of required reserves in system p.u., validation range: `(0, nothing)`, action if invalid: `error`
 - `sustained_time::Float64`: the time in secounds reserve contribution must sustained at a specified level, validation range: `(0, nothing)`, action if invalid: `error`
 - `max_participation_factor::Float64`: the maximum limit of reserve contribution per device, validation range: `(0, 1)`, action if invalid: `error`
-- `requirement::Float64`: the static value of required reserves in system p.u., validation range: `(0, nothing)`, action if invalid: `error`
 - `ext::Dict{String, Any}`
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
@@ -33,23 +33,23 @@ mutable struct StaticReserveNonSpinning <: ReserveNonSpinning
     available::Bool
     "the saturation time_frame in minutes to provide reserve contribution"
     time_frame::Float64
+    "the static value of required reserves in system p.u."
+    requirement::Float64
     "the time in secounds reserve contribution must sustained at a specified level"
     sustained_time::Float64
     "the maximum limit of reserve contribution per device"
     max_participation_factor::Float64
-    "the static value of required reserves in system p.u."
-    requirement::Float64
     ext::Dict{String, Any}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end
 
-function StaticReserveNonSpinning(name, available, time_frame, sustained_time, max_participation_factor=1.0, requirement, ext=Dict{String, Any}(), )
-    StaticReserveNonSpinning(name, available, time_frame, sustained_time, max_participation_factor, requirement, ext, InfrastructureSystemsInternal(), )
+function StaticReserveNonSpinning(name, available, time_frame, requirement, sustained_time=3600.0, max_participation_factor=1.0, ext=Dict{String, Any}(), )
+    StaticReserveNonSpinning(name, available, time_frame, requirement, sustained_time, max_participation_factor, ext, InfrastructureSystemsInternal(), )
 end
 
-function StaticReserveNonSpinning(; name, available, time_frame, sustained_time, max_participation_factor=1.0, requirement, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
-    StaticReserveNonSpinning(name, available, time_frame, sustained_time, max_participation_factor, requirement, ext, internal, )
+function StaticReserveNonSpinning(; name, available, time_frame, requirement, sustained_time=3600.0, max_participation_factor=1.0, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+    StaticReserveNonSpinning(name, available, time_frame, requirement, sustained_time, max_participation_factor, ext, internal, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -58,9 +58,9 @@ function StaticReserveNonSpinning(::Nothing)
         name="init",
         available=false,
         time_frame=0.0,
+        requirement=0.0,
         sustained_time=0.0,
         max_participation_factor=1.0,
-        requirement=0.0,
         ext=Dict{String, Any}(),
     )
 end
@@ -71,12 +71,12 @@ get_name(value::StaticReserveNonSpinning) = value.name
 get_available(value::StaticReserveNonSpinning) = value.available
 """Get [`StaticReserveNonSpinning`](@ref) `time_frame`."""
 get_time_frame(value::StaticReserveNonSpinning) = value.time_frame
+"""Get [`StaticReserveNonSpinning`](@ref) `requirement`."""
+get_requirement(value::StaticReserveNonSpinning) = get_value(value, value.requirement)
 """Get [`StaticReserveNonSpinning`](@ref) `sustained_time`."""
 get_sustained_time(value::StaticReserveNonSpinning) = value.sustained_time
 """Get [`StaticReserveNonSpinning`](@ref) `max_participation_factor`."""
 get_max_participation_factor(value::StaticReserveNonSpinning) = value.max_participation_factor
-"""Get [`StaticReserveNonSpinning`](@ref) `requirement`."""
-get_requirement(value::StaticReserveNonSpinning) = get_value(value, value.requirement)
 """Get [`StaticReserveNonSpinning`](@ref) `ext`."""
 get_ext(value::StaticReserveNonSpinning) = value.ext
 """Get [`StaticReserveNonSpinning`](@ref) `internal`."""
@@ -86,11 +86,11 @@ get_internal(value::StaticReserveNonSpinning) = value.internal
 set_available!(value::StaticReserveNonSpinning, val) = value.available = val
 """Set [`StaticReserveNonSpinning`](@ref) `time_frame`."""
 set_time_frame!(value::StaticReserveNonSpinning, val) = value.time_frame = val
+"""Set [`StaticReserveNonSpinning`](@ref) `requirement`."""
+set_requirement!(value::StaticReserveNonSpinning, val) = value.requirement = set_value(value, val)
 """Set [`StaticReserveNonSpinning`](@ref) `sustained_time`."""
 set_sustained_time!(value::StaticReserveNonSpinning, val) = value.sustained_time = val
 """Set [`StaticReserveNonSpinning`](@ref) `max_participation_factor`."""
 set_max_participation_factor!(value::StaticReserveNonSpinning, val) = value.max_participation_factor = val
-"""Set [`StaticReserveNonSpinning`](@ref) `requirement`."""
-set_requirement!(value::StaticReserveNonSpinning, val) = value.requirement = set_value(value, val)
 """Set [`StaticReserveNonSpinning`](@ref) `ext`."""
 set_ext!(value::StaticReserveNonSpinning, val) = value.ext = val

--- a/src/models/generated/VariableReserve.jl
+++ b/src/models/generated/VariableReserve.jl
@@ -9,6 +9,8 @@ This file is auto-generated. Do not edit.
         name::String
         available::Bool
         time_frame::Float64
+        sustained_time::Float64
+        max_participation_factor::Float64
         requirement::Float64
         ext::Dict{String, Any}
         time_series_container::InfrastructureSystems.TimeSeriesContainer
@@ -20,7 +22,9 @@ Data Structure for the procurement products for system simulations.
 # Arguments
 - `name::String`
 - `available::Bool`
-- `time_frame::Float64`: the relative saturation time_frame, validation range: `(0, nothing)`, action if invalid: `error`
+- `time_frame::Float64`: the saturation time_frame in minutes to provide reserve contribution, validation range: `(0, nothing)`, action if invalid: `error`
+- `sustained_time::Float64`: the time in secounds reserve contribution must sustained at a specified level, validation range: `(0, nothing)`, action if invalid: `error`
+- `max_participation_factor::Float64`: the maximum limit of reserve contribution per device, validation range: `(0, 1)`, action if invalid: `error`
 - `requirement::Float64`: the required quantity of the product should be scaled by a TimeSeriesData
 - `ext::Dict{String, Any}`
 - `time_series_container::InfrastructureSystems.TimeSeriesContainer`: internal time_series storage
@@ -29,8 +33,12 @@ Data Structure for the procurement products for system simulations.
 mutable struct VariableReserve{T <: ReserveDirection} <: Reserve{T}
     name::String
     available::Bool
-    "the relative saturation time_frame"
+    "the saturation time_frame in minutes to provide reserve contribution"
     time_frame::Float64
+    "the time in secounds reserve contribution must sustained at a specified level"
+    sustained_time::Float64
+    "the maximum limit of reserve contribution per device"
+    max_participation_factor::Float64
     "the required quantity of the product should be scaled by a TimeSeriesData"
     requirement::Float64
     ext::Dict{String, Any}
@@ -40,12 +48,12 @@ mutable struct VariableReserve{T <: ReserveDirection} <: Reserve{T}
     internal::InfrastructureSystemsInternal
 end
 
-function VariableReserve{T}(name, available, time_frame, requirement, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), ) where T <: ReserveDirection
-    VariableReserve{T}(name, available, time_frame, requirement, ext, time_series_container, InfrastructureSystemsInternal(), )
+function VariableReserve{T}(name, available, time_frame, sustained_time, max_participation_factor=1.0, requirement, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), ) where T <: ReserveDirection
+    VariableReserve{T}(name, available, time_frame, sustained_time, max_participation_factor, requirement, ext, time_series_container, InfrastructureSystemsInternal(), )
 end
 
-function VariableReserve{T}(; name, available, time_frame, requirement, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), internal=InfrastructureSystemsInternal(), ) where T <: ReserveDirection
-    VariableReserve{T}(name, available, time_frame, requirement, ext, time_series_container, internal, )
+function VariableReserve{T}(; name, available, time_frame, sustained_time, max_participation_factor=1.0, requirement, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), internal=InfrastructureSystemsInternal(), ) where T <: ReserveDirection
+    VariableReserve{T}(name, available, time_frame, sustained_time, max_participation_factor, requirement, ext, time_series_container, internal, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -54,6 +62,8 @@ function VariableReserve{T}(::Nothing) where T <: ReserveDirection
         name="init",
         available=false,
         time_frame=0.0,
+        sustained_time=0.0,
+        max_participation_factor=1.0,
         requirement=0.0,
         ext=Dict{String, Any}(),
         time_series_container=InfrastructureSystems.TimeSeriesContainer(),
@@ -65,7 +75,11 @@ get_name(value::VariableReserve) = value.name
 """Get [`VariableReserve`](@ref) `available`."""
 get_available(value::VariableReserve) = value.available
 """Get [`VariableReserve`](@ref) `time_frame`."""
-get_time_frame(value::VariableReserve) = get_value(value, value.time_frame)
+get_time_frame(value::VariableReserve) = value.time_frame
+"""Get [`VariableReserve`](@ref) `sustained_time`."""
+get_sustained_time(value::VariableReserve) = value.sustained_time
+"""Get [`VariableReserve`](@ref) `max_participation_factor`."""
+get_max_participation_factor(value::VariableReserve) = value.max_participation_factor
 """Get [`VariableReserve`](@ref) `requirement`."""
 get_requirement(value::VariableReserve) = value.requirement
 """Get [`VariableReserve`](@ref) `ext`."""
@@ -78,7 +92,11 @@ get_internal(value::VariableReserve) = value.internal
 """Set [`VariableReserve`](@ref) `available`."""
 set_available!(value::VariableReserve, val) = value.available = val
 """Set [`VariableReserve`](@ref) `time_frame`."""
-set_time_frame!(value::VariableReserve, val) = value.time_frame = set_value(value, val)
+set_time_frame!(value::VariableReserve, val) = value.time_frame = val
+"""Set [`VariableReserve`](@ref) `sustained_time`."""
+set_sustained_time!(value::VariableReserve, val) = value.sustained_time = val
+"""Set [`VariableReserve`](@ref) `max_participation_factor`."""
+set_max_participation_factor!(value::VariableReserve, val) = value.max_participation_factor = val
 """Set [`VariableReserve`](@ref) `requirement`."""
 set_requirement!(value::VariableReserve, val) = value.requirement = val
 """Set [`VariableReserve`](@ref) `ext`."""

--- a/src/models/generated/VariableReserve.jl
+++ b/src/models/generated/VariableReserve.jl
@@ -9,9 +9,9 @@ This file is auto-generated. Do not edit.
         name::String
         available::Bool
         time_frame::Float64
+        requirement::Float64
         sustained_time::Float64
         max_participation_factor::Float64
-        requirement::Float64
         ext::Dict{String, Any}
         time_series_container::InfrastructureSystems.TimeSeriesContainer
         internal::InfrastructureSystemsInternal
@@ -23,9 +23,9 @@ Data Structure for the procurement products for system simulations.
 - `name::String`
 - `available::Bool`
 - `time_frame::Float64`: the saturation time_frame in minutes to provide reserve contribution, validation range: `(0, nothing)`, action if invalid: `error`
+- `requirement::Float64`: the required quantity of the product should be scaled by a TimeSeriesData
 - `sustained_time::Float64`: the time in secounds reserve contribution must sustained at a specified level, validation range: `(0, nothing)`, action if invalid: `error`
 - `max_participation_factor::Float64`: the maximum limit of reserve contribution per device, validation range: `(0, 1)`, action if invalid: `error`
-- `requirement::Float64`: the required quantity of the product should be scaled by a TimeSeriesData
 - `ext::Dict{String, Any}`
 - `time_series_container::InfrastructureSystems.TimeSeriesContainer`: internal time_series storage
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
@@ -35,12 +35,12 @@ mutable struct VariableReserve{T <: ReserveDirection} <: Reserve{T}
     available::Bool
     "the saturation time_frame in minutes to provide reserve contribution"
     time_frame::Float64
+    "the required quantity of the product should be scaled by a TimeSeriesData"
+    requirement::Float64
     "the time in secounds reserve contribution must sustained at a specified level"
     sustained_time::Float64
     "the maximum limit of reserve contribution per device"
     max_participation_factor::Float64
-    "the required quantity of the product should be scaled by a TimeSeriesData"
-    requirement::Float64
     ext::Dict{String, Any}
     "internal time_series storage"
     time_series_container::InfrastructureSystems.TimeSeriesContainer
@@ -48,12 +48,12 @@ mutable struct VariableReserve{T <: ReserveDirection} <: Reserve{T}
     internal::InfrastructureSystemsInternal
 end
 
-function VariableReserve{T}(name, available, time_frame, sustained_time, max_participation_factor=1.0, requirement, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), ) where T <: ReserveDirection
-    VariableReserve{T}(name, available, time_frame, sustained_time, max_participation_factor, requirement, ext, time_series_container, InfrastructureSystemsInternal(), )
+function VariableReserve{T}(name, available, time_frame, requirement, sustained_time=3600.0, max_participation_factor=1.0, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), ) where T <: ReserveDirection
+    VariableReserve{T}(name, available, time_frame, requirement, sustained_time, max_participation_factor, ext, time_series_container, InfrastructureSystemsInternal(), )
 end
 
-function VariableReserve{T}(; name, available, time_frame, sustained_time, max_participation_factor=1.0, requirement, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), internal=InfrastructureSystemsInternal(), ) where T <: ReserveDirection
-    VariableReserve{T}(name, available, time_frame, sustained_time, max_participation_factor, requirement, ext, time_series_container, internal, )
+function VariableReserve{T}(; name, available, time_frame, requirement, sustained_time=3600.0, max_participation_factor=1.0, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), internal=InfrastructureSystemsInternal(), ) where T <: ReserveDirection
+    VariableReserve{T}(name, available, time_frame, requirement, sustained_time, max_participation_factor, ext, time_series_container, internal, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -62,9 +62,9 @@ function VariableReserve{T}(::Nothing) where T <: ReserveDirection
         name="init",
         available=false,
         time_frame=0.0,
+        requirement=0.0,
         sustained_time=0.0,
         max_participation_factor=1.0,
-        requirement=0.0,
         ext=Dict{String, Any}(),
         time_series_container=InfrastructureSystems.TimeSeriesContainer(),
     )
@@ -76,12 +76,12 @@ get_name(value::VariableReserve) = value.name
 get_available(value::VariableReserve) = value.available
 """Get [`VariableReserve`](@ref) `time_frame`."""
 get_time_frame(value::VariableReserve) = value.time_frame
+"""Get [`VariableReserve`](@ref) `requirement`."""
+get_requirement(value::VariableReserve) = value.requirement
 """Get [`VariableReserve`](@ref) `sustained_time`."""
 get_sustained_time(value::VariableReserve) = value.sustained_time
 """Get [`VariableReserve`](@ref) `max_participation_factor`."""
 get_max_participation_factor(value::VariableReserve) = value.max_participation_factor
-"""Get [`VariableReserve`](@ref) `requirement`."""
-get_requirement(value::VariableReserve) = value.requirement
 """Get [`VariableReserve`](@ref) `ext`."""
 get_ext(value::VariableReserve) = value.ext
 """Get [`VariableReserve`](@ref) `time_series_container`."""
@@ -93,12 +93,12 @@ get_internal(value::VariableReserve) = value.internal
 set_available!(value::VariableReserve, val) = value.available = val
 """Set [`VariableReserve`](@ref) `time_frame`."""
 set_time_frame!(value::VariableReserve, val) = value.time_frame = val
+"""Set [`VariableReserve`](@ref) `requirement`."""
+set_requirement!(value::VariableReserve, val) = value.requirement = val
 """Set [`VariableReserve`](@ref) `sustained_time`."""
 set_sustained_time!(value::VariableReserve, val) = value.sustained_time = val
 """Set [`VariableReserve`](@ref) `max_participation_factor`."""
 set_max_participation_factor!(value::VariableReserve, val) = value.max_participation_factor = val
-"""Set [`VariableReserve`](@ref) `requirement`."""
-set_requirement!(value::VariableReserve, val) = value.requirement = val
 """Set [`VariableReserve`](@ref) `ext`."""
 set_ext!(value::VariableReserve, val) = value.ext = val
 """Set [`VariableReserve`](@ref) `time_series_container`."""

--- a/src/models/generated/VariableReserveNonSpinning.jl
+++ b/src/models/generated/VariableReserveNonSpinning.jl
@@ -9,9 +9,9 @@ This file is auto-generated. Do not edit.
         name::String
         available::Bool
         time_frame::Float64
+        requirement::Float64
         sustained_time::Float64
         max_participation_factor::Float64
-        requirement::Float64
         ext::Dict{String, Any}
         time_series_container::InfrastructureSystems.TimeSeriesContainer
         internal::InfrastructureSystemsInternal
@@ -23,9 +23,9 @@ Data Structure for the procurement products for system simulations.
 - `name::String`
 - `available::Bool`
 - `time_frame::Float64`: the saturation time_frame in minutes to provide reserve contribution, validation range: `(0, nothing)`, action if invalid: `error`
+- `requirement::Float64`: the required quantity of the product should be scaled by a TimeSeriesData
 - `sustained_time::Float64`: the time in secounds reserve contribution must sustained at a specified level, validation range: `(0, nothing)`, action if invalid: `error`
 - `max_participation_factor::Float64`: the maximum limit of reserve contribution per device, validation range: `(0, 1)`, action if invalid: `error`
-- `requirement::Float64`: the required quantity of the product should be scaled by a TimeSeriesData
 - `ext::Dict{String, Any}`
 - `time_series_container::InfrastructureSystems.TimeSeriesContainer`: internal time_series storage
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
@@ -35,12 +35,12 @@ mutable struct VariableReserveNonSpinning <: ReserveNonSpinning
     available::Bool
     "the saturation time_frame in minutes to provide reserve contribution"
     time_frame::Float64
+    "the required quantity of the product should be scaled by a TimeSeriesData"
+    requirement::Float64
     "the time in secounds reserve contribution must sustained at a specified level"
     sustained_time::Float64
     "the maximum limit of reserve contribution per device"
     max_participation_factor::Float64
-    "the required quantity of the product should be scaled by a TimeSeriesData"
-    requirement::Float64
     ext::Dict{String, Any}
     "internal time_series storage"
     time_series_container::InfrastructureSystems.TimeSeriesContainer
@@ -48,12 +48,12 @@ mutable struct VariableReserveNonSpinning <: ReserveNonSpinning
     internal::InfrastructureSystemsInternal
 end
 
-function VariableReserveNonSpinning(name, available, time_frame, sustained_time, max_participation_factor=1.0, requirement, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), )
-    VariableReserveNonSpinning(name, available, time_frame, sustained_time, max_participation_factor, requirement, ext, time_series_container, InfrastructureSystemsInternal(), )
+function VariableReserveNonSpinning(name, available, time_frame, requirement, sustained_time=14400.0, max_participation_factor=1.0, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), )
+    VariableReserveNonSpinning(name, available, time_frame, requirement, sustained_time, max_participation_factor, ext, time_series_container, InfrastructureSystemsInternal(), )
 end
 
-function VariableReserveNonSpinning(; name, available, time_frame, sustained_time, max_participation_factor=1.0, requirement, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), internal=InfrastructureSystemsInternal(), )
-    VariableReserveNonSpinning(name, available, time_frame, sustained_time, max_participation_factor, requirement, ext, time_series_container, internal, )
+function VariableReserveNonSpinning(; name, available, time_frame, requirement, sustained_time=14400.0, max_participation_factor=1.0, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), internal=InfrastructureSystemsInternal(), )
+    VariableReserveNonSpinning(name, available, time_frame, requirement, sustained_time, max_participation_factor, ext, time_series_container, internal, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -62,9 +62,9 @@ function VariableReserveNonSpinning(::Nothing)
         name="init",
         available=false,
         time_frame=0.0,
+        requirement=0.0,
         sustained_time=0.0,
         max_participation_factor=1.0,
-        requirement=0.0,
         ext=Dict{String, Any}(),
         time_series_container=InfrastructureSystems.TimeSeriesContainer(),
     )
@@ -76,12 +76,12 @@ get_name(value::VariableReserveNonSpinning) = value.name
 get_available(value::VariableReserveNonSpinning) = value.available
 """Get [`VariableReserveNonSpinning`](@ref) `time_frame`."""
 get_time_frame(value::VariableReserveNonSpinning) = value.time_frame
+"""Get [`VariableReserveNonSpinning`](@ref) `requirement`."""
+get_requirement(value::VariableReserveNonSpinning) = get_value(value, value.requirement)
 """Get [`VariableReserveNonSpinning`](@ref) `sustained_time`."""
 get_sustained_time(value::VariableReserveNonSpinning) = value.sustained_time
 """Get [`VariableReserveNonSpinning`](@ref) `max_participation_factor`."""
 get_max_participation_factor(value::VariableReserveNonSpinning) = value.max_participation_factor
-"""Get [`VariableReserveNonSpinning`](@ref) `requirement`."""
-get_requirement(value::VariableReserveNonSpinning) = get_value(value, value.requirement)
 """Get [`VariableReserveNonSpinning`](@ref) `ext`."""
 get_ext(value::VariableReserveNonSpinning) = value.ext
 """Get [`VariableReserveNonSpinning`](@ref) `time_series_container`."""
@@ -93,12 +93,12 @@ get_internal(value::VariableReserveNonSpinning) = value.internal
 set_available!(value::VariableReserveNonSpinning, val) = value.available = val
 """Set [`VariableReserveNonSpinning`](@ref) `time_frame`."""
 set_time_frame!(value::VariableReserveNonSpinning, val) = value.time_frame = val
+"""Set [`VariableReserveNonSpinning`](@ref) `requirement`."""
+set_requirement!(value::VariableReserveNonSpinning, val) = value.requirement = set_value(value, val)
 """Set [`VariableReserveNonSpinning`](@ref) `sustained_time`."""
 set_sustained_time!(value::VariableReserveNonSpinning, val) = value.sustained_time = val
 """Set [`VariableReserveNonSpinning`](@ref) `max_participation_factor`."""
 set_max_participation_factor!(value::VariableReserveNonSpinning, val) = value.max_participation_factor = val
-"""Set [`VariableReserveNonSpinning`](@ref) `requirement`."""
-set_requirement!(value::VariableReserveNonSpinning, val) = value.requirement = set_value(value, val)
 """Set [`VariableReserveNonSpinning`](@ref) `ext`."""
 set_ext!(value::VariableReserveNonSpinning, val) = value.ext = val
 """Set [`VariableReserveNonSpinning`](@ref) `time_series_container`."""

--- a/src/models/generated/VariableReserveNonSpinning.jl
+++ b/src/models/generated/VariableReserveNonSpinning.jl
@@ -9,6 +9,8 @@ This file is auto-generated. Do not edit.
         name::String
         available::Bool
         time_frame::Float64
+        sustained_time::Float64
+        max_participation_factor::Float64
         requirement::Float64
         ext::Dict{String, Any}
         time_series_container::InfrastructureSystems.TimeSeriesContainer
@@ -20,7 +22,9 @@ Data Structure for the procurement products for system simulations.
 # Arguments
 - `name::String`
 - `available::Bool`
-- `time_frame::Float64`: the relative saturation time_frame, validation range: `(0, nothing)`, action if invalid: `error`
+- `time_frame::Float64`: the saturation time_frame in minutes to provide reserve contribution, validation range: `(0, nothing)`, action if invalid: `error`
+- `sustained_time::Float64`: the time in secounds reserve contribution must sustained at a specified level, validation range: `(0, nothing)`, action if invalid: `error`
+- `max_participation_factor::Float64`: the maximum limit of reserve contribution per device, validation range: `(0, 1)`, action if invalid: `error`
 - `requirement::Float64`: the required quantity of the product should be scaled by a TimeSeriesData
 - `ext::Dict{String, Any}`
 - `time_series_container::InfrastructureSystems.TimeSeriesContainer`: internal time_series storage
@@ -29,8 +33,12 @@ Data Structure for the procurement products for system simulations.
 mutable struct VariableReserveNonSpinning <: ReserveNonSpinning
     name::String
     available::Bool
-    "the relative saturation time_frame"
+    "the saturation time_frame in minutes to provide reserve contribution"
     time_frame::Float64
+    "the time in secounds reserve contribution must sustained at a specified level"
+    sustained_time::Float64
+    "the maximum limit of reserve contribution per device"
+    max_participation_factor::Float64
     "the required quantity of the product should be scaled by a TimeSeriesData"
     requirement::Float64
     ext::Dict{String, Any}
@@ -40,12 +48,12 @@ mutable struct VariableReserveNonSpinning <: ReserveNonSpinning
     internal::InfrastructureSystemsInternal
 end
 
-function VariableReserveNonSpinning(name, available, time_frame, requirement, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), )
-    VariableReserveNonSpinning(name, available, time_frame, requirement, ext, time_series_container, InfrastructureSystemsInternal(), )
+function VariableReserveNonSpinning(name, available, time_frame, sustained_time, max_participation_factor=1.0, requirement, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), )
+    VariableReserveNonSpinning(name, available, time_frame, sustained_time, max_participation_factor, requirement, ext, time_series_container, InfrastructureSystemsInternal(), )
 end
 
-function VariableReserveNonSpinning(; name, available, time_frame, requirement, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), internal=InfrastructureSystemsInternal(), )
-    VariableReserveNonSpinning(name, available, time_frame, requirement, ext, time_series_container, internal, )
+function VariableReserveNonSpinning(; name, available, time_frame, sustained_time, max_participation_factor=1.0, requirement, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), internal=InfrastructureSystemsInternal(), )
+    VariableReserveNonSpinning(name, available, time_frame, sustained_time, max_participation_factor, requirement, ext, time_series_container, internal, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -54,6 +62,8 @@ function VariableReserveNonSpinning(::Nothing)
         name="init",
         available=false,
         time_frame=0.0,
+        sustained_time=0.0,
+        max_participation_factor=1.0,
         requirement=0.0,
         ext=Dict{String, Any}(),
         time_series_container=InfrastructureSystems.TimeSeriesContainer(),
@@ -66,6 +76,10 @@ get_name(value::VariableReserveNonSpinning) = value.name
 get_available(value::VariableReserveNonSpinning) = value.available
 """Get [`VariableReserveNonSpinning`](@ref) `time_frame`."""
 get_time_frame(value::VariableReserveNonSpinning) = value.time_frame
+"""Get [`VariableReserveNonSpinning`](@ref) `sustained_time`."""
+get_sustained_time(value::VariableReserveNonSpinning) = value.sustained_time
+"""Get [`VariableReserveNonSpinning`](@ref) `max_participation_factor`."""
+get_max_participation_factor(value::VariableReserveNonSpinning) = value.max_participation_factor
 """Get [`VariableReserveNonSpinning`](@ref) `requirement`."""
 get_requirement(value::VariableReserveNonSpinning) = get_value(value, value.requirement)
 """Get [`VariableReserveNonSpinning`](@ref) `ext`."""
@@ -79,6 +93,10 @@ get_internal(value::VariableReserveNonSpinning) = value.internal
 set_available!(value::VariableReserveNonSpinning, val) = value.available = val
 """Set [`VariableReserveNonSpinning`](@ref) `time_frame`."""
 set_time_frame!(value::VariableReserveNonSpinning, val) = value.time_frame = val
+"""Set [`VariableReserveNonSpinning`](@ref) `sustained_time`."""
+set_sustained_time!(value::VariableReserveNonSpinning, val) = value.sustained_time = val
+"""Set [`VariableReserveNonSpinning`](@ref) `max_participation_factor`."""
+set_max_participation_factor!(value::VariableReserveNonSpinning, val) = value.max_participation_factor = val
 """Set [`VariableReserveNonSpinning`](@ref) `requirement`."""
 set_requirement!(value::VariableReserveNonSpinning, val) = value.requirement = set_value(value, val)
 """Set [`VariableReserveNonSpinning`](@ref) `ext`."""

--- a/src/models/generated/includes.jl
+++ b/src/models/generated/includes.jl
@@ -530,6 +530,7 @@ export get_max_current_active_power
 export get_max_current_reactive_power
 export get_max_impedance_active_power
 export get_max_impedance_reactive_power
+export get_max_participation_factor
 export get_max_reactive_power
 export get_must_run
 export get_n_states
@@ -590,6 +591,7 @@ export get_states_types
 export get_status
 export get_storage_capacity
 export get_storage_target
+export get_sustained_time
 export get_switch
 export get_tF_delay
 export get_tV_delay
@@ -1043,6 +1045,7 @@ export set_max_current_active_power!
 export set_max_current_reactive_power!
 export set_max_impedance_active_power!
 export set_max_impedance_reactive_power!
+export set_max_participation_factor!
 export set_max_reactive_power!
 export set_must_run!
 export set_n_states!
@@ -1103,6 +1106,7 @@ export set_states_types!
 export set_status!
 export set_storage_capacity!
 export set_storage_target!
+export set_sustained_time!
 export set_switch!
 export set_tF_delay!
 export set_tV_delay!


### PR DESCRIPTION
Adding two new fields to Reserve objects, `sustained_time` the amount of time the reserve contribution must be provided for and `max_participation_factor` the maximum share of reserve product a single device can provide.