### PR TITLE
Fix issue 1081, fix bug from PR 1112

### DIFF
--- a/src/models/cost_functions/operational_cost.jl
+++ b/src/models/cost_functions/operational_cost.jl
@@ -1,5 +1,6 @@
-""" Super type for operational cost representation in the model"""
+""" Supertype for operational cost representation in the model"""
 abstract type OperationalCost <: DeviceParameter end
 
 IS.serialize(val::OperationalCost) = IS.serialize_struct(val)
 IS.deserialize(T::Type{<:OperationalCost}, val::Dict) = IS.deserialize_struct(T, val)
+# NOTE MarketBidCost serialization is handled in serialization.jl

--- a/src/models/cost_functions/variable_cost.jl
+++ b/src/models/cost_functions/variable_cost.jl
@@ -39,7 +39,10 @@ data. The default units for the x-axis are megawatts and can be specified with
 end
 
 CostCurve(value_curve) = CostCurve(; value_curve)
-CostCurve(value_curve, vom_cost) = CostCurve(; value_curve, vom_cost)
+CostCurve(value_curve, vom_cost::Float64) =
+    CostCurve(; value_curve, vom_cost = vom_cost)
+CostCurve(value_curve, power_units::UnitSystem) =
+    CostCurve(; value_curve, power_units = power_units)
 
 Base.:(==)(a::CostCurve, b::CostCurve) =
     (get_value_curve(a) == get_value_curve(b)) &&
@@ -69,13 +72,16 @@ end
 FuelCurve(
     value_curve::ValueCurve,
     power_units::UnitSystem,
-    fuel_cost::Int,
+    fuel_cost::Real,
     vom_cost::Float64,
 ) =
     FuelCurve(value_curve, power_units, Float64(fuel_cost), vom_cost)
 
 FuelCurve(value_curve, fuel_cost) = FuelCurve(; value_curve, fuel_cost)
-FuelCurve(value_curve, fuel_cost, vom_cost) = FuelCurve(; value_curve, fuel_cost, vom_cost)
+FuelCurve(value_curve, fuel_cost::Union{Float64, TimeSeriesKey}, vom_cost::Float64) =
+    FuelCurve(; value_curve, fuel_cost, vom_cost = vom_cost)
+FuelCurve(value_curve, power_units::UnitSystem, fuel_cost::Union{Float64, TimeSeriesKey}) =
+    FuelCurve(; value_curve, power_units = power_units, fuel_cost = fuel_cost)
 
 Base.:(==)(a::FuelCurve, b::FuelCurve) =
     (get_value_curve(a) == get_value_curve(b)) &&

--- a/src/models/serialization.jl
+++ b/src/models/serialization.jl
@@ -15,7 +15,9 @@ const _ENCODE_AS_UUID_B =
 should_encode_as_uuid(val) = any(x -> val isa x, _ENCODE_AS_UUID_B)
 should_encode_as_uuid(::Type{T}) where {T} = any(x -> T <: x, _ENCODE_AS_UUID_A)
 
-function IS.serialize(component::T) where {T <: Component}
+const _CONTAINS_SHOULD_ENCODE = Union{Component, MarketBidCost}  # PSY types with fields that we should_encode_as_uuid
+
+function IS.serialize(component::T) where {T <: _CONTAINS_SHOULD_ENCODE}
     @debug "serialize" _group = IS.LOG_GROUP_SERIALIZATION component T
     data = Dict{String, Any}()
     for name in fieldnames(T)
@@ -60,7 +62,7 @@ function serialize_uuid_handling(val)
     return serialize(value)
 end
 
-function IS.deserialize(::Type{T}, data::Dict, component_cache::Dict) where {T <: Component}
+function IS.deserialize(::Type{T}, data::Dict, component_cache::Dict) where {T <: _CONTAINS_SHOULD_ENCODE}
     @debug "deserialize Component" _group = IS.LOG_GROUP_SERIALIZATION T data
     vals = Dict{Symbol, Any}()
     for (name, type) in zip(fieldnames(T), fieldtypes(T))
@@ -111,9 +113,9 @@ function deserialize_uuid_handling(field_type, val, component_cache)
             component = component_cache[uuid]
             value = component
         end
-    elseif field_type <: Component
+    elseif field_type <: _CONTAINS_SHOULD_ENCODE
         value = IS.deserialize(field_type, val, component_cache)
-    elseif field_type <: Union{Nothing, Component}
+    elseif field_type <: Union{Nothing, _CONTAINS_SHOULD_ENCODE}
         value = IS.deserialize(field_type.b, val, component_cache)
     elseif field_type <: InfrastructureSystemsType
         value = deserialize(field_type, val)

--- a/src/models/serialization.jl
+++ b/src/models/serialization.jl
@@ -62,7 +62,11 @@ function serialize_uuid_handling(val)
     return serialize(value)
 end
 
-function IS.deserialize(::Type{T}, data::Dict, component_cache::Dict) where {T <: _CONTAINS_SHOULD_ENCODE}
+function IS.deserialize(
+    ::Type{T},
+    data::Dict,
+    component_cache::Dict,
+) where {T <: _CONTAINS_SHOULD_ENCODE}
     @debug "deserialize Component" _group = IS.LOG_GROUP_SERIALIZATION T data
     vals = Dict{Symbol, Any}()
     for (name, type) in zip(fieldnames(T), fieldtypes(T))

--- a/test/test_serialization.jl
+++ b/test/test_serialization.jl
@@ -121,19 +121,24 @@ end
         time_series = IS.SingleTimeSeries(; name = "variable_cost", data = ta)
         set_variable_cost!(sys, gen, time_series)
         service = StaticReserve{ReserveDown}(;
-            name="init$i",
-            available=false,
-            time_frame=0.0,
-            requirement=0.0,
-            sustained_time=0.0,
-            max_output_fraction=1.0,
-            max_participation_factor=1.0,
-            deployed_fraction=0.0,
-            ext=Dict{String, Any}(),
+            name = "init_$i",
+            available = false,
+            time_frame = 0.0,
+            requirement = 0.0,
+            sustained_time = 0.0,
+            max_output_fraction = 1.0,
+            max_participation_factor = 1.0,
+            deployed_fraction = 0.0,
+            ext = Dict{String, Any}(),
         )
         add_component!(sys, service)
         add_service!(gen, service, sys)
-        set_service_bid!(sys, gen, service, IS.SingleTimeSeries(; name="init$i", data = ta))
+        set_service_bid!(
+            sys,
+            gen,
+            service,
+            IS.SingleTimeSeries(; name = "init_$i", data = ta),
+        )
     end
     _, result = validate_serialization(sys)
     @test result

--- a/test/test_serialization.jl
+++ b/test/test_serialization.jl
@@ -120,6 +120,20 @@ end
         ta = TimeSeries.TimeArray(dates, data)
         time_series = IS.SingleTimeSeries(; name = "variable_cost", data = ta)
         set_variable_cost!(sys, gen, time_series)
+        service = StaticReserve{ReserveDown}(;
+            name="init$i",
+            available=false,
+            time_frame=0.0,
+            requirement=0.0,
+            sustained_time=0.0,
+            max_output_fraction=1.0,
+            max_participation_factor=1.0,
+            deployed_fraction=0.0,
+            ext=Dict{String, Any}(),
+        )
+        add_component!(sys, service)
+        add_service!(gen, service, sys)
+        set_service_bid!(sys, gen, service, IS.SingleTimeSeries(; name="init$i", data = ta))
     end
     _, result = validate_serialization(sys)
     @test result


### PR DESCRIPTION
This small PR:

- Fixes https://github.com/NREL-Sienna/PowerSystems.jl/issues/1081 by using existing `Component` serialization code to ensure that the vector of `Service`s in `MarketBidCost` gets serialized as UUIDs, adds a test for serialization of `MarketBidCost` with `Service`s
- Fixes a variable cost constructor ambiguity introduced in https://github.com/NREL-Sienna/PowerSystems.jl/pull/1112 (@rodrigomha for visibility; can you verify that this solution works for you?)