### PR TITLE
More Miscellaneous Costs Cleanup

### DIFF
--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -561,7 +561,6 @@ import InfrastructureSystems:
     get_points,  # TODO possible rename to disambiguate from geographical information
     get_x_coords,
     get_y_coords,
-    get_raw_data,
     get_raw_data_type
 
 const IS = InfrastructureSystems

--- a/src/models/cost_functions/HydroGenerationCost.jl
+++ b/src/models/cost_functions/HydroGenerationCost.jl
@@ -1,6 +1,6 @@
 """
     mutable struct HydroGenerationCost <: OperationalCost
-        variable::FuelCurve
+        variable::ProductionVariableCost
         fixed::Float64
     end
 
@@ -10,8 +10,10 @@ values are used or the opportunity cost of water if the costs are positive. It a
 fuel curves to model specific water intake.
 
 # Arguments
-- `variable::FuelCurve`: Production variable cost represented by a fuel curve, where the fuel is water.
-- `fixed::Union{Nothing, Float64}`: Fixed cost of keeping the unit online. For some cost represenations this field can be duplicative.
+- `variable::ProductionVariableCost`: Production variable cost represented by a `FuelCurve`,
+  where the fuel is water, or a `CostCurve` in currency.
+- `fixed::Union{Nothing, Float64}`: Fixed cost of keeping the unit online. For some cost
+  represenations this field can be duplicative.
 """
 @kwdef mutable struct HydroGenerationCost <: OperationalCost
     "variable cost"
@@ -21,7 +23,7 @@ fuel curves to model specific water intake.
 end
 
 # Constructor for demo purposes; non-functional.
-HydroGenerationCost(::Nothing) = HydroGenerationCost(zero(FuelCurve), 0.0)
+HydroGenerationCost(::Nothing) = HydroGenerationCost(zero(CostCurve), 0.0)
 
 """Get [`HydroGenerationCost`](@ref) `variable`."""
 get_variable(value::HydroGenerationCost) = value.variable

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -320,7 +320,7 @@ end
 
 function make_hydro_gen(gen_name, d, bus, sys_mbase)
     ramp_agc = get(d, "ramp_agc", get(d, "ramp_10", get(d, "ramp_30", abs(d["pmax"]))))
-    curtailcost = HydroGenerationCost(zero(FuelCurve), 0.0)
+    curtailcost = HydroGenerationCost(zero(CostCurve), 0.0)
 
     base_conversion = sys_mbase / d["mbase"]
     return HydroDispatch(; # No way to define storage parameters for gens in PM so can only make HydroDispatch


### PR DESCRIPTION
Miscellaneous cleanup:

1. Remove the import from IS of `get_raw_data` as it no longer exists
2. Make the hydro cost struct default constructor use a `CostCurve` as it is simpler to deal with
