### PR TITLE
Add conversion logic for subsystems and attributes

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -1549,6 +1549,10 @@ function IS.deserialize(
         JSON3.read(io, Dict)
     end
 
+    if raw["data_format_version"] != DATA_FORMAT_VERSION
+        pre_read_conversion!(raw)
+    end
+
     # These file paths are relative to the system file.
     directory = dirname(filename)
     for file_key in ("time_series_storage_file", "validation_descriptor_file")

--- a/src/data_format_conversions.jl
+++ b/src/data_format_conversions.jl
@@ -73,6 +73,16 @@ function _convert_data!(
     return
 end
 
+# Conversions to occur immediately after the data is loaded from disk
+function pre_read_conversion!(raw)
+    if VersionNumber(raw["data_format_version"]) < v"4.0.0"
+        haskey(raw["data"], "subsystems") ||
+            (raw["data"]["subsystems"] = Dict{String, Any}())
+        haskey(raw["data"], "attributes") || (raw["data"]["attributes"] = Any[])
+    end
+end
+
+# Conversions to occur before deserialize_components!
 function pre_deserialize_conversion!(raw, sys::System)
     old = raw["data_format_version"]
     if old == DATA_FORMAT_VERSION
@@ -85,6 +95,7 @@ function pre_deserialize_conversion!(raw, sys::System)
     end
 end
 
+# Conversions to occur at the end of deserialization
 function post_deserialize_conversion!(sys::System, raw)
     old = raw["data_format_version"]
     if old == "1.0.0"


### PR DESCRIPTION
A quick check during deserialization to add empty `subsystems` and `attributes` fields to pre-PSY4 systems