### PR TITLE
Quick fix to make valuecurves visible in model library

### DIFF
--- a/docs/src/api/public.md
+++ b/docs/src/api/public.md
@@ -23,7 +23,6 @@ Pages   = ["PowerSystems.jl",
            "dynamic_models.jl",
            "operational_cost.jl",
            "cost_functions/ValueCurves.jl",
-           "cost_functions/cost_aliases.jl",
            "cost_function_timeseries.jl",
            "definitions.jl"]
 Public = true

--- a/docs/src/model_library/value_curves.md
+++ b/docs/src/model_library/value_curves.md
@@ -1,8 +1,9 @@
 # [`ValueCurve`s](@id value_curve_library)
-```@docs
-LinearCurve
-QuadraticCurve
-PiecewisePointCurve
-PiecewiseIncrementalCurve
-PiecewiseAverageCurve
+
+```@autodocs
+Modules = [PowerSystems]
+Pages   = ["cost_functions/cost_aliases.jl"]
+Order = [:type, :function]
+Public = true
+Private = false
 ```


### PR DESCRIPTION
Value curves page in the model library was showing missing docs due to duplication with the API. Quick fix to at least make them all visible (if a bit out of order), pending final docs organization