### PR TITLE
Add `is_component_in_aggregation_topology`

### DIFF
--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -316,6 +316,7 @@ export get_services
 export has_service
 export has_time_series
 export get_buses
+export is_component_in_aggregation_topology
 export get_components_in_aggregation_topology
 export get_aggregation_topology_mapping
 export get_contributing_devices

--- a/src/base.jl
+++ b/src/base.jl
@@ -1205,6 +1205,15 @@ function get_components_in_aggregation_topology(
     return components
 end
 
+"Return whether the given component's bus is in the AggregationTopology."
+function is_component_in_aggregation_topology(
+    comp::Component,
+    aggregator::T,
+) where {T <: AggregationTopology}
+    accessor = get_aggregation_topology_accessor(T)
+    return IS.get_uuid(accessor(get_bus(comp))) == IS.get_uuid(aggregator)
+end
+
 """
 Return a mapping of AggregationTopology name to vector of buses within it.
 """


### PR DESCRIPTION
For PowerAnalytics/`ComponentSelector`-related reasons, it is useful to be able to test whether a given `Component` is within a given `AggregationTopology` without having a reference to the relevant `System`. This exposes that functionality. I also made the existing `get_component_in_aggregation_topology` test more thorough.