### PR TITLE
fix: Adding support for quadratic functions using the table data parser

### DIFF
--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -390,6 +390,9 @@ export get_compression_settings
 export CompressionSettings
 export CompressionTypes
 
+# Parsing functions
+export create_poly_cost
+
 #export make_time_series
 export get_bus_numbers
 export get_name

--- a/src/descriptors/power_system_inputs.json
+++ b/src/descriptors/power_system_inputs.json
@@ -367,6 +367,21 @@
             "default_value": null
         },
         {
+            "name": "heat_rate_a0",
+            "description": "Heat rate Average 0 TODO",
+            "default_value": null
+        },
+        {
+            "name": "heat_rate_a1",
+            "description": "Heat rate Average 0 TODO",
+            "default_value": null
+        },
+        {
+            "name": "heat_rate_a2",
+            "description": "Heat rate Average 0 TODO",
+            "default_value": null
+        },
+        {
             "name": "heat_rate_avg_0",
             "description": "Heat rate Average 0 TODO",
             "default_value": null

--- a/src/descriptors/power_system_inputs.json
+++ b/src/descriptors/power_system_inputs.json
@@ -368,17 +368,17 @@
         },
         {
             "name": "heat_rate_a0",
-            "description": "Heat rate Average 0 TODO",
+            "description": "Heat rate constant term",
             "default_value": null
         },
         {
             "name": "heat_rate_a1",
-            "description": "Heat rate Average 0 TODO",
+            "description": "Heat rate proportional term",
             "default_value": null
         },
         {
             "name": "heat_rate_a2",
-            "description": "Heat rate Average 0 TODO",
+            "description": "Heat rate quadratic term",
             "default_value": null
         },
         {

--- a/src/parsers/power_system_table_data.jl
+++ b/src/parsers/power_system_table_data.jl
@@ -823,7 +823,7 @@ function make_cost(
 ) where {T <: ThermalGen}
     fuel_price = gen.fuel_price / 1000.0
 
-    # We check if there is any Quadratic or Linear Data defined. If not we fall back to create PowerLoad
+    # We check if there is any Quadratic or Linear Data defined. If not we fall back to create PiecewiseIncrementalCurve
     quadratic_fields = (gen.heat_rate_a0, gen.heat_rate_a1, gen.heat_rate_a2)
 
     if any(field -> field != nothing, quadratic_fields)

--- a/src/parsers/power_system_table_data.jl
+++ b/src/parsers/power_system_table_data.jl
@@ -545,7 +545,6 @@ function gen_csv_parser!(sys::System, data::PowerSystemTableData)
         throw(IS.ConflictingInputsError("Heat rate and cost points are both defined"))
     elseif length(heat_rate_fields) > 0
         cost_colnames = _HeatRateColumns(zip(heat_rate_fields, output_point_fields))
-        @warn cost_colnames
     elseif length(cost_point_fields) > 0
         cost_colnames = _CostPointColumns(zip(cost_point_fields, output_point_fields))
     else
@@ -825,7 +824,6 @@ function make_cost(
     fuel_price = gen.fuel_price / 1000.0
 
     # We check if there is any Quadratic or Linear Data defined. If not we fall back to create PowerLoad
-    @warn typeof(gen)
     quadratic_fields = (gen.heat_rate_a0, gen.heat_rate_a1, gen.heat_rate_a2)
 
     if any(field -> field != nothing, quadratic_fields)
@@ -978,9 +976,9 @@ function create_poly_cost(
     end
 
     # Three supported cases,
-    #   1. If three values are passed then we have data looking like: a^2 + a + c,
-    #   2. If two then data is looking like: a + c
-    #   3. If two then data is looking like: c
+    #   1. If three values are passed then we have data looking like: a * x^2 + b * x + c,
+    #   2. If two then data is looking like: a * x + b
+    #   3. If two then data is looking like: a * x
     if length(vals) > 3
         throw(
             DataFormatError(
@@ -989,12 +987,13 @@ function create_poly_cost(
         )
     elseif length(vals) == 3
         var_cost = QuadraticCurve(vals[3], vals[2], vals[1])
-        @debug "Quadratic curve created for $(gen.name)"
+        @debug "QuadraticCurve created for $(gen.name)"
     elseif length(vals) == 2
         var_cost = LinearCurve(vals[2], vals[1])
+        @debug "LinearCurve curve created for $(gen.name)"
     else
-        length(vals) == 1
         var_cost = LinearCurve(vals[1])
+        @debug "LinearCurve curve created for $(gen.name)"
     end
 
     return var_cost, 0.0

--- a/test/test_power_system_table_data.jl
+++ b/test/test_power_system_table_data.jl
@@ -185,7 +185,7 @@ end
 @testset "Test create_poly_cost function" begin
     cost_colnames = ["heat_rate_a0", "heat_rate_a1", "heat_rate_a2"]
 
-    # Coefficients for a CC using natura gas
+    # Coefficients for a CC using natural gas
     a2 = -0.000531607
     a1 = 0.060554675
     a0 = 8.951100118

--- a/test/test_power_system_table_data.jl
+++ b/test/test_power_system_table_data.jl
@@ -181,3 +181,51 @@ end
     g = get_components(ThermalStandard, sys)
     @test get_variable.(get_operation_cost.(g)) == get_variable.(get_operation_cost.(g))
 end
+
+@testset "Test create_poly_cost function" begin
+
+    cost_colnames = ["heat_rate_a0", "heat_rate_a1", "heat_rate_a2"]
+
+    # Coefficients for a CC using natura gas
+    a2 = -0.000531607
+    a1 = 0.060554675
+    a0 = 8.951100118
+
+    # First test that return quadratic if all coefficients are provided.
+    # We convert the coefficients to string to mimic parsing from csv
+    example_generator = (name="test-gen", heat_rate_a0=string(a0), heat_rate_a1=string(a1), heat_rate_a2=string(a2))
+    cost_curve, fixed_cost = create_poly_cost(example_generator, cost_colnames)
+    @assert cost_curve isa QuadraticCurve
+    @assert isapprox(get_quadratic_term(cost_curve), a2, atol=0.01)
+    @assert isapprox(get_proportional_term(cost_curve), a1, atol=0.01)
+    @assert isapprox(get_constant_term(cost_curve), a0, atol=0.01)
+
+    # Test return linear with both proportional and constant term
+    example_generator = (name="test-gen", heat_rate_a0=string(a0), heat_rate_a1=string(a1), heat_rate_a2=nothing)
+    cost_curve, fixed_cost = create_poly_cost(example_generator, cost_colnames)
+    @assert cost_curve isa LinearCurve
+    @assert isapprox(get_proportional_term(cost_curve), a1, atol=0.01)
+    @assert isapprox(get_constant_term(cost_curve), a0, atol=0.01)
+
+    # Test return linear with just proportional term
+    example_generator = (name="test-gen", heat_rate_a0=nothing, heat_rate_a1=string(a1), heat_rate_a2=nothing)
+    cost_curve, fixed_cost = create_poly_cost(example_generator, cost_colnames)
+    @assert cost_curve isa LinearCurve
+    @assert isapprox(get_proportional_term(cost_curve), a1, atol=0.01)
+
+    # Test raises error if a2 is passed but other coefficients are nothing
+    example_generator = (name="test-gen", heat_rate_a0=nothing, heat_rate_a1=nothing, heat_rate_a2=string(a2))
+    @test_throws IS.DataFormatError create_poly_cost(example_generator, cost_colnames)
+    example_generator = (name="test-gen", heat_rate_a0=nothing, heat_rate_a1=string(a1), heat_rate_a2=string(a2))
+    @test_throws IS.DataFormatError create_poly_cost(example_generator, cost_colnames)
+    example_generator = (name="test-gen", heat_rate_a0=string(a0), heat_rate_a1=nothing, heat_rate_a2=string(a2))
+    @test_throws IS.DataFormatError create_poly_cost(example_generator, cost_colnames)
+
+    # Test that it works with zero proportional and constant term
+    example_generator = (name="test-gen", heat_rate_a0=string(0.0), heat_rate_a1=string(0.0), heat_rate_a2=string(a2))
+    cost_curve, fixed_cost = create_poly_cost(example_generator, cost_colnames)
+    @assert cost_curve isa QuadraticCurve
+    @assert isapprox(get_quadratic_term(cost_curve), a2, atol=0.01)
+    @assert isapprox(get_proportional_term(cost_curve), 0.0, atol=0.01)
+    @assert isapprox(get_constant_term(cost_curve), 0.0, atol=0.01)
+end

--- a/test/test_power_system_table_data.jl
+++ b/test/test_power_system_table_data.jl
@@ -183,7 +183,6 @@ end
 end
 
 @testset "Test create_poly_cost function" begin
-
     cost_colnames = ["heat_rate_a0", "heat_rate_a1", "heat_rate_a2"]
 
     # Coefficients for a CC using natura gas
@@ -193,39 +192,74 @@ end
 
     # First test that return quadratic if all coefficients are provided.
     # We convert the coefficients to string to mimic parsing from csv
-    example_generator = (name="test-gen", heat_rate_a0=string(a0), heat_rate_a1=string(a1), heat_rate_a2=string(a2))
+    example_generator = (
+        name = "test-gen",
+        heat_rate_a0 = string(a0),
+        heat_rate_a1 = string(a1),
+        heat_rate_a2 = string(a2),
+    )
     cost_curve, fixed_cost = create_poly_cost(example_generator, cost_colnames)
     @assert cost_curve isa QuadraticCurve
-    @assert isapprox(get_quadratic_term(cost_curve), a2, atol=0.01)
-    @assert isapprox(get_proportional_term(cost_curve), a1, atol=0.01)
-    @assert isapprox(get_constant_term(cost_curve), a0, atol=0.01)
+    @assert isapprox(get_quadratic_term(cost_curve), a2, atol = 0.01)
+    @assert isapprox(get_proportional_term(cost_curve), a1, atol = 0.01)
+    @assert isapprox(get_constant_term(cost_curve), a0, atol = 0.01)
 
     # Test return linear with both proportional and constant term
-    example_generator = (name="test-gen", heat_rate_a0=string(a0), heat_rate_a1=string(a1), heat_rate_a2=nothing)
+    example_generator = (
+        name = "test-gen",
+        heat_rate_a0 = string(a0),
+        heat_rate_a1 = string(a1),
+        heat_rate_a2 = nothing,
+    )
     cost_curve, fixed_cost = create_poly_cost(example_generator, cost_colnames)
     @assert cost_curve isa LinearCurve
-    @assert isapprox(get_proportional_term(cost_curve), a1, atol=0.01)
-    @assert isapprox(get_constant_term(cost_curve), a0, atol=0.01)
+    @assert isapprox(get_proportional_term(cost_curve), a1, atol = 0.01)
+    @assert isapprox(get_constant_term(cost_curve), a0, atol = 0.01)
 
     # Test return linear with just proportional term
-    example_generator = (name="test-gen", heat_rate_a0=nothing, heat_rate_a1=string(a1), heat_rate_a2=nothing)
+    example_generator = (
+        name = "test-gen",
+        heat_rate_a0 = nothing,
+        heat_rate_a1 = string(a1),
+        heat_rate_a2 = nothing,
+    )
     cost_curve, fixed_cost = create_poly_cost(example_generator, cost_colnames)
     @assert cost_curve isa LinearCurve
-    @assert isapprox(get_proportional_term(cost_curve), a1, atol=0.01)
+    @assert isapprox(get_proportional_term(cost_curve), a1, atol = 0.01)
 
     # Test raises error if a2 is passed but other coefficients are nothing
-    example_generator = (name="test-gen", heat_rate_a0=nothing, heat_rate_a1=nothing, heat_rate_a2=string(a2))
+    example_generator = (
+        name = "test-gen",
+        heat_rate_a0 = nothing,
+        heat_rate_a1 = nothing,
+        heat_rate_a2 = string(a2),
+    )
     @test_throws IS.DataFormatError create_poly_cost(example_generator, cost_colnames)
-    example_generator = (name="test-gen", heat_rate_a0=nothing, heat_rate_a1=string(a1), heat_rate_a2=string(a2))
+    example_generator = (
+        name = "test-gen",
+        heat_rate_a0 = nothing,
+        heat_rate_a1 = string(a1),
+        heat_rate_a2 = string(a2),
+    )
     @test_throws IS.DataFormatError create_poly_cost(example_generator, cost_colnames)
-    example_generator = (name="test-gen", heat_rate_a0=string(a0), heat_rate_a1=nothing, heat_rate_a2=string(a2))
+    example_generator = (
+        name = "test-gen",
+        heat_rate_a0 = string(a0),
+        heat_rate_a1 = nothing,
+        heat_rate_a2 = string(a2),
+    )
     @test_throws IS.DataFormatError create_poly_cost(example_generator, cost_colnames)
 
     # Test that it works with zero proportional and constant term
-    example_generator = (name="test-gen", heat_rate_a0=string(0.0), heat_rate_a1=string(0.0), heat_rate_a2=string(a2))
+    example_generator = (
+        name = "test-gen",
+        heat_rate_a0 = string(0.0),
+        heat_rate_a1 = string(0.0),
+        heat_rate_a2 = string(a2),
+    )
     cost_curve, fixed_cost = create_poly_cost(example_generator, cost_colnames)
     @assert cost_curve isa QuadraticCurve
-    @assert isapprox(get_quadratic_term(cost_curve), a2, atol=0.01)
-    @assert isapprox(get_proportional_term(cost_curve), 0.0, atol=0.01)
-    @assert isapprox(get_constant_term(cost_curve), 0.0, atol=0.01)
+    @assert isapprox(get_quadratic_term(cost_curve), a2, atol = 0.01)
+    @assert isapprox(get_proportional_term(cost_curve), 0.0, atol = 0.01)
+    @assert isapprox(get_constant_term(cost_curve), 0.0, atol = 0.01)
 end


### PR DESCRIPTION
Currently only works for heat rate and not cost curves.

### Implementation details:
- Added new fields for generators to capture quadratic heat rate curve. For simplicity, the names are `heat_rate_a0`, `heat_rate_a1`, `heat_rate_a2`. All of the new fields are `null` by default. Open to suggestions on the nameing,
- If any `heat_rate_a*` column are defined, then we call `create_poly_cost` for `ThermalGen`,
- `create_poly_cost` will return 
  - `QuadraticCostCurve` if all the coefficients are passed
  - `LinearCurve` if `a1` and `a0` is passed,
  - `LinearCurve` if `a1`  is passed,.
  - raise an Error if `a2` is passed but `a1` or `a0` is nothing,

Closes #1177 