### PR TITLE
Implement convert_component! for StandardLoad <- PowerLoad

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -1920,9 +1920,9 @@ Converts a Line component to a MonitoredLine component and replaces the original
 system
 """
 function convert_component!(
-    linetype::Type{MonitoredLine},
+    sys::System,
     line::Line,
-    sys::System;
+    linetype::Type{MonitoredLine};
     kwargs...,
 )
     new_line = linetype(
@@ -1954,9 +1954,9 @@ Converts a MonitoredLine component to a Line component and replaces the original
 system
 """
 function convert_component!(
-    linetype::Type{Line},
+    sys::System,
     line::MonitoredLine,
-    sys::System;
+    linetype::Type{Line};
     kwargs...,
 )
     force = get(kwargs, :force, false)
@@ -1996,9 +1996,9 @@ Converts a PowerLoad component to a StandardLoad component and replaces the orig
 system. Does not set any fields in StandardLoad that lack a PowerLoad equivalent
 """
 function convert_component!(
-    new_type::Type{StandardLoad},
+    sys::System,
     old_load::PowerLoad,
-    sys::System;
+    new_type::Type{StandardLoad};
     kwargs...,
 )
     new_load = new_type(;

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,1 +1,13 @@
 # BEGIN 2.0.0  deprecations
+Base.@deprecate convert_component!(
+    linetype::Type{MonitoredLine},
+    line::Line,
+    sys::System;
+    kwargs...,
+) convert_component!(sys, line, linetype; kwargs...)
+Base.@deprecate convert_component!(
+    linetype::Type{Line},
+    line::MonitoredLine,
+    sys::System;
+    kwargs...,
+) convert_component!(sys, line, linetype; kwargs...)

--- a/test/test_deprecations.jl
+++ b/test/test_deprecations.jl
@@ -1,1 +1,39 @@
-# Currently no 2.0.0  deprecations
+@testset "Test deprecated convert_component!" begin
+    # Test copied from test_powersystemconstructors.jl
+    test_line_conversion =
+        () -> begin
+            sys = System(joinpath(BAD_DATA, "case5_re.m"))
+            l = get_component(Line, sys, "bus2-bus3-i_4")
+            initial_time = Dates.DateTime("2020-01-01T00:00:00")
+            dates = collect(
+                initial_time:Dates.Hour(1):Dates.DateTime("2020-01-01T23:00:00"),
+            )
+            data = collect(1:24)
+            ta = TimeSeries.TimeArray(dates, data, [get_name(l)])
+            name = "active_power_flow"
+            time_series = SingleTimeSeries(; name = name, data = ta)
+            add_time_series!(sys, l, time_series)
+            @test get_time_series(SingleTimeSeries, l, name) isa SingleTimeSeries
+            @test_deprecated PSY.convert_component!(MonitoredLine, l, sys)
+            @test isnothing(get_component(Line, sys, "bus2-bus3-i_4"))
+            mline = get_component(MonitoredLine, sys, "bus2-bus3-i_4")
+            @test !isnothing(mline)
+            @test get_name(mline) == "bus2-bus3-i_4"
+            @test get_time_series(SingleTimeSeries, mline, name) isa SingleTimeSeries
+            @test_deprecated @test_throws ErrorException convert_component!(
+                Line,
+                get_component(MonitoredLine, sys, "bus2-bus3-i_4"),
+                sys,
+            )
+            @test_deprecated convert_component!(
+                Line,
+                get_component(MonitoredLine, sys, "bus2-bus3-i_4"),
+                sys;
+                force = true,
+            )
+            line = get_component(Line, sys, "bus2-bus3-i_4")
+            @test !isnothing(mline)
+            @test get_time_series(SingleTimeSeries, line, name) isa SingleTimeSeries
+        end
+    @test_logs (:error,) min_level = Logging.Error match_mode = :any test_line_conversion()
+end

--- a/test/test_powersystemconstructors.jl
+++ b/test/test_powersystemconstructors.jl
@@ -132,26 +132,51 @@ end
 end
 
 @testset "Test component conversion" begin
-    test_conversion =
+    # Reusable resources for this testset
+    load_test_system = () -> System(joinpath(BAD_DATA, "case5_re.m"))
+    function setup_time_series!(sys::System, component::Component, ts_name::String)
+        dates = collect(
+            Dates.DateTime("2020-01-01T00:00:00"):Dates.Hour(1):Dates.DateTime(
+                "2020-01-01T23:00:00",
+            ),
+        )
+        data = collect(1:24)
+        ta = TimeSeries.TimeArray(dates, data, [get_name(component)])
+        time_series = SingleTimeSeries(; name = ts_name, data = ta)
+        add_time_series!(sys, component, time_series)
+        @test get_time_series(SingleTimeSeries, component, ts_name) isa SingleTimeSeries
+    end
+
+    function test_forward_conversion(
+        new_type::Type{<:Component},
+        old_component::Component,
+        sys,
+        component_name,
+        ts_name,
+    )
+        convert_component!(new_type, old_component, sys)
+        println(typeof(old_component))
+        @test isnothing(get_component(typeof(old_component), sys, component_name))
+        new_component = get_component(new_type, sys, component_name)
+        @test !isnothing(new_component)
+        @test get_name(new_component) == component_name
+        @test get_time_series(SingleTimeSeries, new_component, ts_name) isa SingleTimeSeries
+        return new_component
+    end
+
+    """Tests Line <-> MonitoredLine conversion"""
+    test_line_conversion =
         () -> begin
-            sys = System(joinpath(BAD_DATA, "case5_re.m"))
+            sys = load_test_system()
             l = get_component(Line, sys, "bus2-bus3-i_4")
-            initial_time = Dates.DateTime("2020-01-01T00:00:00")
-            dates = collect(
-                initial_time:Dates.Hour(1):Dates.DateTime("2020-01-01T23:00:00"),
-            )
-            data = collect(1:24)
-            ta = TimeSeries.TimeArray(dates, data, [get_name(l)])
-            name = "active_power_flow"
-            time_series = SingleTimeSeries(; name = name, data = ta)
-            add_time_series!(sys, l, time_series)
-            @test get_time_series(SingleTimeSeries, l, name) isa SingleTimeSeries
-            PSY.convert_component!(MonitoredLine, l, sys)
-            @test isnothing(get_component(Line, sys, "bus2-bus3-i_4"))
-            mline = get_component(MonitoredLine, sys, "bus2-bus3-i_4")
-            @test !isnothing(mline)
-            @test get_name(mline) == "bus2-bus3-i_4"
-            @test get_time_series(SingleTimeSeries, mline, name) isa SingleTimeSeries
+            ts_name = "active_power_flow"
+            setup_time_series!(sys, l, ts_name)
+
+            # Conversion to MonitoredLine
+            mline =
+                test_forward_conversion(MonitoredLine, l, sys, "bus2-bus3-i_4", ts_name)
+
+            # Conversion back (must be forced)
             @test_throws ErrorException convert_component!(
                 Line,
                 get_component(MonitoredLine, sys, "bus2-bus3-i_4"),
@@ -165,7 +190,23 @@ end
             )
             line = get_component(Line, sys, "bus2-bus3-i_4")
             @test !isnothing(mline)
-            @test get_time_series(SingleTimeSeries, line, name) isa SingleTimeSeries
+            @test get_time_series(SingleTimeSeries, line, ts_name) isa SingleTimeSeries
         end
-    @test_logs (:error,) min_level = Logging.Error match_mode = :any test_conversion()
+
+    """Tests PowerLoad --> StandardLoad conversion"""
+    test_load_conversion =
+        () -> begin
+            sys = load_test_system()
+            l = get_component(PowerLoad, sys, "bus2")
+            ts_name = "max_active_power"
+            setup_time_series!(sys, l, ts_name)
+
+            # Conversion to StandardLoad
+            sload = test_forward_conversion(StandardLoad, l, sys, "bus2", ts_name)
+
+            # Conversion back is not implemented
+        end
+
+    @test_logs (:error,) min_level = Logging.Error match_mode = :any test_line_conversion()
+    @test_logs (:error,) min_level = Logging.Error match_mode = :any test_load_conversion()
 end

--- a/test/test_powersystemconstructors.jl
+++ b/test/test_powersystemconstructors.jl
@@ -146,21 +146,21 @@ end
             time_series = SingleTimeSeries(; name = name, data = ta)
             add_time_series!(sys, l, time_series)
             @test get_time_series(SingleTimeSeries, l, name) isa SingleTimeSeries
-            PSY.convert_component!(MonitoredLine, l, sys)
+            PSY.convert_component!(sys, l, MonitoredLine)
             @test isnothing(get_component(Line, sys, "bus2-bus3-i_4"))
             mline = get_component(MonitoredLine, sys, "bus2-bus3-i_4")
             @test !isnothing(mline)
             @test get_name(mline) == "bus2-bus3-i_4"
             @test get_time_series(SingleTimeSeries, mline, name) isa SingleTimeSeries
             @test_throws ErrorException convert_component!(
-                Line,
-                get_component(MonitoredLine, sys, "bus2-bus3-i_4"),
                 sys,
+                get_component(MonitoredLine, sys, "bus2-bus3-i_4"),
+                Line,
             )
             convert_component!(
-                Line,
+                sys,
                 get_component(MonitoredLine, sys, "bus2-bus3-i_4"),
-                sys;
+                Line;
                 force = true,
             )
             line = get_component(Line, sys, "bus2-bus3-i_4")
@@ -183,17 +183,19 @@ end
             ta = TimeSeries.TimeArray(dates, data, [component_name])
             time_series = SingleTimeSeries(; name = ts_name, data = ta)
             add_time_series!(sys, old_component, time_series)
-            @test get_time_series(SingleTimeSeries, old_component, ts_name) isa SingleTimeSeries
+            @test get_time_series(SingleTimeSeries, old_component, ts_name) isa
+                  SingleTimeSeries
 
-            convert_component!(StandardLoad, old_component, sys)
+            convert_component!(sys, old_component, StandardLoad)
             @test isnothing(get_component(typeof(old_component), sys, component_name))
             new_component = get_component(StandardLoad, sys, component_name)
             @test !isnothing(new_component)
             @test get_name(new_component) == component_name
-            @test get_time_series(SingleTimeSeries, new_component, ts_name) isa SingleTimeSeries
+            @test get_time_series(SingleTimeSeries, new_component, ts_name) isa
+                  SingleTimeSeries
             # Conversion back is not implemented
         end
-    
+
     @test_logs (:error,) min_level = Logging.Error match_mode = :any test_line_conversion()
     test_load_conversion()
 end


### PR DESCRIPTION
This will be used for a new system in PowerSystemCaseBuilder. Includes unit tests.
---

 - Define convert_component! for conversions from PowerLoad to StandardLoad
 - Add unit tests for this method along the lines of existing convert_component! unit tests
 - Refactor convert_component! unit tests to remove repetition
