### PR TITLE
Resolve nameof vs strip_module_name

### DIFF
--- a/src/models/static_injection_subsystem.jl
+++ b/src/models/static_injection_subsystem.jl
@@ -51,5 +51,5 @@ function make_subsystem_time_series_name(subcomponent::Component, label::String)
 end
 
 function make_subsystem_time_series_name(subcomponent::Type{<:Component}, label::String)
-    return string(nameof(subcomponent)) * "__" * label
+    return IS.strip_module_name(subcomponent) * "__" * label
 end

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -79,7 +79,7 @@ function show_components_table(io::IO, sys::System; kwargs...)
     static_data = Array{Any, 2}(undef, length(static_types), length(static_header))
     dynamic_data = Array{Any, 2}(undef, length(dynamic_types), length(dynamic_header))
 
-    static_type_names = [(nameof(x), x) for x in static_types]
+    static_type_names = [(IS.strip_module_name(x), x) for x in static_types]
     sort!(static_type_names; by = x -> x[1])
     for (i, (type_name, type)) in enumerate(static_type_names)
         vals = components.data[type]
@@ -114,7 +114,7 @@ function show_components_table(io::IO, sys::System; kwargs...)
         )
     end
 
-    dynamic_type_names = [(nameof(x), x) for x in dynamic_types]
+    dynamic_type_names = [(IS.strip_module_name(x), x) for x in dynamic_types]
     sort!(dynamic_type_names; by = x -> x[1])
     for (i, (type_name, type)) in enumerate(dynamic_type_names)
         vals = components.data[type]
@@ -153,7 +153,7 @@ function Base.show(io::IO, ::MIME"text/plain", data::PowerSystemTableData)
 end
 
 function Base.show(io::IO, ist::Component)
-    print(io, string(nameof(typeof(ist))), "(")
+    print(io, IS.strip_module_name(typeof(ist)), "(")
     is_first = true
     for (name, field_type) in zip(fieldnames(typeof(ist)), fieldtypes(typeof(ist)))
         getter_name = Symbol("get_$name")


### PR DESCRIPTION
This is a follow-on to #1073. There were cases where we were using nameof (which removes parameteric types) where we should have used strip_module_name (which preserves parametric types). The best example is when printing a table of component counts. We were showing VariableReserve twice instead of showing both VariableReserve{ReserveDown} and VariableReserve{ReserveUp}.
