### PR TITLE
Add Cost Alias Getters

### DIFF
--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -49,13 +49,15 @@ export get_proportional_term
 export get_quadratic_term
 export get_constant_term
 export get_slopes
+export get_average_rates
 export get_x_lengths
 export is_convex
 export get_points
 export get_x_coords
 export get_y_coords
 
-export ValueCurve, InputOutputCurve, IncrementalCurve, AverageRateCurve
+export ValueCurve
+export InputOutputCurve, IncrementalCurve, AverageRateCurve
 export LinearCurve, QuadraticCurve
 export PiecewisePointCurve, PiecewiseIncrementalCurve, PiecewiseAverageCurve
 export ProductionVariableCostCurve, CostCurve, FuelCurve

--- a/src/models/cost_functions/cost_aliases.jl
+++ b/src/models/cost_functions/cost_aliases.jl
@@ -31,11 +31,14 @@ InputOutputCurve{LinearFunctionData}(proportional_term::Real) =
 InputOutputCurve{LinearFunctionData}(proportional_term::Real, constant_term::Real) =
     InputOutputCurve(LinearFunctionData(proportional_term, constant_term))
 
-function Base.show(io::IO, data::LinearCurve)
-    fd = get_function_data(data)
-    p, c = get_proportional_term(fd), get_constant_term(fd)
-    print(io, "$(typeof(data))($p, $c)")
-end
+"Get the proportional term (i.e., slope) of the `LinearCurve`"
+get_proportional_term(vc::LinearCurve) = get_proportional_term(get_function_data(vc))
+
+"Get the constant term (i.e., intercept) of the `LinearCurve`"
+get_constant_term(vc::LinearCurve) = get_constant_term(get_function_data(vc))
+
+Base.show(io::IO, vc::LinearCurve) =
+    print(io, "$(typeof(vc))($(get_proportional_term(vc)), $(get_constant_term(vc)))")
 
 """
     QuadraticCurve(quadratic_term::Float64, proportional_term::Float64, constant_term::Float64)
@@ -56,11 +59,20 @@ InputOutputCurve{QuadraticFunctionData}(quadratic_term, proportional_term, const
         QuadraticFunctionData(quadratic_term, proportional_term, constant_term),
     )
 
-function Base.show(io::IO, data::QuadraticCurve)
-    fd = get_function_data(data)
-    q, p, c = get_quadratic_term(fd), get_proportional_term(fd), get_constant_term(fd)
-    print(io, "$(typeof(data))($q, $p, $c)")
-end
+"Get the quadratic term of the `QuadraticCurve`"
+get_quadratic_term(vc::QuadraticCurve) = get_quadratic_term(get_function_data(vc))
+
+"Get the proportional (i.e., linear) term of the `QuadraticCurve`"
+get_proportional_term(vc::QuadraticCurve) = get_proportional_term(get_function_data(vc))
+
+"Get the constant term of the `QuadraticCurve`"
+get_constant_term(vc::QuadraticCurve) = get_constant_term(get_function_data(vc))
+
+Base.show(io::IO, vc::QuadraticCurve) =
+    print(
+        io,
+        "$(typeof(vc))($(get_quadratic_term(vc)), $(get_proportional_term(vc)), $(get_constant_term(vc)))",
+    )
 
 """
     PiecewisePointCurve(points::Vector{Tuple{Float64, Float64}})
@@ -77,11 +89,21 @@ is_cost_alias(::Union{PiecewisePointCurve, Type{PiecewisePointCurve}}) = true
 InputOutputCurve{PiecewiseLinearData}(points::Vector) =
     InputOutputCurve(PiecewiseLinearData(points))
 
-get_points(curve::PiecewisePointCurve) = get_points(get_function_data(curve))
+"Get the points that define the `PiecewisePointCurve`"
+get_points(vc::PiecewisePointCurve) = get_points(get_function_data(vc))
 
-# Here we manually circumvent the @NamedTuple{x::Float64, y::Float64} annotation, but we keep things looking like named tuples
-Base.show(io::IO, data::PiecewisePointCurve) =
-    print(io, "$(typeof(data))([$(join(get_points(data), ", "))])")
+"Get the x-coordinates of the points that define the `PiecewisePointCurve`"
+get_x_coords(vc::PiecewisePointCurve) = get_x_coords(get_function_data(vc))
+
+"Get the y-coordinates of the points that define the `PiecewisePointCurve`"
+get_y_coords(vc::PiecewisePointCurve) = get_y_coords(get_function_data(vc))
+
+"Calculate the slopes of the line segments defined by the `PiecewisePointCurve`"
+get_slopes(vc::PiecewisePointCurve) = get_slopes(get_function_data(vc))
+
+# Here we manually circumvent the @NamedTuple{x::Float64, y::Float64} type annotation, but we keep things looking like named tuples
+Base.show(io::IO, vc::PiecewisePointCurve) =
+    print(io, "$(typeof(vc))([$(join(get_points(vc), ", "))])")
 
 """
     PiecewiseIncrementalCurve(initial_input::Float64, x_coords::Vector{Float64}, slopes::Vector{Float64})
@@ -102,15 +124,17 @@ is_cost_alias(::Union{PiecewiseIncrementalCurve, Type{PiecewiseIncrementalCurve}
 IncrementalCurve{PiecewiseStepData}(initial_input, x_coords::Vector, slopes::Vector) =
     IncrementalCurve(PiecewiseStepData(x_coords, slopes), initial_input)
 
-get_slopes(curve::PiecewiseIncrementalCurve) = get_y_coords(get_function_data(curve))
+"Get the x-coordinates that define the `PiecewiseIncrementalCurve`"
+get_x_coords(vc::PiecewiseIncrementalCurve) = get_x_coords(get_function_data(vc))
 
-function Base.show(io::IO, data::PiecewiseIncrementalCurve)
-    initial_input = get_initial_input(data)
-    fd = get_function_data(data)
-    x_coords = get_x_coords(fd)
-    slopes = get_slopes(data)
-    print(io, "$(typeof(data))($initial_input, $x_coords, $slopes)")
-end
+"Fetch the slopes that define the `PiecewiseIncrementalCurve`"
+get_slopes(vc::PiecewiseIncrementalCurve) = get_y_coords(get_function_data(vc))
+
+Base.show(io::IO, vc::PiecewiseIncrementalCurve) =
+    print(
+        io,
+        "$(typeof(vc))($(get_initial_input(vc)), $(get_x_coords(vc)), $(get_slopes(vc)))",
+    )
 
 """
     PiecewiseAverageCurve(initial_input::Float64, x_coords::Vector{Float64}, slopes::Vector{Float64})
@@ -131,12 +155,14 @@ is_cost_alias(::Union{PiecewiseAverageCurve, Type{PiecewiseAverageCurve}}) = tru
 AverageRateCurve{PiecewiseStepData}(initial_input, x_coords::Vector, y_coords::Vector) =
     AverageRateCurve(PiecewiseStepData(x_coords, y_coords), initial_input)
 
-function Base.show(io::IO, data::PiecewiseAverageCurve)
-    initial_input = get_initial_input(data)
-    fd = get_function_data(data)
-    x_coords = get_x_coords(fd)
-    y_coords = get_y_coords(fd)
-    print(io, "$(typeof(data))($initial_input, $x_coords, $y_coords)")
-end
+"Get the x-coordinates that define the `PiecewiseAverageCurve`"
+get_x_coords(vc::PiecewiseAverageCurve) = get_x_coords(get_function_data(vc))
 
-# TODO documentation, more getters
+"Get the average rates that define the `PiecewiseAverageCurve`"
+get_average_rates(vc::PiecewiseAverageCurve) = get_y_coords(get_function_data(vc))
+
+Base.show(io::IO, vc::PiecewiseAverageCurve) =
+    print(
+        io,
+        "$(typeof(vc))($(get_initial_input(vc)), $(get_x_coords(vc)), $(get_average_rates(vc)))",
+    )

--- a/src/models/cost_functions/variable_cost.jl
+++ b/src/models/cost_functions/variable_cost.jl
@@ -31,7 +31,7 @@ Base.hash(a::ProductionVariableCostCurve) = IS.hash_from_fields(a)
     @kwdef struct CostCurve{T <: ValueCurve} <: ProductionVariableCostCurve{T}
         value_curve::T
         power_units::UnitSystem = UnitSystem.NATURAL_UNITS
-        vom_cost::Float64 = 0.0
+        vom_cost::LinearCurve = LinearCurve(0.0)
     end
 
 Direct representation of the variable operation cost of a power plant in currency. Composed
@@ -44,8 +44,8 @@ data. The default units for the x-axis are megawatts and can be specified with
     `ProductionVariableCostCurve`
   - `power_units::UnitSystem = UnitSystem.NATURAL_UNITS`: The units for the x-axis of the
     curve; defaults to natural units (megawatts)
-  - `vom_cost::Float64 = 0.0`: Additional proportional Variable Operation and Maintenance
-    cost in currency/(power_unit h)
+  - `vom_cost::LinearCurve = LinearCurve(0.0)`: Additional proportional Variable Operation
+    and Maintenance cost in currency/(power_unit h)
 """
 @kwdef struct CostCurve{T <: ValueCurve} <: ProductionVariableCostCurve{T}
     "The underlying `ValueCurve` representation of this `ProductionVariableCostCurve`"
@@ -75,7 +75,7 @@ Base.zero(::Union{CostCurve, Type{CostCurve}}) = CostCurve(zero(ValueCurve))
         value_curve::T
         power_units::UnitSystem = UnitSystem.NATURAL_UNITS
         fuel_cost::Union{Float64, TimeSeriesKey}
-        vom_cost::Float64 = 0.0
+        vom_cost::LinearCurve = LinearCurve(0.0)
     end
 
 Representation of the variable operation cost of a power plant in terms of fuel (MBTU,
@@ -90,8 +90,8 @@ The default units for the x-axis are megawatts and can be specified with `power_
     curve; defaults to natural units (megawatts)
   - `fuel_cost::Union{Float64, TimeSeriesKey}`: Either a fixed value for fuel cost or the
     key to a fuel cost time series
-  - `vom_cost::Float64 = 0.0`: Additional proportional Variable Operation and Maintenance
-    cost in currency/(power_unit h)
+  - `vom_cost::LinearCurve = LinearCurve(0.0)`: Additional proportional Variable Operation
+    and Maintenance cost in currency/(power_unit h)
 """
 @kwdef struct FuelCurve{T <: ValueCurve} <: ProductionVariableCostCurve{T}
     "The underlying `ValueCurve` representation of this `ProductionVariableCostCurve`"

--- a/test/test_cost_functions.jl
+++ b/test/test_cost_functions.jl
@@ -163,19 +163,19 @@ end
           FuelCurve(InputOutputCurve(PSY.LinearFunctionData(0.0, 0.0)), 0.0)
 
     @test repr(cc) == sprint(show, cc) ==
-          "CostCurve{QuadraticCurve}(QuadraticCurve(1.0, 2.0, 3.0), UnitSystem.NATURAL_UNITS = 2, 0.0)"
+          "CostCurve{QuadraticCurve}(QuadraticCurve(1.0, 2.0, 3.0), UnitSystem.NATURAL_UNITS = 2, LinearCurve(0.0, 0.0))"
     @test repr(fc) == sprint(show, fc) ==
-          "FuelCurve{QuadraticCurve}(QuadraticCurve(1.0, 2.0, 3.0), UnitSystem.NATURAL_UNITS = 2, 4.0, 0.0)"
+          "FuelCurve{QuadraticCurve}(QuadraticCurve(1.0, 2.0, 3.0), UnitSystem.NATURAL_UNITS = 2, 4.0, LinearCurve(0.0, 0.0))"
     @test sprint(show, "text/plain", cc) ==
           sprint(show, "text/plain", cc; context = :compact => false) ==
-          "CostCurve:\n  value_curve: QuadraticCurve (a type of InputOutputCurve) with function: f(x) = 1.0 x^2 + 2.0 x + 3.0\n  power_units: UnitSystem.NATURAL_UNITS = 2\n  vom_cost: 0.0"
+          "CostCurve:\n  value_curve: QuadraticCurve (a type of InputOutputCurve) with function: f(x) = 1.0 x^2 + 2.0 x + 3.0\n  power_units: UnitSystem.NATURAL_UNITS = 2\n  vom_cost: LinearCurve (a type of InputOutputCurve) with function: f(x) = 0.0 x + 0.0"
     @test sprint(show, "text/plain", fc) ==
           sprint(show, "text/plain", fc; context = :compact => false) ==
-          "FuelCurve:\n  value_curve: QuadraticCurve (a type of InputOutputCurve) with function: f(x) = 1.0 x^2 + 2.0 x + 3.0\n  power_units: UnitSystem.NATURAL_UNITS = 2\n  fuel_cost: 4.0\n  vom_cost: 0.0"
+          "FuelCurve:\n  value_curve: QuadraticCurve (a type of InputOutputCurve) with function: f(x) = 1.0 x^2 + 2.0 x + 3.0\n  power_units: UnitSystem.NATURAL_UNITS = 2\n  fuel_cost: 4.0\n  vom_cost: LinearCurve (a type of InputOutputCurve) with function: f(x) = 0.0 x + 0.0"
     @test sprint(show, "text/plain", cc; context = :compact => true) ==
-          "CostCurve with power_units UnitSystem.NATURAL_UNITS = 2, vom_cost 0.0, and value_curve:\n  QuadraticCurve (a type of InputOutputCurve) with function: f(x) = 1.0 x^2 + 2.0 x + 3.0"
+          "CostCurve with power_units UnitSystem.NATURAL_UNITS = 2, vom_cost LinearCurve(0.0, 0.0), and value_curve:\n  QuadraticCurve (a type of InputOutputCurve) with function: f(x) = 1.0 x^2 + 2.0 x + 3.0"
     @test sprint(show, "text/plain", fc; context = :compact => true) ==
-          "FuelCurve with power_units UnitSystem.NATURAL_UNITS = 2, fuel_cost 4.0, vom_cost 0.0, and value_curve:\n  QuadraticCurve (a type of InputOutputCurve) with function: f(x) = 1.0 x^2 + 2.0 x + 3.0"
+          "FuelCurve with power_units UnitSystem.NATURAL_UNITS = 2, fuel_cost 4.0, vom_cost LinearCurve(0.0, 0.0), and value_curve:\n  QuadraticCurve (a type of InputOutputCurve) with function: f(x) = 1.0 x^2 + 2.0 x + 3.0"
 
     @test get_power_units(cc) == UnitSystem.NATURAL_UNITS
     @test get_power_units(fc) == UnitSystem.NATURAL_UNITS

--- a/test/test_cost_functions.jl
+++ b/test/test_cost_functions.jl
@@ -129,16 +129,35 @@
 end
 
 @testset "Test cost aliases" begin
+    lc = LinearCurve(3.0, 5.0)
+    @test lc == InputOutputCurve(LinearFunctionData(3.0, 5.0))
     @test LinearCurve(3.0) == InputOutputCurve(LinearFunctionData(3.0, 0.0))
-    @test LinearCurve(3.0, 5.0) == InputOutputCurve(LinearFunctionData(3.0, 5.0))
-    @test QuadraticCurve(1.0, 1.0, 18.0) ==
-          InputOutputCurve(QuadraticFunctionData(1.0, 1.0, 18.0))
-    @test PiecewisePointCurve([(1.0, 20.0), (2.0, 24.0), (3.0, 30.0)]) ==
+    @test get_proportional_term(lc) == 3.0
+    @test get_constant_term(lc) == 5.0
+
+    qc = QuadraticCurve(1.0, 2.0, 18.0)
+    @test qc == InputOutputCurve(QuadraticFunctionData(1.0, 2.0, 18.0))
+    @test get_quadratic_term(qc) == 1.0
+    @test get_proportional_term(qc) == 2.0
+    @test get_constant_term(qc) == 18.0
+
+    ppc = PiecewisePointCurve([(1.0, 20.0), (2.0, 24.0), (3.0, 30.0)])
+    @test ppc ==
           InputOutputCurve(PiecewiseLinearData([(1.0, 20.0), (2.0, 24.0), (3.0, 30.0)]))
-    @test PiecewiseIncrementalCurve(20.0, [1.0, 2.0, 3.0], [4.0, 6.0]) ==
-          IncrementalCurve(PiecewiseStepData([1.0, 2.0, 3.0], [4.0, 6.0]), 20.0)
-    @test PiecewiseAverageCurve(20.0, [1.0, 2.0, 3.0], [12.0, 10.0]) ==
-          AverageRateCurve(PiecewiseStepData([1.0, 2.0, 3.0], [12.0, 10.0]), 20.0)
+    @test get_points(ppc) == [(x = 1.0, y = 20.0), (x = 2.0, y = 24.0), (x = 3.0, y = 30.0)]
+    @test get_x_coords(ppc) == [1.0, 2.0, 3.0]
+    @test get_y_coords(ppc) == [20.0, 24.0, 30.0]
+    @test get_slopes(ppc) == [4.0, 6.0]
+
+    pic = PiecewiseIncrementalCurve(20.0, [1.0, 2.0, 3.0], [4.0, 6.0])
+    @test pic == IncrementalCurve(PiecewiseStepData([1.0, 2.0, 3.0], [4.0, 6.0]), 20.0)
+    @test get_x_coords(pic) == [1.0, 2.0, 3.0]
+    @test get_slopes(pic) == [4.0, 6.0]
+
+    pac = PiecewiseAverageCurve(20.0, [1.0, 2.0, 3.0], [12.0, 10.0])
+    @test pac == AverageRateCurve(PiecewiseStepData([1.0, 2.0, 3.0], [12.0, 10.0]), 20.0)
+    @test get_x_coords(pac) == [1.0, 2.0, 3.0]
+    @test get_average_rates(pac) == [12.0, 10.0]
 end
 
 @testset "Test CostCurve and FuelCurve" begin


### PR DESCRIPTION
The main goal here, discussed with @rodrigomha, is to allow a user of the `ValueCurve` cost aliases to get everything they need without unwrapping to the `FunctionData`. I also cleaned up some docs and tests that were outdated due to a VOM cost refactor. I didn't fix this failure, which I assume is due to changes elsewhere:

<img width="1021" alt="Screenshot 2024-06-21 at 11 35 57 AM" src="https://github.com/NREL-Sienna/PowerSystems.jl/assets/23368820/c4bf0ec4-d455-489c-af98-51e17a6aea1f">

---
Adding @kdayday as a reviewer of these added semantics:

- `get_slopes(::PiecewisePointwiseCurve)`  _calculates_ the slopes from the underlying pointwise `FunctionData`
- `get_slopes(::PiecewiseIncrementalCurve)` _fetches_ the slopes == the y-coordinates of the underlying step `FunctionData`
- `get_average_rates(::PiecewiseAverageCurve)` _fetches_ the average rates == the y-coordinates of the underlying step `FunctionData`