### PR TITLE
Added structure for user to set I limit

### DIFF
--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -2415,6 +2415,168 @@
             "supertype": "DynamicInjection"
         },
         {
+            "struct_name": "CSVGN1",
+            "docstring": "Parameters of static shunt compensator: CSVGN1 in PSSE",
+            "fields": [
+                {
+                    "null_value": "init",
+                    "name": "name",
+                    "exclude_setter": true,
+                    "data_type": "String"
+                },
+                {
+                    "name": "K",
+                    "comment": "Gain in pu",
+                    "null_value": 0,
+                    "data_type": "Float64",
+                    "valid_range": {
+                        "min": 0,
+                        "max": null
+                    }
+                },
+                {
+                    "name": "T1",
+                    "comment": "Time constant in s",
+                    "null_value": 0,
+                    "data_type": "Float64",
+                    "valid_range": {
+                        "min": 0,
+                        "max": null
+                    }
+                },
+                {
+                    "name": "T2",
+                    "comment": "Time constant in s",
+                    "null_value": 0,
+                    "data_type": "Float64",
+                    "valid_range": {
+                        "min": 0,
+                        "max": null
+                    }
+                },
+                {
+                    "name": "T3",
+                    "comment": "Time constant in s",
+                    "null_value": 0,
+                    "data_type": "Float64",
+                    "valid_range": {
+                        "min": "eps()",
+                        "max": null
+                    }
+                },
+                {
+                    "name": "T4",
+                    "comment": "Time constant in s",
+                    "null_value": 0,
+                    "data_type": "Float64",
+                    "valid_range": {
+                        "min": 0,
+                        "max": null
+                    }
+                },
+                {
+                    "name": "T5",
+                    "comment": "Time constant in s",
+                    "null_value": 0,
+                    "data_type": "Float64",
+                    "valid_range": {
+                        "min": 0,
+                        "max": null
+                    }
+                },
+                {
+                    "name": "Rmin",
+                    "comment": "Reactor minimum Mvar",
+                    "null_value": 0,
+                    "data_type": "Float64",
+                    "valid_range": {
+                        "min": 0,
+                        "max": null
+                    }
+                },
+                {
+                    "name": "Vmax",
+                    "comment": "Maximum voltage in pu",
+                    "null_value": 0,
+                    "data_type": "Float64",
+                    "valid_range": {
+                        "min": 0,
+                        "max": null
+                    }
+                },
+                {
+                    "name": "Vmin",
+                    "comment": "Minimum voltage in pu",
+                    "null_value": 0,
+                    "data_type": "Float64",
+                    "valid_range": {
+                        "min": 0,
+                        "max": null
+                    }
+                },
+                {
+                    "name": "CBase",
+                    "comment": "Capacitor Mvar",
+                    "null_value": 0,
+                    "data_type": "Float64",
+                    "valid_range": {
+                        "min": 0,
+                        "max": null
+                    }
+                },
+                {
+                    "name": "base_power",
+                    "comment": "Base power",
+                    "null_value": 0,
+                    "data_type": "Float64",
+                    "valid_range": {
+                        "min": 0,
+                        "max": null
+                    }
+                },
+                {
+                    "name": "ext",
+                    "data_type": "Dict{String, Any}",
+                    "null_value": "Dict{String, Any}()",
+                    "default": "Dict{String, Any}()"
+                },
+                {
+                    "name": "R_th",
+                    "comment": "Source Thevenin resistance",
+                    "internal_default": "0.0",
+                    "data_type": "Float64"
+                },
+                {
+                    "name": "X_th",
+                    "comment": "Source Thevenin reactance",
+                    "internal_default": "0.0",
+                    "data_type": "Float64"
+                },
+                {
+                    "name": "states",
+                    "exclude_setter": true,
+                    "comment": "The states are:\n\tthy: thyristor,\n\tvr1: regulator output 1,\n\tvr2: regulator output 2",
+                    "internal_default": "[:thy, :vr1, :vr2]",
+                    "data_type": "Vector{Symbol}"
+                },
+                {
+                    "name": "n_states",
+                    "exclude_setter": true,
+                    "comment": "CSVGN1 has 3 states",
+                    "internal_default": 3,
+                    "data_type": "Int"
+                },
+                {
+                    "name": "internal",
+                    "comment": "power system internal reference, do not modify",
+                    "data_type": "InfrastructureSystemsInternal",
+                    "internal_default": "InfrastructureSystemsInternal()",
+                    "exclude_setter": true
+                }
+            ],
+            "supertype": "DynamicInjection"
+        },
+        {
             "struct_name": "HydroEnergyReservoir",
             "fields": [
                 {
@@ -4000,7 +4162,8 @@
                         "min": 0,
                         "max": null
                     },
-                    "validation_action": "error"
+                    "validation_action": "error",
+                    "needs_conversion": true
                 },
                 {
                     "name": "ext",
@@ -4053,7 +4216,8 @@
                         "min": 0,
                         "max": null
                     },
-                    "validation_action": "error"
+                    "validation_action": "error",
+                    "needs_conversion": true
                 },
                 {
                     "name": "ext",
@@ -4096,7 +4260,8 @@
                         "min": 0,
                         "max": null
                     },
-                    "validation_action": "error"
+                    "validation_action": "error",
+                    "needs_conversion": true
                 },
                 {
                     "name": "ext",
@@ -4203,7 +4368,8 @@
                         "min": 0,
                         "max": null
                     },
-                    "validation_action": "error"
+                    "validation_action": "error",
+                    "needs_conversion": true
                 },
                 {
                     "name": "requirement",
@@ -4264,7 +4430,8 @@
                     "name": "requirement",
                     "comment": "the required quantity of the product should be scaled by a TimeSeriesData",
                     "null_value": "0.0",
-                    "data_type": "Float64"
+                    "data_type": "Float64",
+                    "needs_conversion": true
                 },
                 {
                     "name": "ext",
@@ -13235,6 +13402,28 @@
                     }
                 },
                 {
+                    "name": "I_lim_type",
+                    "comment": "Set current limiting method: 0.0 - none, 1.0 - instananeous, 2.0 - magnitude",
+                    "null_value": 0,
+                    "data_type": "Float64",
+                    "default":"0.0",
+                    "valid_range": {
+                        "min": 0,
+                        "max": 2
+                    }
+                },
+                {
+                    "name": "I_max",
+                    "comment": "Allowed current.",
+                    "null_value": 0,
+                    "data_type": "Float64",
+                    "default":"10.0",
+                    "valid_range": {
+                        "min": 0,
+                        "max": null
+                    }
+                },
+                {
                     "name": "ext",
                     "data_type": "Dict{String, Any}",
                     "null_value": "Dict{String, Any}()",
@@ -13286,6 +13475,28 @@
                     "comment": "Gain to enable feed-forward gain of voltage.",
                     "null_value": 0,
                     "data_type": "Float64",
+                    "valid_range": {
+                        "min": 0,
+                        "max": null
+                    }
+                },
+                {
+                    "name": "I_lim_type",
+                    "comment": "Set current limiting method: 0.0 - none, 1.0 - instananeous, 2.0 - magnitude",
+                    "null_value": 0,
+                    "data_type": "Float64",
+                    "default":"0.0",
+                    "valid_range": {
+                        "min": 0,
+                        "max": 2
+                    }
+                },
+                {
+                    "name": "I_max",
+                    "comment": "Allowed current.",
+                    "null_value": 0,
+                    "data_type": "Float64",
+                    "default":"10.0",
                     "valid_range": {
                         "min": 0,
                         "max": null

--- a/src/models/generated/CurrentModeControl.jl
+++ b/src/models/generated/CurrentModeControl.jl
@@ -9,6 +9,8 @@ This file is auto-generated. Do not edit.
         kpc::Float64
         kic::Float64
         kffv::Float64
+        I_lim_type::Float64
+        I_max::Float64
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
@@ -22,6 +24,8 @@ Parameters of an inner loop PI current control using based on Purba, Dhople, Jaf
 - `kpc::Float64`: Current controller proportional gain, validation range: `(0, nothing)`
 - `kic::Float64`: Current controller integral gain, validation range: `(0, nothing)`
 - `kffv::Float64`: Gain to enable feed-forward gain of voltage., validation range: `(0, nothing)`
+- `I_lim_type::Float64`: Set current limiting method: 0.0 - none, 1.0 - instananeous, 2.0 - magnitude, validation range: `(0, 2)`
+- `I_max::Float64`: Allowed current., validation range: `(0, nothing)`
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`: The states of the CurrentModeControl model are:
 	γd_ic: d-axis integrator state of the PI current controller,
@@ -35,6 +39,10 @@ mutable struct CurrentModeControl <: InnerControl
     kic::Float64
     "Gain to enable feed-forward gain of voltage."
     kffv::Float64
+    "Set current limiting method: 0.0 - none, 1.0 - instananeous, 2.0 - magnitude"
+    I_lim_type::Float64
+    "Allowed current."
+    I_max::Float64
     ext::Dict{String, Any}
     "The states of the CurrentModeControl model are:
 	γd_ic: d-axis integrator state of the PI current controller,
@@ -44,12 +52,12 @@ mutable struct CurrentModeControl <: InnerControl
     n_states::Int
 end
 
-function CurrentModeControl(kpc, kic, kffv, ext=Dict{String, Any}(), )
-    CurrentModeControl(kpc, kic, kffv, ext, [:γd_ic, :γq_ic], 2, )
+function CurrentModeControl(kpc, kic, kffv, I_lim_type=0.0, I_max=10.0, ext=Dict{String, Any}(), )
+    CurrentModeControl(kpc, kic, kffv, I_lim_type, I_max, ext, [:γd_ic, :γq_ic], 2, )
 end
 
-function CurrentModeControl(; kpc, kic, kffv, ext=Dict{String, Any}(), states=[:γd_ic, :γq_ic], n_states=2, )
-    CurrentModeControl(kpc, kic, kffv, ext, states, n_states, )
+function CurrentModeControl(; kpc, kic, kffv, I_lim_type=0.0, I_max=10.0, ext=Dict{String, Any}(), states=[:γd_ic, :γq_ic], n_states=2, )
+    CurrentModeControl(kpc, kic, kffv, I_lim_type, I_max, ext, states, n_states, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -58,6 +66,8 @@ function CurrentModeControl(::Nothing)
         kpc=0,
         kic=0,
         kffv=0,
+        I_lim_type=0,
+        I_max=0,
         ext=Dict{String, Any}(),
     )
 end
@@ -68,6 +78,10 @@ get_kpc(value::CurrentModeControl) = value.kpc
 get_kic(value::CurrentModeControl) = value.kic
 """Get [`CurrentModeControl`](@ref) `kffv`."""
 get_kffv(value::CurrentModeControl) = value.kffv
+"""Get [`CurrentModeControl`](@ref) `I_lim_type`."""
+get_I_lim_type(value::CurrentModeControl) = value.I_lim_type
+"""Get [`CurrentModeControl`](@ref) `I_max`."""
+get_I_max(value::CurrentModeControl) = value.I_max
 """Get [`CurrentModeControl`](@ref) `ext`."""
 get_ext(value::CurrentModeControl) = value.ext
 """Get [`CurrentModeControl`](@ref) `states`."""
@@ -81,5 +95,9 @@ set_kpc!(value::CurrentModeControl, val) = value.kpc = val
 set_kic!(value::CurrentModeControl, val) = value.kic = val
 """Set [`CurrentModeControl`](@ref) `kffv`."""
 set_kffv!(value::CurrentModeControl, val) = value.kffv = val
+"""Set [`CurrentModeControl`](@ref) `I_lim_type`."""
+set_I_lim_type!(value::CurrentModeControl, val) = value.I_lim_type = val
+"""Set [`CurrentModeControl`](@ref) `I_max`."""
+set_I_max!(value::CurrentModeControl, val) = value.I_max = val
 """Set [`CurrentModeControl`](@ref) `ext`."""
 set_ext!(value::CurrentModeControl, val) = value.ext = val

--- a/src/models/generated/VoltageModeControl.jl
+++ b/src/models/generated/VoltageModeControl.jl
@@ -16,6 +16,8 @@ This file is auto-generated. Do not edit.
         kffi::Float64
         ωad::Float64
         kad::Float64
+        I_lim_type::Float64
+        I_max::Float64
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
@@ -36,6 +38,8 @@ Electric Power Systems Research 122 (2015) 180–197.
 - `kffi::Float64`: Binary variable to enable feed-forward gain of current, validation range: `(0, nothing)`
 - `ωad::Float64`: active damping filter cutoff frequency (rad/sec), validation range: `(0, nothing)`
 - `kad::Float64`: active damping gain, validation range: `(0, nothing)`
+- `I_lim_type::Float64`: Set current limiting method: 0.0 - none, 1.0 - instananeous, 2.0 - magnitude, validation range: `(0, 2)`
+- `I_max::Float64`: Allowed current., validation range: `(0, nothing)`
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`: The states of the VoltageModeControl model are:
 	ξd_ic: d-axis integrator state of the PI voltage controller,
@@ -67,6 +71,10 @@ mutable struct VoltageModeControl <: InnerControl
     ωad::Float64
     "active damping gain"
     kad::Float64
+    "Set current limiting method: 0.0 - none, 1.0 - instananeous, 2.0 - magnitude"
+    I_lim_type::Float64
+    "Allowed current."
+    I_max::Float64
     ext::Dict{String, Any}
     "The states of the VoltageModeControl model are:
 	ξd_ic: d-axis integrator state of the PI voltage controller,
@@ -80,12 +88,12 @@ mutable struct VoltageModeControl <: InnerControl
     n_states::Int
 end
 
-function VoltageModeControl(kpv, kiv, kffv, rv, lv, kpc, kic, kffi, ωad, kad, ext=Dict{String, Any}(), )
-    VoltageModeControl(kpv, kiv, kffv, rv, lv, kpc, kic, kffi, ωad, kad, ext, [:ξd_ic, :ξq_ic, :γd_ic, :γq_ic, :ϕd_ic, :ϕq_ic], 6, )
+function VoltageModeControl(kpv, kiv, kffv, rv, lv, kpc, kic, kffi, ωad, kad, I_lim_type=0.0, I_max=10.0, ext=Dict{String, Any}(), )
+    VoltageModeControl(kpv, kiv, kffv, rv, lv, kpc, kic, kffi, ωad, kad, I_lim_type, I_max, ext, [:ξd_ic, :ξq_ic, :γd_ic, :γq_ic, :ϕd_ic, :ϕq_ic], 6, )
 end
 
-function VoltageModeControl(; kpv, kiv, kffv, rv, lv, kpc, kic, kffi, ωad, kad, ext=Dict{String, Any}(), states=[:ξd_ic, :ξq_ic, :γd_ic, :γq_ic, :ϕd_ic, :ϕq_ic], n_states=6, )
-    VoltageModeControl(kpv, kiv, kffv, rv, lv, kpc, kic, kffi, ωad, kad, ext, states, n_states, )
+function VoltageModeControl(; kpv, kiv, kffv, rv, lv, kpc, kic, kffi, ωad, kad, I_lim_type=0.0, I_max=10.0, ext=Dict{String, Any}(), states=[:ξd_ic, :ξq_ic, :γd_ic, :γq_ic, :ϕd_ic, :ϕq_ic], n_states=6, )
+    VoltageModeControl(kpv, kiv, kffv, rv, lv, kpc, kic, kffi, ωad, kad, I_lim_type, I_max, ext, states, n_states, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -101,6 +109,8 @@ function VoltageModeControl(::Nothing)
         kffi=0,
         ωad=0,
         kad=0,
+        I_lim_type=0,
+        I_max=0,
         ext=Dict{String, Any}(),
     )
 end
@@ -125,6 +135,10 @@ get_kffi(value::VoltageModeControl) = value.kffi
 get_ωad(value::VoltageModeControl) = value.ωad
 """Get [`VoltageModeControl`](@ref) `kad`."""
 get_kad(value::VoltageModeControl) = value.kad
+"""Get [`VoltageModeControl`](@ref) `I_lim_type`."""
+get_I_lim_type(value::VoltageModeControl) = value.I_lim_type
+"""Get [`VoltageModeControl`](@ref) `I_max`."""
+get_I_max(value::VoltageModeControl) = value.I_max
 """Get [`VoltageModeControl`](@ref) `ext`."""
 get_ext(value::VoltageModeControl) = value.ext
 """Get [`VoltageModeControl`](@ref) `states`."""
@@ -152,5 +166,9 @@ set_kffi!(value::VoltageModeControl, val) = value.kffi = val
 set_ωad!(value::VoltageModeControl, val) = value.ωad = val
 """Set [`VoltageModeControl`](@ref) `kad`."""
 set_kad!(value::VoltageModeControl, val) = value.kad = val
+"""Set [`VoltageModeControl`](@ref) `I_lim_type`."""
+set_I_lim_type!(value::VoltageModeControl, val) = value.I_lim_type = val
+"""Set [`VoltageModeControl`](@ref) `I_max`."""
+set_I_max!(value::VoltageModeControl, val) = value.I_max = val
 """Set [`VoltageModeControl`](@ref) `ext`."""
 set_ext!(value::VoltageModeControl, val) = value.ext = val

--- a/src/models/generated/includes.jl
+++ b/src/models/generated/includes.jl
@@ -24,6 +24,7 @@ include("SingleCageInductionMachine.jl")
 include("SimplifiedSingleCageInductionMachine.jl")
 include("DynamicExponentialLoad.jl")
 include("ActiveConstantPowerLoad.jl")
+include("CSVGN1.jl")
 include("HydroEnergyReservoir.jl")
 include("HydroDispatch.jl")
 include("HydroPumpedStorage.jl")
@@ -130,6 +131,7 @@ export get_B_shunt
 export get_Be
 export get_Brkpt
 export get_C
+export get_CBase
 export get_D
 export get_DB_h
 export get_DB_l
@@ -161,6 +163,7 @@ export get_H_hp
 export get_H_ip
 export get_H_lim
 export get_H_lp
+export get_I_lim_type
 export get_I_lr
 export get_I_max
 export get_Iflim
@@ -275,6 +278,7 @@ export get_R_source
 export get_R_th
 export get_Recon_Flag
 export get_Ref_Flag
+export get_Rmin
 export get_Rp
 export get_Rrpwr
 export get_Rselect
@@ -367,6 +371,8 @@ export get_Vdip_lim
 export get_Vf
 export get_Vi_lim
 export get_Vm_lim
+export get_Vmax
+export get_Vmin
 export get_Vo_lim
 export get_Vpr
 export get_Vr_lim
@@ -621,6 +627,7 @@ export set_B_shunt!
 export set_Be!
 export set_Brkpt!
 export set_C!
+export set_CBase!
 export set_D!
 export set_DB_h!
 export set_DB_l!
@@ -652,6 +659,7 @@ export set_H_hp!
 export set_H_ip!
 export set_H_lim!
 export set_H_lp!
+export set_I_lim_type!
 export set_I_lr!
 export set_I_max!
 export set_Iflim!
@@ -766,6 +774,7 @@ export set_R_source!
 export set_R_th!
 export set_Recon_Flag!
 export set_Ref_Flag!
+export set_Rmin!
 export set_Rp!
 export set_Rrpwr!
 export set_Rselect!
@@ -858,6 +867,8 @@ export set_Vdip_lim!
 export set_Vf!
 export set_Vi_lim!
 export set_Vm_lim!
+export set_Vmax!
+export set_Vmin!
 export set_Vo_lim!
 export set_Vpr!
 export set_Vr_lim!


### PR DESCRIPTION
Thanks for opening a PR to PowerSystems.jl, please take note of the following when making a PR:

Check the [contributor guidelines](https://nrel-sienna.github.io/PowerSystems.jl/stable/code_base_developer_guide/developer/)

1. Add a description of the changes proposed in the pull request.
2. Is my PR fixing an open issue? Add the reference to the related issue
3. If you are contributing a new struct: please refer to the [testing requirements for new structs](https://nrel-sienna.github.io/PowerSystems.jl/stable/code_base_developer_guide/adding_new_types/#Testing-the-addition-of-new-struct-to-the-code-base)

Updated the CurrentModeControl and VoltageModeControl structs using power_system_structs.json to have new parameters that allow users to set a current limiting technique and current maximum. Also updated includes.jl to allow those parameters to be exported and imported so that they could be accessed in inner_control_models.jl in PSID. Must be paired with my other PR to PSID for full functionality here [https://github.com/NREL-Sienna/PowerSimulationsDynamics.jl/pull/345](url)