### PR TITLE
Add cost alias functions to public API

### DIFF
--- a/docs/src/api/public.md
+++ b/docs/src/api/public.md
@@ -23,6 +23,7 @@ Pages   = ["PowerSystems.jl",
            "dynamic_models.jl",
            "operational_cost.jl",
            "cost_functions/ValueCurves.jl",
+           "cost_functions/cost_aliases.jl",
            "cost_function_timeseries.jl",
            "definitions.jl"]
 Public = true


### PR DESCRIPTION
Quick fix to add the cost alias getter/setter functions to the Public API (cost_aliases.jl)
