### PR TITLE
Fix component-is-attached-to-system check

### DIFF
--- a/test/test_dynamic_generator.jl
+++ b/test/test_dynamic_generator.jl
@@ -612,6 +612,7 @@ end
     bus = ACBus(nothing)
     add_component!(sys, bus)
     static_injector = ThermalStandard(nothing)
+    static_injector.bus = bus
     add_component!(sys, static_injector)
     add_component!(sys, derd, static_injector)
     DERDs = collect(get_components(GenericDER, sys))
@@ -714,6 +715,7 @@ end
     bus = ACBus(nothing)
     add_component!(sys, bus)
     static_injector = ThermalStandard(nothing)
+    static_injector.bus = bus
     add_component!(sys, static_injector)
     add_component!(sys, dera, static_injector)
     DERAs = collect(get_components(AggregateDistributedGenerationA, sys))

--- a/test/test_dynamic_loads.jl
+++ b/test/test_dynamic_loads.jl
@@ -32,6 +32,7 @@
     bus = ACBus(nothing)
     add_component!(sys, bus)
     static_load = PowerLoad(nothing)
+    static_load.bus = bus
     add_component!(sys, static_load)
     add_component!(sys, im, static_load)
     IMs = collect(get_components(SingleCageInductionMachine, sys))
@@ -69,6 +70,7 @@
     bus = ACBus(nothing)
     add_component!(sys, bus)
     static_load = PowerLoad(nothing)
+    static_load.bus = bus
     add_component!(sys, static_load)
     add_component!(sys, im, static_load)
     IMs = collect(get_components(SimplifiedSingleCageInductionMachine, sys))
@@ -100,6 +102,7 @@ end
     bus = ACBus(nothing)
     add_component!(sys, bus)
     static_load = PowerLoad(nothing)
+    static_load.bus = bus
     add_component!(sys, static_load)
     add_component!(sys, al, static_load)
     ALs = collect(get_components(ActiveConstantPowerLoad, sys))
@@ -123,6 +126,7 @@ end
     bus = ACBus(nothing)
     add_component!(sys, bus)
     static_load = PowerLoad(nothing)
+    static_load.bus = bus
     add_component!(sys, static_load)
     add_component!(sys, al, static_load)
     ALs = collect(get_components(DynamicExponentialLoad, sys))

--- a/test/test_system.jl
+++ b/test/test_system.jl
@@ -524,3 +524,11 @@ end
     @test metadata["time_series_resolution_milliseconds"] == 3600000
     @test metadata["user_data"]["author"] == "test"
 end
+
+@testset "Test addition of service to the wrong system" begin
+    sys1 = PSB.build_system(PSITestSystems, "test_RTS_GMLC_sys")
+    sys2 = PSB.build_system(PSITestSystems, "test_RTS_GMLC_sys")
+    service1 = first(get_components(VariableReserve{ReserveDown}, sys1))
+    device2 = first(get_components(ThermalStandard, sys2))
+    @test_throws ArgumentError add_service!(device2, service1, sys2)
+end

--- a/test/test_validation.jl
+++ b/test/test_validation.jl
@@ -125,9 +125,9 @@ end
     )
 
     #test custom range (active_power and active_power_limits)
+    nodes = nodes5()
     bad_therm_gen_act_power = thermal_generators5(nodes)
     bad_therm_gen_act_power[1].active_power = 10
-    nodes = nodes5()
     # This is an explicit check for one error message.
     @test_logs (:warn, r"Invalid range") System(
         100.0,


### PR DESCRIPTION
Fixes #1016. The check for whether a component is attached to a system was inadequate. It checked whether a component of the given type and name was attached to the system. If you built two systems with the same components and names, that check would incorrectly pass. This PR fixes that bug.

There were numerous tests that only passed because of this same-type-and-name comparison. This PR also fixes those tests.
