### PR TITLE
Fuel Cost Interface, Including Time Series

### DIFF
--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -60,7 +60,8 @@ export PiecewisePointCurve, PiecewiseIncrementalCurve, PiecewiseAverageCurve
 export ProductionVariableCost, CostCurve, FuelCurve
 export OperationalCost, MarketBidCost, LoadCost, StorageCost
 export HydroGenerationCost, RenewableGenerationCost, ThermalGenerationCost
-export get_function_data, get_initial_input, get_value_curve, get_power_units, get_fuel_cost
+export get_function_data, get_initial_input, get_value_curve, get_power_units
+export get_fuel_cost, set_fuel_cost!
 
 export Generator
 export HydroGen

--- a/src/models/cost_function_timeseries.jl
+++ b/src/models/cost_function_timeseries.jl
@@ -158,6 +158,50 @@ function set_variable_cost!(
     return
 end
 
+function _process_fuel_cost(::Component, fuel_cost::Float64, start_time, len)
+    isnothing(start_time) && isnothing(len) && return fuel_cost
+    throw(ArgumentError("Got time series start_time and/or len, but fuel cost is a scalar"))
+end
+
+function _process_fuel_cost(component::Component, ts_key::TimeSeriesKey, start_time, len)
+    ts = get_time_series(component, ts_key, start_time, len)
+    return get_time_series_array(component, ts, start_time; len = len)
+end
+
+"Get the fuel cost of the component's variable cost, which must be a `FuelCurve`."
+function get_fuel_cost(component::StaticInjection;
+    start_time::Union{Nothing, Dates.DateTime} = nothing,
+    len::Union{Nothing, Int} = nothing)
+    op_cost = get_operation_cost(component)
+    var_cost = get_variable(op_cost)
+    !(var_cost isa FuelCurve) && throw(ArgumentError("Variable cost of type $(typeof(var_cost)) cannot represent a fuel cost, use FuelCurve instead"))
+    return _process_fuel_cost(component, get_fuel_cost(var_cost), start_time, len)
+end
+
+function _set_fuel_cost!(component::StaticInjection, fuel_cost)
+    op_cost = get_operation_cost(component)
+    var_cost = get_variable(op_cost)
+    !(var_cost isa FuelCurve) && throw(ArgumentError("Variable cost of type $(typeof(var_cost)) cannot represent a fuel cost, use FuelCurve instead"))
+    new_var_cost = FuelCurve(get_value_curve(var_cost), get_power_units(var_cost), fuel_cost)
+    set_variable!(op_cost, new_var_cost)
+end
+
+"Set the fuel cost of the component's variable cost, which must be a `FuelCurve`, to a scalar value."
+set_fuel_cost!(_::System, component::StaticInjection, fuel_cost::Real) =
+    # the System is not required, but we take it for consistency with the time series method of this function
+    _set_fuel_cost!(component, Float64(fuel_cost))
+
+"Set the fuel cost of the component's variable cost, which must be a `FuelCurve`, to a time series value."
+function set_fuel_cost!(
+    sys::System,
+    component::StaticInjection,
+    time_series_data::IS.TimeSeriesData,
+)
+    _validate_time_series_variable_cost(time_series_data; desired_type = Float64)
+    key = add_time_series!(sys, component, time_series_data)
+    _set_fuel_cost!(component, key)
+end
+
 """
 Adds energy market bids time-series to the ReserveDemandCurve.
 

--- a/src/models/cost_function_timeseries.jl
+++ b/src/models/cost_function_timeseries.jl
@@ -174,21 +174,30 @@ function get_fuel_cost(component::StaticInjection;
     len::Union{Nothing, Int} = nothing)
     op_cost = get_operation_cost(component)
     var_cost = get_variable(op_cost)
-    !(var_cost isa FuelCurve) && throw(ArgumentError("Variable cost of type $(typeof(var_cost)) cannot represent a fuel cost, use FuelCurve instead"))
+    !(var_cost isa FuelCurve) && throw(
+        ArgumentError(
+            "Variable cost of type $(typeof(var_cost)) cannot represent a fuel cost, use FuelCurve instead",
+        ),
+    )
     return _process_fuel_cost(component, get_fuel_cost(var_cost), start_time, len)
 end
 
 function _set_fuel_cost!(component::StaticInjection, fuel_cost)
     op_cost = get_operation_cost(component)
     var_cost = get_variable(op_cost)
-    !(var_cost isa FuelCurve) && throw(ArgumentError("Variable cost of type $(typeof(var_cost)) cannot represent a fuel cost, use FuelCurve instead"))
-    new_var_cost = FuelCurve(get_value_curve(var_cost), get_power_units(var_cost), fuel_cost)
+    !(var_cost isa FuelCurve) && throw(
+        ArgumentError(
+            "Variable cost of type $(typeof(var_cost)) cannot represent a fuel cost, use FuelCurve instead",
+        ),
+    )
+    new_var_cost =
+        FuelCurve(get_value_curve(var_cost), get_power_units(var_cost), fuel_cost)
     set_variable!(op_cost, new_var_cost)
 end
 
 "Set the fuel cost of the component's variable cost, which must be a `FuelCurve`, to a scalar value."
 set_fuel_cost!(_::System, component::StaticInjection, fuel_cost::Real) =
-    # the System is not required, but we take it for consistency with the time series method of this function
+# the System is not required, but we take it for consistency with the time series method of this function
     _set_fuel_cost!(component, Float64(fuel_cost))
 
 "Set the fuel cost of the component's variable cost, which must be a `FuelCurve`, to a time series value."

--- a/src/models/cost_function_timeseries.jl
+++ b/src/models/cost_function_timeseries.jl
@@ -158,13 +158,16 @@ function set_variable_cost!(
     return
 end
 
-function _process_fuel_cost(::Component, fuel_cost::Float64, start_time, len)
+function _process_fuel_cost(::Component, fuel_cost::Float64, start_time::Union{Nothing, Dates.DateTime}, len::Union{Nothing, Int})
     isnothing(start_time) && isnothing(len) && return fuel_cost
     throw(ArgumentError("Got time series start_time and/or len, but fuel cost is a scalar"))
 end
 
-function _process_fuel_cost(component::Component, ts_key::TimeSeriesKey, start_time, len)
+function _process_fuel_cost(component::Component, ts_key::TimeSeriesKey, start_time::Union{Nothing, Dates.DateTime}, len::Union{Nothing, Int})
     ts = get_time_series(component, ts_key, start_time, len)
+    if start_time === nothing
+        start_time = IS.get_initial_timestamp(ts)
+    end
     return get_time_series_array(component, ts, start_time; len = len)
 end
 

--- a/src/models/cost_function_timeseries.jl
+++ b/src/models/cost_function_timeseries.jl
@@ -158,12 +158,22 @@ function set_variable_cost!(
     return
 end
 
-function _process_fuel_cost(::Component, fuel_cost::Float64, start_time::Union{Nothing, Dates.DateTime}, len::Union{Nothing, Int})
+function _process_fuel_cost(
+    ::Component,
+    fuel_cost::Float64,
+    start_time::Union{Nothing, Dates.DateTime},
+    len::Union{Nothing, Int},
+)
     isnothing(start_time) && isnothing(len) && return fuel_cost
     throw(ArgumentError("Got time series start_time and/or len, but fuel cost is a scalar"))
 end
 
-function _process_fuel_cost(component::Component, ts_key::TimeSeriesKey, start_time::Union{Nothing, Dates.DateTime}, len::Union{Nothing, Int})
+function _process_fuel_cost(
+    component::Component,
+    ts_key::TimeSeriesKey,
+    start_time::Union{Nothing, Dates.DateTime},
+    len::Union{Nothing, Int},
+)
     ts = get_time_series(component, ts_key, start_time, len)
     if start_time === nothing
         start_time = IS.get_initial_timestamp(ts)

--- a/src/models/cost_functions/variable_cost.jl
+++ b/src/models/cost_functions/variable_cost.jl
@@ -47,8 +47,8 @@ The default units for the x-axis are megawatts and can be specified with `power_
     value_curve::T
     "The units for the x-axis of the curve; defaults to natural units (megawatts)"
     power_units::UnitSystem = UnitSystem.NATURAL_UNITS
-    "Either a fixed value for fuel cost or the name of a fuel cost time series name"
-    fuel_cost::Union{Float64, String}
+    "Either a fixed value for fuel cost or the name of a fuel cost time series"
+    fuel_cost::Union{Float64, TimeSeriesKey}
 end
 
 FuelCurve(value_curve::ValueCurve, power_units::UnitSystem, fuel_cost::Int) =

--- a/src/models/cost_functions/variable_cost.jl
+++ b/src/models/cost_functions/variable_cost.jl
@@ -47,7 +47,7 @@ The default units for the x-axis are megawatts and can be specified with `power_
     value_curve::T
     "The units for the x-axis of the curve; defaults to natural units (megawatts)"
     power_units::UnitSystem = UnitSystem.NATURAL_UNITS
-    "Either a fixed value for fuel cost or the name of a fuel cost time series"
+    "Either a fixed value for fuel cost or the key to a fuel cost time series"
     fuel_cost::Union{Float64, TimeSeriesKey}
 end
 

--- a/test/test_cost_functions.jl
+++ b/test/test_cost_functions.jl
@@ -168,7 +168,7 @@ test_costs = Dict(
     end
 end
 
-@testset "Test MarketBidCost with PiecewiseLinearData Cost Timeseries with Service Forecast" begin
+@testset "Test MarketBidCost with PiecewiseLinearData Cost Timeseries with Service Bid Forecast" begin
     initial_time = Dates.DateTime("2020-01-01")
     resolution = Dates.Hour(1)
     name = "test"

--- a/test/test_cost_functions.jl
+++ b/test/test_cost_functions.jl
@@ -219,25 +219,25 @@ end
 end
 
 @testset "Test fuel cost (scalar and time series)" begin
-      sys = PSB.build_system(PSITestSystems, "test_RTS_GMLC_sys")
-      generators = collect(get_components(ThermalStandard, sys))
-      generator = get_component(ThermalStandard, sys, "322_CT_6")
-      op_cost = get_operation_cost(generator)
-      value_curve = get_value_curve(get_variable(op_cost))
-      set_variable!(op_cost, FuelCurve(value_curve, 0.0))
+    sys = PSB.build_system(PSITestSystems, "test_RTS_GMLC_sys")
+    generators = collect(get_components(ThermalStandard, sys))
+    generator = get_component(ThermalStandard, sys, "322_CT_6")
+    op_cost = get_operation_cost(generator)
+    value_curve = get_value_curve(get_variable(op_cost))
+    set_variable!(op_cost, FuelCurve(value_curve, 0.0))
 
-      @test get_fuel_cost(generator) == 0.0
-      @test_throws ArgumentError get_fuel_cost(generator; len = 2)
+    @test get_fuel_cost(generator) == 0.0
+    @test_throws ArgumentError get_fuel_cost(generator; len = 2)
 
-      set_fuel_cost!(sys, generator, 1.23)
-      @test get_fuel_cost(generator) == 1.23
+    set_fuel_cost!(sys, generator, 1.23)
+    @test get_fuel_cost(generator) == 1.23
 
-      initial_time = Dates.DateTime("2020-01-01")
-      resolution = Dates.Hour(1)
-      horizon = 24
-      data_float = SortedDict(initial_time => test_costs[Float64])
-      forecast = IS.Deterministic("variable_cost", data_float, resolution)
-      set_fuel_cost!(sys, generator, forecast)
-      fuel_forecast = get_fuel_cost(generator; start_time = initial_time)
-      @test first(TimeSeries.values(fuel_forecast)) == first(data_float[initial_time])
+    initial_time = Dates.DateTime("2020-01-01")
+    resolution = Dates.Hour(1)
+    horizon = 24
+    data_float = SortedDict(initial_time => test_costs[Float64])
+    forecast = IS.Deterministic("variable_cost", data_float, resolution)
+    set_fuel_cost!(sys, generator, forecast)
+    fuel_forecast = get_fuel_cost(generator; start_time = initial_time)
+    @test first(TimeSeries.values(fuel_forecast)) == first(data_float[initial_time])
 end

--- a/test/test_cost_functions.jl
+++ b/test/test_cost_functions.jl
@@ -242,4 +242,6 @@ end
     set_fuel_cost!(sys, generator, forecast)
     fuel_forecast = get_fuel_cost(generator; start_time = initial_time)
     @test first(TimeSeries.values(fuel_forecast)) == first(data_float[initial_time])
+    fuel_forecast = get_fuel_cost(generator)  # missing start_time filled in with initial time
+    @test first(TimeSeries.values(fuel_forecast)) == first(data_float[initial_time])
 end

--- a/test/test_cost_functions.jl
+++ b/test/test_cost_functions.jl
@@ -222,10 +222,12 @@ end
     sys = PSB.build_system(PSITestSystems, "test_RTS_GMLC_sys")
     generators = collect(get_components(ThermalStandard, sys))
     generator = get_component(ThermalStandard, sys, "322_CT_6")
+
+    @test_throws ArgumentError get_fuel_cost(generator)  # Can't get the fuel cost of a CostCurve
+
     op_cost = get_operation_cost(generator)
     value_curve = get_value_curve(get_variable(op_cost))
     set_variable!(op_cost, FuelCurve(value_curve, 0.0))
-
     @test get_fuel_cost(generator) == 0.0
     @test_throws ArgumentError get_fuel_cost(generator; len = 2)
 


### PR DESCRIPTION
This PR implements an interface to get at the fuel cost fields within the new cost structs. I took inspiration from the existing variable cost time series interface for `MarketBidCost`. Depends on https://github.com/NREL-Sienna/PowerSystems.jl/pull/1100, that should be merged first.