### PR TITLE
Add bus_name_formatter to documentation

### DIFF
--- a/docs/src/modeler_guide/parsing.md
+++ b/docs/src/modeler_guide/parsing.md
@@ -97,6 +97,13 @@ RAW_dir = joinpath(file_dir, "ThreeBusNetwork.raw")
 DYR_dir = joinpath(file_dir, "TestGENCLS.dyr")
 dyn_system = System(RAW_dir, DYR_dir, runchecks = false)
 ```
+### Common Issues
+
+Please note that while PSS/e does not enforce unique bus names, `PowerSystems.jl` does. To automatically reparse bus names to comply with this requirement, the `System()` call can be modified with the bus_name_formatter *kwarg as shown below:
+
+```@repl raw_dyr_system
+dyn_system = System(RAW_dir, DYR_dir; bus_name_formatter = x -> strip(string(x["name"])) * "-" * string(x["index"]), runchecks = false)
+```
 
 ## [PowerSystems Table Data](@id table_data)
 

--- a/docs/src/modeler_guide/parsing.md
+++ b/docs/src/modeler_guide/parsing.md
@@ -99,11 +99,12 @@ dyn_system = System(RAW_dir, DYR_dir, runchecks = false)
 ```
 ### Common Issues
 
-Please note that while PSS/e does not enforce unique bus names, `PowerSystems.jl` does. To automatically reparse bus names to comply with this requirement, the `System()` call can be modified with the bus_name_formatter *kwarg as shown below:
+Please note that while PSS/e does not enforce unique bus names, `PowerSystems.jl` does. To reparse bus names to comply with this requirement the `bus_name_formatter` *kwarg  can be used in `System()` as shown in the example below:
 
 ```@repl raw_dyr_system
-dyn_system = System(RAW_dir, DYR_dir; bus_name_formatter = x -> strip(string(x["name"])) * "-" * string(x["index"]), runchecks = false)
+dyn_system = System(RAW_dir, DYR_dir; bus_name_formatter = x -> strip(string(x["name"])) * "-" * string(x["index"]))
 ```
+In this example the anonymous function `x -> strip(string(x["name"])) * "-" * string(x["index"])` takes the bus name and index from PSSe and concatenates them to produce the name. 
 
 ## [PowerSystems Table Data](@id table_data)
 


### PR DESCRIPTION
1. Added a section to the parsing.md documentation file addressing common issues when parsing PSS/e data. 
Added a guide to working around non-unique PSS/e bus names. 

2. This is not fixing an open issue.

3. This does not contribute a new struct. 