### PR TITLE
Fix case sensitivity in enum parsers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PowerSystems"
 uuid = "bcd98974-b02a-5e2f-9ee0-a103f5c450dd"
 authors = ["Jose Daniel Lara", "Daniel Thom", "Dheepak Krishnamurthy", "Clayton Barrows", "Sourabh Dalvi"]
-version = "3.2.1"
+version = "3.2.2"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/parsers/common.jl
+++ b/src/parsers/common.jl
@@ -19,28 +19,28 @@ merge!(
     ),
 )
 
-const STRING2PRIMEMOVER = Dict((string(x) => x) for x in instances(PrimeMovers))
+const STRING2PRIMEMOVER =
+    Dict((normalize(string(x); casefold = true) => x) for x in instances(PrimeMovers))
 merge!(
     STRING2PRIMEMOVER,
     Dict(
-        "W2" => PrimeMovers.WT,
-        "WIND" => PrimeMovers.WT,
-        "PV" => PrimeMovers.PVe,
-        "PVe" => PrimeMovers.PVe,
-        "SOLAR" => PrimeMovers.PVe,
-        "RTPV" => PrimeMovers.PVe,
-        "NB" => PrimeMovers.ST,
-        "STEAM" => PrimeMovers.ST,
-        "HYDRO" => PrimeMovers.HY,
-        "ROR" => PrimeMovers.HY,
-        "PUMP" => PrimeMovers.PS,
-        "PUMPED_HYDRO" => PrimeMovers.PS,
-        "NUCLEAR" => PrimeMovers.ST,
-        "SYNC_COND" => PrimeMovers.OT,
-        "CSP" => PrimeMovers.CP,
-        "UN" => PrimeMovers.OT,
-        "STORAGE" => PrimeMovers.BA,
-        "ICE" => PrimeMovers.IC,
+        "w2" => PrimeMovers.WT,
+        "wind" => PrimeMovers.WT,
+        "pv" => PrimeMovers.PVe,
+        "solar" => PrimeMovers.PVe,
+        "rtpv" => PrimeMovers.PVe,
+        "nb" => PrimeMovers.ST,
+        "steam" => PrimeMovers.ST,
+        "hydro" => PrimeMovers.HY,
+        "ror" => PrimeMovers.HY,
+        "pump" => PrimeMovers.PS,
+        "pumped_hydro" => PrimeMovers.PS,
+        "nuclear" => PrimeMovers.ST,
+        "sync_cond" => PrimeMovers.OT,
+        "csp" => PrimeMovers.CP,
+        "un" => PrimeMovers.OT,
+        "storage" => PrimeMovers.BA,
+        "ice" => PrimeMovers.IC,
     ),
 )
 
@@ -209,7 +209,7 @@ function parse_enum_mapping(::Type{ThermalFuels}, fuel::Symbol)
 end
 
 function parse_enum_mapping(::Type{PrimeMovers}, prime_mover::AbstractString)
-    return STRING2PRIMEMOVER[uppercase(prime_mover)]
+    return STRING2PRIMEMOVER[normalize(prime_mover, casefold = true)]
 end
 
 function parse_enum_mapping(::Type{PrimeMovers}, prime_mover::Symbol)

--- a/src/parsers/common.jl
+++ b/src/parsers/common.jl
@@ -202,7 +202,7 @@ function convert_units!(
 end
 
 function parse_enum_mapping(::Type{ThermalFuels}, fuel::AbstractString)
-    return STRING2FUEL[normalize(fuel, casefold = true)]
+    return STRING2FUEL[normalize(fuel; casefold = true)]
 end
 
 function parse_enum_mapping(::Type{ThermalFuels}, fuel::Symbol)

--- a/src/parsers/common.jl
+++ b/src/parsers/common.jl
@@ -4,18 +4,19 @@ const GENERATOR_MAPPING_FILE =
 const PSSE_DYR_MAPPING_FILE =
     joinpath(dirname(pathof(PowerSystems)), "parsers", "psse_dynamic_mapping.yaml")
 
-const STRING2FUEL = Dict((string(x) => x) for x in instances(ThermalFuels))
+const STRING2FUEL =
+    Dict((normalize(string(x); casefold = true) => x) for x in instances(ThermalFuels))
 merge!(
     STRING2FUEL,
     Dict(
-        "NG" => ThermalFuels.NATURAL_GAS,
-        "NUC" => ThermalFuels.NUCLEAR,
-        "GAS" => ThermalFuels.NATURAL_GAS,
-        "OIL" => ThermalFuels.DISTILLATE_FUEL_OIL,
-        "DFO" => ThermalFuels.DISTILLATE_FUEL_OIL,
-        "SYNC_COND" => ThermalFuels.OTHER,
-        "GEOTHERMAL " => ThermalFuels.GEOTHERMAL,
-        "AG_BIPRODUCT" => ThermalFuels.AG_BIPRODUCT,
+        "ng" => ThermalFuels.NATURAL_GAS,
+        "nuc" => ThermalFuels.NUCLEAR,
+        "gas" => ThermalFuels.NATURAL_GAS,
+        "oil" => ThermalFuels.DISTILLATE_FUEL_OIL,
+        "dfo" => ThermalFuels.DISTILLATE_FUEL_OIL,
+        "sync_cond" => ThermalFuels.OTHER,
+        "geothermal " => ThermalFuels.GEOTHERMAL,
+        "ag_biproduct" => ThermalFuels.AG_BIPRODUCT,
     ),
 )
 
@@ -201,7 +202,7 @@ function convert_units!(
 end
 
 function parse_enum_mapping(::Type{ThermalFuels}, fuel::AbstractString)
-    return STRING2FUEL[uppercase(fuel)]
+    return STRING2FUEL[normalize(fuel, casefold = true)]
 end
 
 function parse_enum_mapping(::Type{ThermalFuels}, fuel::Symbol)

--- a/src/parsers/common.jl
+++ b/src/parsers/common.jl
@@ -209,7 +209,7 @@ function parse_enum_mapping(::Type{ThermalFuels}, fuel::Symbol)
 end
 
 function parse_enum_mapping(::Type{PrimeMovers}, prime_mover::AbstractString)
-    return STRING2PRIMEMOVER[normalize(prime_mover, casefold = true)]
+    return STRING2PRIMEMOVER[normalize(prime_mover; casefold = true)]
 end
 
 function parse_enum_mapping(::Type{PrimeMovers}, prime_mover::Symbol)


### PR DESCRIPTION
`parse_enum_mapping` was converting input to uppercase but the keys of the underlying dictionary were not all uppercase, so, e.g., `parse_enum_mapping(PrimeMovers, "PVe")` wouldn't work and https://github.com/NREL-Sienna/PowerSystems.jl/issues/849 wasn't truly solved. Now everything is `Unicode.normalize(casefold=true)`'d on both sides.