### PR TITLE
Repair StandardLoad parsing from .mat/.raw files

### DIFF
--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -483,7 +483,7 @@ function make_thermal_gen(gen_name::AbstractString, d::Dict, bus::ACBus, sys_mba
     thermal_gen = ThermalStandard(;
         name = gen_name,
         status = Bool(d["gen_status"]),
-        available = true,
+        available = Bool(d["gen_status"]),
         bus = bus,
         active_power = d["pg"] * base_conversion,
         reactive_power = d["qg"] * base_conversion,

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -254,8 +254,7 @@ function read_loads!(sys::System, data, bus_number_to_bus::Dict{Int, ACBus}; kwa
     for d_key in keys(data["load"])
         d = data["load"][d_key]
         bus = bus_number_to_bus[d["load_bus"]]
-            if data["source_type"] == "pti"
-                println("HEEEEERE")
+            if data["source_type"] == "pti" 
                 load = make_standard_load(d, bus, sys_mbase; kwargs...)
                 has_component(StandardLoad, sys, get_name(load)) && throw(
                     DataFormatError(

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -253,9 +253,9 @@ function read_loads!(sys::System, data, bus_number_to_bus::Dict{Int, ACBus}; kwa
     sys_mbase = data["baseMVA"]
     for d_key in keys(data["load"])
         d = data["load"][d_key]
-        if d["pd"] != 0.0
-            bus = bus_number_to_bus[d["load_bus"]]
+        bus = bus_number_to_bus[d["load_bus"]]
             if data["source_type"] == "pti"
+                println("HEEEEERE")
                 load = make_standard_load(d, bus, sys_mbase; kwargs...)
                 has_component(StandardLoad, sys, get_name(load)) && throw(
                     DataFormatError(
@@ -270,8 +270,7 @@ function read_loads!(sys::System, data, bus_number_to_bus::Dict{Int, ACBus}; kwa
                     ),
                 )
             end
-            add_component!(sys, load; skip_validation = SKIP_PM_VALIDATION)
-        end
+        add_component!(sys, load; skip_validation = SKIP_PM_VALIDATION)
     end
 end
 

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -254,21 +254,21 @@ function read_loads!(sys::System, data, bus_number_to_bus::Dict{Int, ACBus}; kwa
     for d_key in keys(data["load"])
         d = data["load"][d_key]
         bus = bus_number_to_bus[d["load_bus"]]
-            if data["source_type"] == "pti" 
-                load = make_standard_load(d, bus, sys_mbase; kwargs...)
-                has_component(StandardLoad, sys, get_name(load)) && throw(
-                    DataFormatError(
-                        "Found duplicate load names of $(get_name(load)), consider formatting names with `load_name_formatter` kwarg",
-                    ),
-                )
-            else
-                load = make_power_load(d, bus, sys_mbase; kwargs...)
-                has_component(PowerLoad, sys, get_name(load)) && throw(
-                    DataFormatError(
-                        "Found duplicate load names of $(get_name(load)), consider formatting names with `load_name_formatter` kwarg",
-                    ),
-                )
-            end
+        if data["source_type"] == "pti"
+            load = make_standard_load(d, bus, sys_mbase; kwargs...)
+            has_component(StandardLoad, sys, get_name(load)) && throw(
+                DataFormatError(
+                    "Found duplicate load names of $(get_name(load)), consider formatting names with `load_name_formatter` kwarg",
+                ),
+            )
+        else
+            load = make_power_load(d, bus, sys_mbase; kwargs...)
+            has_component(PowerLoad, sys, get_name(load)) && throw(
+                DataFormatError(
+                    "Found duplicate load names of $(get_name(load)), consider formatting names with `load_name_formatter` kwarg",
+                ),
+            )
+        end
         add_component!(sys, load; skip_validation = SKIP_PM_VALIDATION)
     end
 end

--- a/test/test_parse_psse.jl
+++ b/test/test_parse_psse.jl
@@ -24,11 +24,12 @@ end
 @testset "PSSE Component Parsing" begin
     @info "Testing Load Parsing"
     sys = build_system(PSYTestSystems, "psse_240_parsing_sys") # current/imedance_power read in natural units during parsing
-    @test get_current_active_power(get_component(StandardLoad, sys, "load10021")) ==  223.71
-    @test get_impedance_reactive_power(get_component(StandardLoad, sys, "load10021")) ==  583.546
+    @test get_current_active_power(get_component(StandardLoad, sys, "load10021")) == 223.71
+    @test get_impedance_reactive_power(get_component(StandardLoad, sys, "load10021")) ==
+          583.546
     sys2 = build_system(PSYTestSystems, "psse_Benchmark_4ger_33_2015_sys")  # Constant_active/reactive_power read in pu during parsing
-    @test get_constant_active_power(get_component(StandardLoad, sys2,  "load71")) ==  9.67
-    @test get_constant_reactive_power(get_component(StandardLoad, sys2,  "load71")) ==  1.0
+    @test get_constant_active_power(get_component(StandardLoad, sys2, "load71")) == 9.67
+    @test get_constant_reactive_power(get_component(StandardLoad, sys2, "load71")) == 1.0
 
     @info "Testing Generator Parsing"
     @test get_status(get_component(ThermalStandard, sys, "generator-2438-ND")) == 0

--- a/test/test_parse_psse.jl
+++ b/test/test_parse_psse.jl
@@ -20,3 +20,19 @@
     pm_data.data["bus"] = Dict{String, Any}()
     @test_throws PowerSystems.DataFormatError System(pm_data)
 end
+
+@testset "PSSE Component Parsing" begin
+    @info "Testing Load Parsing"
+    sys = build_system(PSYTestSystems, "psse_240_parsing_sys") # current/imedance_power read in natural units during parsing
+    @test get_current_active_power(get_component(StandardLoad, sys, "load10021")) ==  223.71
+    @test get_impedance_reactive_power(get_component(StandardLoad, sys, "load10021")) ==  583.546
+    sys2 = build_system(PSYTestSystems, "psse_Benchmark_4ger_33_2015_sys")  # Constant_active/reactive_power read in pu during parsing
+    @test get_constant_active_power(get_component(StandardLoad, sys2,  "load71")) ==  9.67
+    @test get_constant_reactive_power(get_component(StandardLoad, sys2,  "load71")) ==  1.0
+
+    @info "Testing Generator Parsing"
+    @test get_status(get_component(ThermalStandard, sys, "generator-2438-ND")) == 0
+    @test get_available(get_component(ThermalStandard, sys, "generator-2438-ND")) == 0
+    @test get_status(get_component(ThermalStandard, sys, "generator-2438-EG")) == 1
+    @test get_available(get_component(ThermalStandard, sys, "generator-2438-EG")) == 1
+end


### PR DESCRIPTION
Removed if statement from the read_loads!() function that caused StandardLoads being read from .mat and .raw files to be dropped if the constant_active_power and constant_reactive_power arguments were 0. 

This is correcting issue #1032 