### PR TITLE
Variable Cost Refactor Part 2: PowerSimulations

### DIFF
--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -538,9 +538,9 @@ import InfrastructureSystems:
     get_slopes,
     get_x_lengths,
     is_convex,
-    get_points,
+    get_points,  # TODO possible rename to disambiguate from geographical information
     get_x_coords,
-    get_y0,
+    get_y0,  # TODO reevaluate whether this should be exported
     get_raw_data,
     get_raw_data_type
 

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -540,7 +540,9 @@ import InfrastructureSystems:
     is_convex,
     get_points,
     get_x_coords,
-    get_y0
+    get_y0,
+    get_raw_data,
+    get_raw_data_type
 
 const IS = InfrastructureSystems
 


### PR DESCRIPTION
The second part of a significant refactor of Sienna cost data structures (part 1 is [here](https://github.com/NREL-Sienna/PowerSystems.jl/pull/1056#issuecomment-1959057500)). The main focus here is to bring PowerSimulations.jl up to date with the elimination of `VariableCost` in favor of `FunctionData`. That entails these changes in PowerSystems:

- Add exports for the new "raw data" functions added to `FunctionData`

Tests pass:
<img width="1635" alt="Screenshot 2024-02-26 at 4 32 27 AM" src="https://github.com/NREL-Sienna/InfrastructureSystems.jl/assets/23368820/8c27f79b-1f06-4a81-8344-1a78e4ef76ad">
