### PR TITLE
Add `input_at_zero` to cost functions

### DIFF
--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -63,7 +63,8 @@ export PiecewisePointCurve, PiecewiseIncrementalCurve, PiecewiseAverageCurve
 export ProductionVariableCostCurve, CostCurve, FuelCurve
 export OperationalCost, MarketBidCost, LoadCost, StorageCost
 export HydroGenerationCost, RenewableGenerationCost, ThermalGenerationCost
-export get_function_data, get_initial_input, get_value_curve, get_power_units
+export get_function_data, get_initial_input, get_input_at_zero
+export get_value_curve, get_power_units
 export get_fuel_cost, set_fuel_cost!, get_vom_cost
 export is_market_bid_curve, make_market_bid_curve
 export get_no_load_cost, set_no_load_cost!, get_start_up, set_start_up!

--- a/src/models/cost_functions/ValueCurves.jl
+++ b/src/models/cost_functions/ValueCurves.jl
@@ -23,7 +23,12 @@ and `y` is fuel/hr.
 } <: ValueCurve{T}
     "The underlying `FunctionData` representation of this `ValueCurve`"
     function_data::T
+    "Optional, an explicit representation of the input value at zero output."
+    input_at_zero::Union{Nothing, Float64} = nothing
 end
+
+InputOutputCurve(function_data) = InputOutputCurve(function_data, nothing)
+InputOutputCurve{T}(function_data) where (T <: Union{QuadraticFunctionData, LinearFunctionData, PiecewiseLinearData}) = InputOutputCurve{T}(function_data, nothing)
 
 """
 An incremental (or 'marginal') curve, relating the production quantity to the derivative of
@@ -37,7 +42,12 @@ where `x` is MW and `y` is fuel/MWh.
     function_data::T
     "The value of f(x) at the least x for which the function is defined, or the origin for functions with no left endpoint, used for conversion to `InputOutputCurve`"
     initial_input::Float64
+    "Optional, an explicit representation of the input value at zero output."
+    input_at_zero::Union{Nothing, Float64} = nothing
 end
+
+IncrementalCurve(function_data, initial_input) = IncrementalCurve(function_data, initial_input, nothing)
+IncrementalCurve{T}(function_data, initial_input) where (T <: Union{QuadraticFunctionData, LinearFunctionData, PiecewiseLinearData}) = IncrementalCurve{T}(function_data, initial_input, nothing)
 
 """
 An average rate curve, relating the production quantity to the average cost rate from the
@@ -52,7 +62,12 @@ absolute values of cost rate or fuel input rate by absolute values of electric p
     function_data::T
     "The value of f(x) at the least x for which the function is defined, or the origin for functions with no left endpoint, used for conversion to `InputOutputCurve`"
     initial_input::Float64
+    "Optional, an explicit representation of the input value at zero output."
+    input_at_zero::Union{Nothing, Float64} = nothing
 end
+
+AverageRateCurve(function_data, initial_input) = AverageRateCurve(function_data, initial_input, nothing)
+AverageRateCurve{T}(function_data, initial_input) where (T <: Union{QuadraticFunctionData, LinearFunctionData, PiecewiseLinearData}) = AverageRateCurve{T}(function_data, initial_input, nothing)
 
 "Get the `initial_input` field of this `ValueCurve` (not defined for `InputOutputCurve`)"
 get_initial_input(curve::Union{IncrementalCurve, AverageRateCurve}) = curve.initial_input

--- a/src/models/cost_functions/ValueCurves.jl
+++ b/src/models/cost_functions/ValueCurves.jl
@@ -12,6 +12,9 @@ IS.deserialize(T::Type{<:ValueCurve}, val::Dict) = IS.deserialize_struct(T, val)
 "Get the underlying `FunctionData` representation of this `ValueCurve`"
 get_function_data(curve::ValueCurve) = curve.function_data
 
+"Get the `input_at_zero` field of this `ValueCurve`"
+get_input_at_zero(curve::ValueCurve) = curve.input_at_zero
+
 """
 An input-output curve, directly relating the production quantity to the cost: `y = f(x)`.
 Can be used, for instance, in the representation of a [`CostCurve`](@ref) where `x` is MW
@@ -28,7 +31,10 @@ and `y` is fuel/hr.
 end
 
 InputOutputCurve(function_data) = InputOutputCurve(function_data, nothing)
-InputOutputCurve{T}(function_data) where (T <: Union{QuadraticFunctionData, LinearFunctionData, PiecewiseLinearData}) = InputOutputCurve{T}(function_data, nothing)
+InputOutputCurve{T}(
+    function_data,
+) where {(T <: Union{QuadraticFunctionData, LinearFunctionData, PiecewiseLinearData})} =
+    InputOutputCurve{T}(function_data, nothing)
 
 """
 An incremental (or 'marginal') curve, relating the production quantity to the derivative of
@@ -46,8 +52,13 @@ where `x` is MW and `y` is fuel/MWh.
     input_at_zero::Union{Nothing, Float64} = nothing
 end
 
-IncrementalCurve(function_data, initial_input) = IncrementalCurve(function_data, initial_input, nothing)
-IncrementalCurve{T}(function_data, initial_input) where (T <: Union{QuadraticFunctionData, LinearFunctionData, PiecewiseLinearData}) = IncrementalCurve{T}(function_data, initial_input, nothing)
+IncrementalCurve(function_data, initial_input) =
+    IncrementalCurve(function_data, initial_input, nothing)
+IncrementalCurve{T}(
+    function_data,
+    initial_input,
+) where {(T <: Union{QuadraticFunctionData, LinearFunctionData, PiecewiseLinearData})} =
+    IncrementalCurve{T}(function_data, initial_input, nothing)
 
 """
 An average rate curve, relating the production quantity to the average cost rate from the
@@ -66,8 +77,13 @@ absolute values of cost rate or fuel input rate by absolute values of electric p
     input_at_zero::Union{Nothing, Float64} = nothing
 end
 
-AverageRateCurve(function_data, initial_input) = AverageRateCurve(function_data, initial_input, nothing)
-AverageRateCurve{T}(function_data, initial_input) where (T <: Union{QuadraticFunctionData, LinearFunctionData, PiecewiseLinearData}) = AverageRateCurve{T}(function_data, initial_input, nothing)
+AverageRateCurve(function_data, initial_input) =
+    AverageRateCurve(function_data, initial_input, nothing)
+AverageRateCurve{T}(
+    function_data,
+    initial_input,
+) where {(T <: Union{QuadraticFunctionData, LinearFunctionData, PiecewiseLinearData})} =
+    AverageRateCurve{T}(function_data, initial_input, nothing)
 
 "Get the `initial_input` field of this `ValueCurve` (not defined for `InputOutputCurve`)"
 get_initial_input(curve::Union{IncrementalCurve, AverageRateCurve}) = curve.initial_input
@@ -197,20 +213,29 @@ simple_type_name(curve::ValueCurve) =
 function Base.show(io::IO, ::MIME"text/plain", curve::InputOutputCurve)
     print(io, simple_type_name(curve))
     is_cost_alias(curve) && print(io, " (a type of $InputOutputCurve)")
-    print(io, " with function: ")
+    print(io, " where ")
+    !isnothing(get_input_at_zero(curve)) &&
+        print(io, "value at zero is $(get_input_at_zero(curve)), ")
+    print(io, "function is: ")
     show(IOContext(io, :compact => true), "text/plain", get_function_data(curve))
 end
 
 function Base.show(io::IO, ::MIME"text/plain", curve::IncrementalCurve)
     print(io, simple_type_name(curve))
-    print(io, " where initial value is $(get_initial_input(curve))")
-    print(io, " and derivative function f is: ")
+    print(io, " where ")
+    !isnothing(get_input_at_zero(curve)) &&
+        print(io, "value at zero is $(get_input_at_zero(curve)), ")
+    print(io, "initial value is $(get_initial_input(curve))")
+    print(io, ", derivative function f is: ")
     show(IOContext(io, :compact => true), "text/plain", get_function_data(curve))
 end
 
 function Base.show(io::IO, ::MIME"text/plain", curve::AverageRateCurve)
     print(io, simple_type_name(curve))
-    print(io, " where initial value is $(get_initial_input(curve))")
-    print(io, " and average rate function f is: ")
+    print(io, " where ")
+    !isnothing(get_input_at_zero(curve)) &&
+        print(io, "value at zero is $(get_input_at_zero(curve)), ")
+    print(io, "initial value is $(get_initial_input(curve))")
+    print(io, ", average rate function f is: ")
     show(IOContext(io, :compact => true), "text/plain", get_function_data(curve))
 end

--- a/src/models/cost_functions/ValueCurves.jl
+++ b/src/models/cost_functions/ValueCurves.jl
@@ -265,3 +265,23 @@ function Base.show(io::IO, ::MIME"text/plain", curve::AverageRateCurve)
     print(io, ", average rate function f is: ")
     show(IOContext(io, :compact => true), "text/plain", get_function_data(curve))
 end
+
+# MORE GENERIC CONSTRUCTORS
+# These manually do what https://github.com/JuliaLang/julia/issues/35053 (open at time of writing) proposes to automatically provide
+InputOutputCurve(
+    function_data::T,
+    input_at_zero,
+) where {T <: Union{LinearFunctionData, QuadraticFunctionData, PiecewiseLinearData}} =
+    InputOutputCurve{T}(function_data, input_at_zero)
+IncrementalCurve(
+    function_data::T,
+    initial_input,
+    input_at_zero,
+) where {T <: Union{LinearFunctionData, PiecewiseStepData}} =
+    IncrementalCurve{T}(function_data, initial_input, input_at_zero)
+AverageRateCurve(
+    function_data::T,
+    initial_input,
+    input_at_zero,
+) where {T <: Union{LinearFunctionData, PiecewiseStepData}} =
+    AverageRateCurve{T}(function_data, initial_input, input_at_zero)

--- a/src/models/cost_functions/cost_aliases.jl
+++ b/src/models/cost_functions/cost_aliases.jl
@@ -12,6 +12,7 @@
 is_cost_alias(::Union{ValueCurve, Type{<:ValueCurve}}) = false
 
 """
+    LinearCurve(proportional_term::Float64)
     LinearCurve(proportional_term::Float64, constant_term::Float64)
 
 A linear input-output curve, representing a constant marginal rate. May have zero no-load
@@ -119,13 +120,14 @@ Base.show(io::IO, vc::PiecewisePointCurve) =
 
 """
     PiecewiseIncrementalCurve(initial_input::Float64, x_coords::Vector{Float64}, slopes::Vector{Float64})
+    PiecewiseIncrementalCurve(input_at_zero::Float64, initial_input::Float64, x_coords::Vector{Float64}, slopes::Vector{Float64})
 
 A piecewise linear curve specified by marginal rates (slopes) between production points. May
 have nonzero initial value.
 
 # Arguments
-- `input_at_zero::Float64`: (optional) cost at zero production
-- `initial_input::Float64`: cost at minimum production point
+- `input_at_zero::Union{Nothing, Float64}`: (optional, defaults to `nothing`) cost at zero production, does NOT represent a part of the curve
+- `initial_input::Float64`: cost at minimum production point `first(x_coords)` (NOT at zero production), defines the start of the curve
 - `x_coords::Vector{Float64}`: vector of `n` production points
 - `slopes::Vector{Float64}`: vector of `n-1` marginal rates/slopes of the curve segments between
   the points
@@ -168,7 +170,7 @@ A piecewise linear curve specified by average rates between production points. M
 nonzero initial value.
 
 # Arguments
-- `initial_input::Float64`: cost at minimum production point
+- `initial_input::Float64`: cost at minimum production point `first(x_coords)` (NOT at zero production), defines the start of the curve
 - `x_coords::Vector{Float64}`: vector of `n` production points
 - `slopes::Vector{Float64}`: vector of `n-1` average rates/slopes of the curve segments between
   the points

--- a/src/models/cost_functions/cost_aliases.jl
+++ b/src/models/cost_functions/cost_aliases.jl
@@ -37,8 +37,11 @@ get_proportional_term(vc::LinearCurve) = get_proportional_term(get_function_data
 "Get the constant term (i.e., intercept) of the `LinearCurve`"
 get_constant_term(vc::LinearCurve) = get_constant_term(get_function_data(vc))
 
-Base.show(io::IO, vc::LinearCurve) =
+Base.show(io::IO, vc::LinearCurve) = if isnothing(get_input_at_zero(vc))
     print(io, "$(typeof(vc))($(get_proportional_term(vc)), $(get_constant_term(vc)))")
+else
+    Base.show_default(io, vc)
+end
 
 """
     QuadraticCurve(quadratic_term::Float64, proportional_term::Float64, constant_term::Float64)
@@ -68,11 +71,14 @@ get_proportional_term(vc::QuadraticCurve) = get_proportional_term(get_function_d
 "Get the constant term of the `QuadraticCurve`"
 get_constant_term(vc::QuadraticCurve) = get_constant_term(get_function_data(vc))
 
-Base.show(io::IO, vc::QuadraticCurve) =
+Base.show(io::IO, vc::QuadraticCurve) = if isnothing(get_input_at_zero(vc))
     print(
-        io,
-        "$(typeof(vc))($(get_quadratic_term(vc)), $(get_proportional_term(vc)), $(get_constant_term(vc)))",
-    )
+    io,
+    "$(typeof(vc))($(get_quadratic_term(vc)), $(get_proportional_term(vc)), $(get_constant_term(vc)))",
+)
+else
+    Base.show_default(io, vc)
+end
 
 """
     PiecewisePointCurve(points::Vector{Tuple{Float64, Float64}})
@@ -102,8 +108,11 @@ get_y_coords(vc::PiecewisePointCurve) = get_y_coords(get_function_data(vc))
 get_slopes(vc::PiecewisePointCurve) = get_slopes(get_function_data(vc))
 
 # Here we manually circumvent the @NamedTuple{x::Float64, y::Float64} type annotation, but we keep things looking like named tuples
-Base.show(io::IO, vc::PiecewisePointCurve) =
+Base.show(io::IO, vc::PiecewisePointCurve) = if isnothing(get_input_at_zero(vc))
     print(io, "$(typeof(vc))([$(join(get_points(vc), ", "))])")
+else
+    Base.show_default(io, vc)
+end
 
 """
     PiecewiseIncrementalCurve(initial_input::Float64, x_coords::Vector{Float64}, slopes::Vector{Float64})
@@ -112,6 +121,7 @@ A piecewise linear curve specified by marginal rates (slopes) between production
 have nonzero initial value.
 
 # Arguments
+- `input_at_zero::Float64`: (optional) cost at zero production
 - `initial_input::Float64`: cost at minimum production point
 - `x_coords::Vector{Float64}`: vector of `n` production points
 - `slopes::Vector{Float64}`: vector of `n-1` marginal rates/slopes of the curve segments between
@@ -124,6 +134,14 @@ is_cost_alias(::Union{PiecewiseIncrementalCurve, Type{PiecewiseIncrementalCurve}
 IncrementalCurve{PiecewiseStepData}(initial_input, x_coords::Vector, slopes::Vector) =
     IncrementalCurve(PiecewiseStepData(x_coords, slopes), initial_input)
 
+IncrementalCurve{PiecewiseStepData}(
+    input_at_zero,
+    initial_input,
+    x_coords::Vector,
+    slopes::Vector,
+) =
+    IncrementalCurve(PiecewiseStepData(x_coords, slopes), initial_input, input_at_zero)
+
 "Get the x-coordinates that define the `PiecewiseIncrementalCurve`"
 get_x_coords(vc::PiecewiseIncrementalCurve) = get_x_coords(get_function_data(vc))
 
@@ -133,7 +151,11 @@ get_slopes(vc::PiecewiseIncrementalCurve) = get_y_coords(get_function_data(vc))
 Base.show(io::IO, vc::PiecewiseIncrementalCurve) =
     print(
         io,
-        "$(typeof(vc))($(get_initial_input(vc)), $(get_x_coords(vc)), $(get_slopes(vc)))",
+        if isnothing(get_input_at_zero(vc))
+            "$(typeof(vc))($(get_initial_input(vc)), $(get_x_coords(vc)), $(get_slopes(vc)))"
+        else
+            "$(typeof(vc))($(get_input_at_zero(vc)), $(get_initial_input(vc)), $(get_x_coords(vc)), $(get_slopes(vc)))"
+        end,
     )
 
 """
@@ -161,8 +183,11 @@ get_x_coords(vc::PiecewiseAverageCurve) = get_x_coords(get_function_data(vc))
 "Get the average rates that define the `PiecewiseAverageCurve`"
 get_average_rates(vc::PiecewiseAverageCurve) = get_y_coords(get_function_data(vc))
 
-Base.show(io::IO, vc::PiecewiseAverageCurve) =
+Base.show(io::IO, vc::PiecewiseAverageCurve) = if isnothing(get_input_at_zero(vc))
     print(
-        io,
-        "$(typeof(vc))($(get_initial_input(vc)), $(get_x_coords(vc)), $(get_average_rates(vc)))",
-    )
+    io,
+    "$(typeof(vc))($(get_initial_input(vc)), $(get_x_coords(vc)), $(get_average_rates(vc)))",
+)
+else
+    Base.show_default(io, vc)
+end

--- a/src/models/cost_functions/cost_aliases.jl
+++ b/src/models/cost_functions/cost_aliases.jl
@@ -119,15 +119,15 @@ Base.show(io::IO, vc::PiecewisePointCurve) =
     end
 
 """
-    PiecewiseIncrementalCurve(initial_input::Float64, x_coords::Vector{Float64}, slopes::Vector{Float64})
-    PiecewiseIncrementalCurve(input_at_zero::Float64, initial_input::Float64, x_coords::Vector{Float64}, slopes::Vector{Float64})
+    PiecewiseIncrementalCurve(initial_input::Union{Float64, Nothing}, x_coords::Vector{Float64}, slopes::Vector{Float64})
+    PiecewiseIncrementalCurve(input_at_zero::Union{Nothing, Float64}, initial_input::Union{Float64, Nothing}, x_coords::Vector{Float64}, slopes::Vector{Float64})
 
 A piecewise linear curve specified by marginal rates (slopes) between production points. May
 have nonzero initial value.
 
 # Arguments
 - `input_at_zero::Union{Nothing, Float64}`: (optional, defaults to `nothing`) cost at zero production, does NOT represent a part of the curve
-- `initial_input::Float64`: cost at minimum production point `first(x_coords)` (NOT at zero production), defines the start of the curve
+- `initial_input::Union{Float64, Nothing}`: cost at minimum production point `first(x_coords)` (NOT at zero production), defines the start of the curve
 - `x_coords::Vector{Float64}`: vector of `n` production points
 - `slopes::Vector{Float64}`: vector of `n-1` marginal rates/slopes of the curve segments between
   the points
@@ -164,13 +164,13 @@ Base.show(io::IO, vc::PiecewiseIncrementalCurve) =
     )
 
 """
-    PiecewiseAverageCurve(initial_input::Float64, x_coords::Vector{Float64}, slopes::Vector{Float64})
+    PiecewiseAverageCurve(initial_input::Union{Float64, Nothing}, x_coords::Vector{Float64}, slopes::Vector{Float64})
 
 A piecewise linear curve specified by average rates between production points. May have
 nonzero initial value.
 
 # Arguments
-- `initial_input::Float64`: cost at minimum production point `first(x_coords)` (NOT at zero production), defines the start of the curve
+- `initial_input::Union{Float64, Nothing}`: cost at minimum production point `first(x_coords)` (NOT at zero production), defines the start of the curve
 - `x_coords::Vector{Float64}`: vector of `n` production points
 - `slopes::Vector{Float64}`: vector of `n-1` average rates/slopes of the curve segments between
   the points

--- a/src/models/cost_functions/cost_aliases.jl
+++ b/src/models/cost_functions/cost_aliases.jl
@@ -37,11 +37,12 @@ get_proportional_term(vc::LinearCurve) = get_proportional_term(get_function_data
 "Get the constant term (i.e., intercept) of the `LinearCurve`"
 get_constant_term(vc::LinearCurve) = get_constant_term(get_function_data(vc))
 
-Base.show(io::IO, vc::LinearCurve) = if isnothing(get_input_at_zero(vc))
-    print(io, "$(typeof(vc))($(get_proportional_term(vc)), $(get_constant_term(vc)))")
-else
-    Base.show_default(io, vc)
-end
+Base.show(io::IO, vc::LinearCurve) =
+    if isnothing(get_input_at_zero(vc))
+        print(io, "$(typeof(vc))($(get_proportional_term(vc)), $(get_constant_term(vc)))")
+    else
+        Base.show_default(io, vc)
+    end
 
 """
     QuadraticCurve(quadratic_term::Float64, proportional_term::Float64, constant_term::Float64)
@@ -71,14 +72,15 @@ get_proportional_term(vc::QuadraticCurve) = get_proportional_term(get_function_d
 "Get the constant term of the `QuadraticCurve`"
 get_constant_term(vc::QuadraticCurve) = get_constant_term(get_function_data(vc))
 
-Base.show(io::IO, vc::QuadraticCurve) = if isnothing(get_input_at_zero(vc))
-    print(
-    io,
-    "$(typeof(vc))($(get_quadratic_term(vc)), $(get_proportional_term(vc)), $(get_constant_term(vc)))",
-)
-else
-    Base.show_default(io, vc)
-end
+Base.show(io::IO, vc::QuadraticCurve) =
+    if isnothing(get_input_at_zero(vc))
+        print(
+            io,
+            "$(typeof(vc))($(get_quadratic_term(vc)), $(get_proportional_term(vc)), $(get_constant_term(vc)))",
+        )
+    else
+        Base.show_default(io, vc)
+    end
 
 """
     PiecewisePointCurve(points::Vector{Tuple{Float64, Float64}})
@@ -108,11 +110,12 @@ get_y_coords(vc::PiecewisePointCurve) = get_y_coords(get_function_data(vc))
 get_slopes(vc::PiecewisePointCurve) = get_slopes(get_function_data(vc))
 
 # Here we manually circumvent the @NamedTuple{x::Float64, y::Float64} type annotation, but we keep things looking like named tuples
-Base.show(io::IO, vc::PiecewisePointCurve) = if isnothing(get_input_at_zero(vc))
-    print(io, "$(typeof(vc))([$(join(get_points(vc), ", "))])")
-else
-    Base.show_default(io, vc)
-end
+Base.show(io::IO, vc::PiecewisePointCurve) =
+    if isnothing(get_input_at_zero(vc))
+        print(io, "$(typeof(vc))([$(join(get_points(vc), ", "))])")
+    else
+        Base.show_default(io, vc)
+    end
 
 """
     PiecewiseIncrementalCurve(initial_input::Float64, x_coords::Vector{Float64}, slopes::Vector{Float64})
@@ -183,11 +186,12 @@ get_x_coords(vc::PiecewiseAverageCurve) = get_x_coords(get_function_data(vc))
 "Get the average rates that define the `PiecewiseAverageCurve`"
 get_average_rates(vc::PiecewiseAverageCurve) = get_y_coords(get_function_data(vc))
 
-Base.show(io::IO, vc::PiecewiseAverageCurve) = if isnothing(get_input_at_zero(vc))
-    print(
-    io,
-    "$(typeof(vc))($(get_initial_input(vc)), $(get_x_coords(vc)), $(get_average_rates(vc)))",
-)
-else
-    Base.show_default(io, vc)
-end
+Base.show(io::IO, vc::PiecewiseAverageCurve) =
+    if isnothing(get_input_at_zero(vc))
+        print(
+            io,
+            "$(typeof(vc))($(get_initial_input(vc)), $(get_x_coords(vc)), $(get_average_rates(vc)))",
+        )
+    else
+        Base.show_default(io, vc)
+    end

--- a/test/test_cost_functions.jl
+++ b/test/test_cost_functions.jl
@@ -57,7 +57,9 @@ end
 
     # IncrementalCurve
     inc_linear = IncrementalCurve(LinearFunctionData(6, 2), 1.0)
+    inc_linear_no_initial = IncrementalCurve(LinearFunctionData(6, 2), nothing)
     @test inc_linear isa IncrementalCurve{LinearFunctionData}
+    @test inc_linear_no_initial isa IncrementalCurve{LinearFunctionData}
     @test get_function_data(inc_linear) == LinearFunctionData(6, 2)
     @test get_initial_input(inc_linear) == 1
     @test InputOutputCurve(inc_linear) ==
@@ -66,6 +68,8 @@ end
           InputOutputCurve(LinearFunctionData(2, 1))
     @test AverageRateCurve(inc_linear) ==
           AverageRateCurve(LinearFunctionData(3, 2), 1.0)
+    @test_throws ArgumentError InputOutputCurve(inc_linear_no_initial)
+    @test_throws ArgumentError AverageRateCurve(inc_linear_no_initial)
     @test zero(inc_linear) == IncrementalCurve(LinearFunctionData(0, 0), 0.0)
     @test zero(IncrementalCurve) == IncrementalCurve(LinearFunctionData(0, 0), 0.0)
     @test PSY.is_cost_alias(inc_linear) == PSY.is_cost_alias(typeof(inc_linear)) == false
@@ -75,13 +79,18 @@ end
           "IncrementalCurve where initial value is 1.0, derivative function f is: f(x) = 6.0 x + 2.0"
 
     inc_piecewise = IncrementalCurve(PiecewiseStepData([1, 3, 5], [1.5, 2]), 6.0)
+    inc_piecewise_no_initial =
+        IncrementalCurve(PiecewiseStepData([1, 3, 5], [1.5, 2]), nothing)
     @test inc_piecewise isa IncrementalCurve{PiecewiseStepData}
+    @test inc_piecewise_no_initial isa IncrementalCurve{PiecewiseStepData}
     @test get_function_data(inc_piecewise) == PiecewiseStepData([1, 3, 5], [1.5, 2])
     @test get_initial_input(inc_piecewise) == 6
     @test InputOutputCurve(inc_piecewise) ==
           InputOutputCurve(PiecewiseLinearData([(1, 6), (3, 9), (5, 13)]))
     @test AverageRateCurve(inc_piecewise) ==
           AverageRateCurve(PiecewiseStepData([1, 3, 5], [3, 2.6]), 6.0)
+    @test_throws ArgumentError InputOutputCurve(inc_piecewise_no_initial)
+    @test_throws ArgumentError AverageRateCurve(inc_piecewise_no_initial)
     @test PSY.is_cost_alias(inc_piecewise) == PSY.is_cost_alias(typeof(inc_piecewise)) ==
           true
     @test repr(inc_piecewise) == sprint(show, inc_piecewise) ==
@@ -91,7 +100,9 @@ end
 
     # AverageRateCurve
     ar_linear = AverageRateCurve(LinearFunctionData(3, 2), 1.0)
+    ar_linear_no_initial = AverageRateCurve(LinearFunctionData(3, 2), nothing)
     @test ar_linear isa AverageRateCurve{LinearFunctionData}
+    @test ar_linear_no_initial isa AverageRateCurve{LinearFunctionData}
     @test get_function_data(ar_linear) == LinearFunctionData(3, 2)
     @test get_initial_input(ar_linear) == 1
     @test InputOutputCurve(ar_linear) ==
@@ -100,6 +111,8 @@ end
           InputOutputCurve(LinearFunctionData(2, 1))
     @test IncrementalCurve(ar_linear) ==
           IncrementalCurve(LinearFunctionData(6, 2), 1.0)
+    @test_throws ArgumentError InputOutputCurve(ar_linear_no_initial)
+    @test_throws ArgumentError IncrementalCurve(ar_linear_no_initial)
     @test zero(ar_linear) == AverageRateCurve(LinearFunctionData(0, 0), 0.0)
     @test zero(AverageRateCurve) == AverageRateCurve(LinearFunctionData(0, 0), 0.0)
     @test PSY.is_cost_alias(ar_linear) == PSY.is_cost_alias(typeof(ar_linear)) == false
@@ -109,12 +122,18 @@ end
           "AverageRateCurve where initial value is 1.0, average rate function f is: f(x) = 3.0 x + 2.0"
 
     ar_piecewise = AverageRateCurve(PiecewiseStepData([1, 3, 5], [3, 2.6]), 6.0)
+    ar_piecewise_no_initial =
+        AverageRateCurve(PiecewiseStepData([1, 3, 5], [3, 2.6]), nothing)
+    @test ar_piecewise isa AverageRateCurve{PiecewiseStepData}
+    @test ar_piecewise_no_initial isa AverageRateCurve{PiecewiseStepData}
     @test get_function_data(ar_piecewise) == PiecewiseStepData([1, 3, 5], [3, 2.6])
     @test get_initial_input(ar_piecewise) == 6
     @test InputOutputCurve(ar_piecewise) ==
           InputOutputCurve(PiecewiseLinearData([(1, 6), (3, 9), (5, 13)]))
     @test IncrementalCurve(ar_piecewise) ==
           IncrementalCurve(PiecewiseStepData([1, 3, 5], [1.5, 2]), 6.0)
+    @test_throws ArgumentError InputOutputCurve(ar_piecewise_no_initial)
+    @test_throws ArgumentError IncrementalCurve(ar_piecewise_no_initial)
     @test PSY.is_cost_alias(ar_piecewise) == PSY.is_cost_alias(typeof(ar_piecewise)) == true
     @test repr(ar_piecewise) == sprint(show, ar_piecewise) ==
           "PiecewiseAverageCurve(6.0, [1.0, 3.0, 5.0], [3.0, 2.6])"
@@ -130,6 +149,10 @@ end
         (inc_piecewise, IncrementalCurve),
         (ar_linear, AverageRateCurve),
         (ar_piecewise, AverageRateCurve),
+        (inc_linear_no_initial, IncrementalCurve),
+        (inc_piecewise_no_initial, IncrementalCurve),
+        (ar_linear_no_initial, AverageRateCurve),
+        (ar_piecewise_no_initial, AverageRateCurve),
     ]
     for (curve, curve_type) in curves_by_type
         @test IS.serialize(curve) isa AbstractDict
@@ -176,25 +199,24 @@ end
     pwinc_without_iaz =
         IncrementalCurve(PiecewiseStepData([1, 3, 5], [1.5, 2]), 6.0, nothing)
     pwinc_with_iaz = IncrementalCurve(PiecewiseStepData([1, 3, 5], [1.5, 2]), 6.0, iaz)
-    others_without_iaz = [
+    all_without_iaz = [
         InputOutputCurve(QuadraticFunctionData(3, 2, 1), nothing),
         InputOutputCurve(LinearFunctionData(2, 1), nothing),
         InputOutputCurve(PiecewiseLinearData([(1, 6), (3, 9), (5, 13)]), nothing),
         IncrementalCurve(LinearFunctionData(6, 2), 1.0, nothing),
+        pwinc_without_iaz,
         AverageRateCurve(LinearFunctionData(3, 2), 1.0, nothing),
         AverageRateCurve(PiecewiseStepData([1, 3, 5], [3, 2.6]), 6.0, nothing),
     ]
-    others_with_iaz = [
+    all_with_iaz = [
         InputOutputCurve(QuadraticFunctionData(3, 2, 1), iaz),
         InputOutputCurve(LinearFunctionData(2, 1), iaz),
         InputOutputCurve(PiecewiseLinearData([(1, 6), (3, 9), (5, 13)]), iaz),
         IncrementalCurve(LinearFunctionData(6, 2), 1.0, iaz),
-        IncrementalCurve(PiecewiseStepData([1, 3, 5], [1.5, 2]), 6.0, iaz),
+        pwinc_with_iaz,
         AverageRateCurve(LinearFunctionData(3, 2), 1.0, iaz),
         AverageRateCurve(PiecewiseStepData([1, 3, 5], [3, 2.6]), 6.0, iaz),
     ]
-    all_without_iaz = vcat(pwinc_without_iaz, others_without_iaz)
-    all_with_iaz = vcat(pwinc_with_iaz, others_with_iaz)
 
     # Alias constructors
     @test PiecewiseIncrementalCurve(1234.5, 6.0, [1.0, 3.0, 5.0], [1.5, 2.0]) ==

--- a/test/test_cost_functions.jl
+++ b/test/test_cost_functions.jl
@@ -59,7 +59,7 @@
     @test zero(IncrementalCurve) == IncrementalCurve(LinearFunctionData(0, 0), 0.0)
     @test PSY.is_cost_alias(inc_linear) == PSY.is_cost_alias(typeof(inc_linear)) == false
     @test repr(inc_linear) == sprint(show, inc_linear) ==
-          "IncrementalCurve{LinearFunctionData}(LinearFunctionData(6.0, 2.0), 1.0)"
+          "IncrementalCurve{LinearFunctionData}(LinearFunctionData(6.0, 2.0), 1.0, nothing)"
     @test sprint(show, "text/plain", inc_linear) ==
           "IncrementalCurve where initial value is 1.0 and derivative function f is: f(x) = 6.0 x + 2.0"
 
@@ -93,7 +93,7 @@
     @test zero(AverageRateCurve) == AverageRateCurve(LinearFunctionData(0, 0), 0.0)
     @test PSY.is_cost_alias(ar_linear) == PSY.is_cost_alias(typeof(ar_linear)) == false
     @test repr(ar_linear) == sprint(show, ar_linear) ==
-          "AverageRateCurve{LinearFunctionData}(LinearFunctionData(3.0, 2.0), 1.0)"
+          "AverageRateCurve{LinearFunctionData}(LinearFunctionData(3.0, 2.0), 1.0, nothing)"
     @test sprint(show, "text/plain", ar_linear) ==
           "AverageRateCurve where initial value is 1.0 and average rate function f is: f(x) = 3.0 x + 2.0"
 

--- a/test/test_cost_functions.jl
+++ b/test/test_cost_functions.jl
@@ -162,6 +162,15 @@ end
     @test zero(PSY.ValueCurve) == InputOutputCurve(LinearFunctionData(0, 0))
 end
 
+@testset "Test ValueCurve type conversion constructors" begin
+    @test InputOutputCurve(QuadraticFunctionData(3, 2, 1), 1) ==
+          InputOutputCurve(QuadraticFunctionData(3, 2, 1), 1.0)
+    @test IncrementalCurve(LinearFunctionData(6, 2), 1) ==
+          IncrementalCurve(LinearFunctionData(6, 2), 1.0)
+    @test AverageRateCurve(LinearFunctionData(3, 2), 1) ==
+          AverageRateCurve(LinearFunctionData(3, 2), 1.0)
+end
+
 @testset "Test cost aliases" begin
     lc = LinearCurve(3.0, 5.0)
     @test lc == InputOutputCurve(LinearFunctionData(3.0, 5.0))

--- a/test/test_cost_functions.jl
+++ b/test/test_cost_functions.jl
@@ -13,7 +13,7 @@
     @test repr(io_quadratic) == sprint(show, io_quadratic) ==
           "QuadraticCurve(3.0, 2.0, 1.0)"
     @test sprint(show, "text/plain", io_quadratic) ==
-          "QuadraticCurve (a type of InputOutputCurve) with function: f(x) = 3.0 x^2 + 2.0 x + 1.0"
+          "QuadraticCurve (a type of InputOutputCurve) where function is: f(x) = 3.0 x^2 + 2.0 x + 1.0"
 
     io_linear = InputOutputCurve(LinearFunctionData(2, 1))
     @test io_linear isa InputOutputCurve{LinearFunctionData}
@@ -28,7 +28,7 @@
     @test repr(io_linear) == sprint(show, io_linear) ==
           "LinearCurve(2.0, 1.0)"
     @test sprint(show, "text/plain", io_linear) ==
-          "LinearCurve (a type of InputOutputCurve) with function: f(x) = 2.0 x + 1.0"
+          "LinearCurve (a type of InputOutputCurve) where function is: f(x) = 2.0 x + 1.0"
 
     io_piecewise = InputOutputCurve(PiecewiseLinearData([(1, 6), (3, 9), (5, 13)]))
     @test io_piecewise isa InputOutputCurve{PiecewiseLinearData}
@@ -42,7 +42,7 @@
     @test repr(io_piecewise) == sprint(show, io_piecewise) ==
           "PiecewisePointCurve([(x = 1.0, y = 6.0), (x = 3.0, y = 9.0), (x = 5.0, y = 13.0)])"
     @test sprint(show, "text/plain", io_piecewise) ==
-          "PiecewisePointCurve (a type of InputOutputCurve) with function: piecewise linear y = f(x) connecting points:\n  (x = 1.0, y = 6.0)\n  (x = 3.0, y = 9.0)\n  (x = 5.0, y = 13.0)"
+          "PiecewisePointCurve (a type of InputOutputCurve) where function is: piecewise linear y = f(x) connecting points:\n  (x = 1.0, y = 6.0)\n  (x = 3.0, y = 9.0)\n  (x = 5.0, y = 13.0)"
 
     # IncrementalCurve
     inc_linear = IncrementalCurve(LinearFunctionData(6, 2), 1.0)
@@ -61,7 +61,7 @@
     @test repr(inc_linear) == sprint(show, inc_linear) ==
           "IncrementalCurve{LinearFunctionData}(LinearFunctionData(6.0, 2.0), 1.0, nothing)"
     @test sprint(show, "text/plain", inc_linear) ==
-          "IncrementalCurve where initial value is 1.0 and derivative function f is: f(x) = 6.0 x + 2.0"
+          "IncrementalCurve where initial value is 1.0, derivative function f is: f(x) = 6.0 x + 2.0"
 
     inc_piecewise = IncrementalCurve(PiecewiseStepData([1, 3, 5], [1.5, 2]), 6.0)
     @test inc_piecewise isa IncrementalCurve{PiecewiseStepData}
@@ -76,7 +76,7 @@
     @test repr(inc_piecewise) == sprint(show, inc_piecewise) ==
           "PiecewiseIncrementalCurve(6.0, [1.0, 3.0, 5.0], [1.5, 2.0])"
     @test sprint(show, "text/plain", inc_piecewise) ==
-          "PiecewiseIncrementalCurve where initial value is 6.0 and derivative function f is: f(x) =\n  1.5 for x in [1.0, 3.0)\n  2.0 for x in [3.0, 5.0)"
+          "PiecewiseIncrementalCurve where initial value is 6.0, derivative function f is: f(x) =\n  1.5 for x in [1.0, 3.0)\n  2.0 for x in [3.0, 5.0)"
 
     # AverageRateCurve
     ar_linear = AverageRateCurve(LinearFunctionData(3, 2), 1.0)
@@ -95,7 +95,7 @@
     @test repr(ar_linear) == sprint(show, ar_linear) ==
           "AverageRateCurve{LinearFunctionData}(LinearFunctionData(3.0, 2.0), 1.0, nothing)"
     @test sprint(show, "text/plain", ar_linear) ==
-          "AverageRateCurve where initial value is 1.0 and average rate function f is: f(x) = 3.0 x + 2.0"
+          "AverageRateCurve where initial value is 1.0, average rate function f is: f(x) = 3.0 x + 2.0"
 
     ar_piecewise = AverageRateCurve(PiecewiseStepData([1, 3, 5], [3, 2.6]), 6.0)
     @test get_function_data(ar_piecewise) == PiecewiseStepData([1, 3, 5], [3, 2.6])
@@ -108,7 +108,7 @@
     @test repr(ar_piecewise) == sprint(show, ar_piecewise) ==
           "PiecewiseAverageCurve(6.0, [1.0, 3.0, 5.0], [3.0, 2.6])"
     @test sprint(show, "text/plain", ar_piecewise) ==
-          "PiecewiseAverageCurve where initial value is 6.0 and average rate function f is: f(x) =\n  3.0 for x in [1.0, 3.0)\n  2.6 for x in [3.0, 5.0)"
+          "PiecewiseAverageCurve where initial value is 6.0, average rate function f is: f(x) =\n  3.0 for x in [1.0, 3.0)\n  2.6 for x in [3.0, 5.0)"
 
     # Serialization round trip
     curves_by_type = [  # typeof() gives parameterized types
@@ -160,6 +160,52 @@ end
     @test get_average_rates(pac) == [12.0, 10.0]
 end
 
+@testset "Test input_at_zero" begin
+    iaz = 1234.5
+    pwinc_without_iaz =
+        IncrementalCurve(PiecewiseStepData([1, 3, 5], [1.5, 2]), 6.0, nothing)
+    pwinc_with_iaz = IncrementalCurve(PiecewiseStepData([1, 3, 5], [1.5, 2]), 6.0, iaz)
+    others_without_iaz = [
+        InputOutputCurve(QuadraticFunctionData(3, 2, 1), nothing),
+        InputOutputCurve(LinearFunctionData(2, 1), nothing),
+        InputOutputCurve(PiecewiseLinearData([(1, 6), (3, 9), (5, 13)]), nothing),
+        IncrementalCurve(LinearFunctionData(6, 2), 1.0, nothing),
+        AverageRateCurve(LinearFunctionData(3, 2), 1.0, nothing),
+        AverageRateCurve(PiecewiseStepData([1, 3, 5], [3, 2.6]), 6.0, nothing),
+    ]
+    others_with_iaz = [
+        InputOutputCurve(QuadraticFunctionData(3, 2, 1), iaz),
+        InputOutputCurve(LinearFunctionData(2, 1), iaz),
+        InputOutputCurve(PiecewiseLinearData([(1, 6), (3, 9), (5, 13)]), iaz),
+        IncrementalCurve(LinearFunctionData(6, 2), 1.0, iaz),
+        IncrementalCurve(PiecewiseStepData([1, 3, 5], [1.5, 2]), 6.0, iaz),
+        AverageRateCurve(LinearFunctionData(3, 2), 1.0, iaz),
+        AverageRateCurve(PiecewiseStepData([1, 3, 5], [3, 2.6]), 6.0, iaz),
+    ]
+    all_without_iaz = vcat(pwinc_without_iaz, others_without_iaz)
+    all_with_iaz = vcat(pwinc_with_iaz, others_with_iaz)
+
+    # Alias constructors
+    @test PiecewiseIncrementalCurve(1234.5, 6.0, [1.0, 3.0, 5.0], [1.5, 2.0]) ==
+          pwinc_with_iaz
+
+    # Getters and printouts
+    for (without_iaz, with_iaz) in zip(all_without_iaz, all_with_iaz)
+        @test get_input_at_zero(without_iaz) === nothing
+        @test get_input_at_zero(with_iaz) == iaz
+        @test occursin(string(iaz), repr(with_iaz))
+        @test sprint(show, with_iaz) == repr(with_iaz)
+        @test occursin(string(iaz), sprint(show, "text/plain", with_iaz))
+    end
+
+    @test repr(pwinc_with_iaz) == sprint(show, pwinc_with_iaz) ==
+          "PiecewiseIncrementalCurve(1234.5, 6.0, [1.0, 3.0, 5.0], [1.5, 2.0])"
+    @test sprint(show, "text/plain", pwinc_with_iaz) ==
+          "PiecewiseIncrementalCurve where value at zero is 1234.5, initial value is 6.0, derivative function f is: f(x) =\n  1.5 for x in [1.0, 3.0)\n  2.0 for x in [3.0, 5.0)"
+
+    # TODO preserved under conversion
+end
+
 @testset "Test CostCurve and FuelCurve" begin
     cc = CostCurve(InputOutputCurve(PSY.QuadraticFunctionData(1, 2, 3)))
     fc = FuelCurve(InputOutputCurve(PSY.QuadraticFunctionData(1, 2, 3)), 4.0)
@@ -187,14 +233,14 @@ end
           "FuelCurve{QuadraticCurve}(QuadraticCurve(1.0, 2.0, 3.0), UnitSystem.NATURAL_UNITS = 2, 4.0, LinearCurve(0.0, 0.0))"
     @test sprint(show, "text/plain", cc) ==
           sprint(show, "text/plain", cc; context = :compact => false) ==
-          "CostCurve:\n  value_curve: QuadraticCurve (a type of InputOutputCurve) with function: f(x) = 1.0 x^2 + 2.0 x + 3.0\n  power_units: UnitSystem.NATURAL_UNITS = 2\n  vom_cost: LinearCurve (a type of InputOutputCurve) with function: f(x) = 0.0 x + 0.0"
+          "CostCurve:\n  value_curve: QuadraticCurve (a type of InputOutputCurve) where function is: f(x) = 1.0 x^2 + 2.0 x + 3.0\n  power_units: UnitSystem.NATURAL_UNITS = 2\n  vom_cost: LinearCurve (a type of InputOutputCurve) where function is: f(x) = 0.0 x + 0.0"
     @test sprint(show, "text/plain", fc) ==
           sprint(show, "text/plain", fc; context = :compact => false) ==
-          "FuelCurve:\n  value_curve: QuadraticCurve (a type of InputOutputCurve) with function: f(x) = 1.0 x^2 + 2.0 x + 3.0\n  power_units: UnitSystem.NATURAL_UNITS = 2\n  fuel_cost: 4.0\n  vom_cost: LinearCurve (a type of InputOutputCurve) with function: f(x) = 0.0 x + 0.0"
+          "FuelCurve:\n  value_curve: QuadraticCurve (a type of InputOutputCurve) where function is: f(x) = 1.0 x^2 + 2.0 x + 3.0\n  power_units: UnitSystem.NATURAL_UNITS = 2\n  fuel_cost: 4.0\n  vom_cost: LinearCurve (a type of InputOutputCurve) where function is: f(x) = 0.0 x + 0.0"
     @test sprint(show, "text/plain", cc; context = :compact => true) ==
-          "CostCurve with power_units UnitSystem.NATURAL_UNITS = 2, vom_cost LinearCurve(0.0, 0.0), and value_curve:\n  QuadraticCurve (a type of InputOutputCurve) with function: f(x) = 1.0 x^2 + 2.0 x + 3.0"
+          "CostCurve with power_units UnitSystem.NATURAL_UNITS = 2, vom_cost LinearCurve(0.0, 0.0), and value_curve:\n  QuadraticCurve (a type of InputOutputCurve) where function is: f(x) = 1.0 x^2 + 2.0 x + 3.0"
     @test sprint(show, "text/plain", fc; context = :compact => true) ==
-          "FuelCurve with power_units UnitSystem.NATURAL_UNITS = 2, fuel_cost 4.0, vom_cost LinearCurve(0.0, 0.0), and value_curve:\n  QuadraticCurve (a type of InputOutputCurve) with function: f(x) = 1.0 x^2 + 2.0 x + 3.0"
+          "FuelCurve with power_units UnitSystem.NATURAL_UNITS = 2, fuel_cost 4.0, vom_cost LinearCurve(0.0, 0.0), and value_curve:\n  QuadraticCurve (a type of InputOutputCurve) where function is: f(x) = 1.0 x^2 + 2.0 x + 3.0"
 
     @test get_power_units(cc) == UnitSystem.NATURAL_UNITS
     @test get_power_units(fc) == UnitSystem.NATURAL_UNITS


### PR DESCRIPTION
Discussing with @jd-lara et al., it sounds like in certain cases we need to be able to explicitly represent a no-load cost as part of a cost curve instance, even if that cost is not part of the representation of the actual… cost curve. For instance, some input formats define a no-load cost and *do not* define a cost at minimum generation, and (roughly) you're supposed to infer the latter from the former by assuming the data is quadratic. Here we:

- Add `input_at_zero` to all `ValueCurve` subtypes to maintain the isomorphic design, but only expose it to the user through the simplified cost alias interface as part of `PiecewiseIncrementalCurve` because that is the only place we expect it to be used. It defaults to `nothing` if not specified and is preserved under all conversions.
- Add relevant getters, alter relevant printouts.
- Make `initial_input` a `Union{Float64, Nothing}` to represent the case where we have a no-load cost but have not yet calculated a minimum generation cost. It is the user's responsibility to figure out how to fill in `initial_input`; if they want it to be `nothing` they have to specify that.
- Have the conversions error out if `initial_input` is `nothing`.
- Make the docstrings clearer about the difference between `initial_input` and `input_at_zero`.

If these changes look good, I'll next:

- Edit the `Variable Costs` modeler guide page (the one with the table of all the cost aliases) to match.
- Add hand-drawn graphs to that page to illustrate all the cost aliases — this will further disambiguate `initial_input` vs. `input_at_zero`.
- Add an `initial_input` time series to `MarketBidCost`.