### PR TITLE
Add `ComponentSelector` feature: PSY portion (take two)

### DIFF
--- a/docs/src/api/public.md
+++ b/docs/src/api/public.md
@@ -74,7 +74,7 @@ Filter = t -> nameof(t) in names(PowerSystems)
 
 ```@autodocs
 Modules = [PowerSystems]
-Pages   = ["base.jl"]
+Pages   = ["get_components_interface.jl", "base.jl", "component_selector.jl"]
 Public = true
 Private = false
 Filter = t -> t ∈ [System]
@@ -82,7 +82,7 @@ Filter = t -> t ∈ [System]
 
 ```@autodocs
 Modules = [PowerSystems]
-Pages   = ["base.jl"]
+Pages   = ["get_components_interface.jl", "base.jl", "component_selector.jl"]
 Public = true
 Private = false
 Filter = t -> t ∉ [System]

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -630,6 +630,7 @@ import InfrastructureSystems:
     ListComponentSelector,
     TypeComponentSelector,
     FilterComponentSelector,
+    RegroupedComponentSelector,
     component_to_qualified_string,
     subtype_to_string,
     COMPONENT_NAME_DELIMITER,

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -755,6 +755,7 @@ include("base.jl")
 include("subsystems.jl")
 include("component_selector.jl")
 include("data_format_conversions.jl")
+include("get_components_interface.jl")
 
 #Data Checks
 include("utils/IO/system_checks.jl")

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -630,8 +630,7 @@ import InfrastructureSystems:
     component_to_qualified_string,
     subtype_to_string,
     COMPONENT_NAME_DELIMITER,
-    make_selector,
-    default_name
+    make_selector
 import InfrastructureSystems:
     ValueCurve,
     InputOutputCurve,

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -496,10 +496,10 @@ export UnitSystem # internal.jl
 export ComponentSelector
 export SingularComponentSelector
 export PluralComponentSelector
+export DynamicallyGroupedComponentSelector
 export subtype_to_string
 export component_to_qualified_string
 export make_selector
-export get_components
 export get_groups
 #################################################################################
 # Imports
@@ -622,7 +622,7 @@ import InfrastructureSystems:
     ComponentSelector,
     SingularComponentSelector,
     PluralComponentSelector,
-    DynamicallyGroupedPluralComponentSelector,
+    DynamicallyGroupedComponentSelector,
     NameComponentSelector,
     ListComponentSelector,
     SubtypeComponentSelector,

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -492,7 +492,7 @@ export generate_struct_file
 export generate_struct_files
 export UnitSystem # internal.jl
 
-# TODO export ComponentSelector stuff
+#ComponentSelector
 export ComponentSelector
 export ComponentSelectorElement
 export ComponentSelectorSet
@@ -506,6 +506,7 @@ export component_to_qualified_string
 export select_components
 export get_components
 export get_subselectors
+export NAME_DELIMETER
 #################################################################################
 # Imports
 

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -494,13 +494,8 @@ export UnitSystem # internal.jl
 
 # ComponentSelector
 export ComponentSelector
-export ComponentSelectorElement
-export ComponentSelectorSet
-export SingleComponentSelector
-export ListComponentSelector
-export SubtypeComponentSelector
-export FilterComponentSelector
-export TopologyComponentSelector
+export SingularComponentSelector
+export PluralComponentSelector
 export subtype_to_string
 export component_to_qualified_string
 export make_selector
@@ -625,10 +620,10 @@ import InfrastructureSystems:
     supports_supplemental_attributes,
     fast_deepcopy_system,
     ComponentSelector,
-    ComponentSelectorElement,
-    ComponentSelectorSet,
-    DynamicallyGroupedComponentSelectorSet,
-    SingleComponentSelector,
+    SingularComponentSelector,
+    PluralComponentSelector,
+    DynamicallyGroupedPluralComponentSelector,
+    NameComponentSelector,
     ListComponentSelector,
     SubtypeComponentSelector,
     FilterComponentSelector,

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -501,6 +501,7 @@ export DynamicallyGroupedComponentSelector
 export subtype_to_string
 export component_to_qualified_string
 export make_selector
+export rebuild_selector
 export get_groups
 export get_available_groups
 #################################################################################
@@ -632,7 +633,8 @@ import InfrastructureSystems:
     component_to_qualified_string,
     subtype_to_string,
     COMPONENT_NAME_DELIMITER,
-    make_selector
+    make_selector,
+    rebuild_selector
 import InfrastructureSystems:
     ValueCurve,
     InputOutputCurve,

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -630,7 +630,8 @@ import InfrastructureSystems:
     component_to_qualified_string,
     subtype_to_string,
     COMPONENT_NAME_DELIMETER,
-    make_selector
+    make_selector,
+    default_name
 import InfrastructureSystems:
     ValueCurve,
     InputOutputCurve,

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -501,7 +501,6 @@ export DynamicallyGroupedComponentSelector
 export subtype_to_string
 export component_to_qualified_string
 export make_selector
-export rebuild_selector
 export get_groups
 export get_available_groups
 #################################################################################
@@ -633,8 +632,7 @@ import InfrastructureSystems:
     component_to_qualified_string,
     subtype_to_string,
     COMPONENT_NAME_DELIMITER,
-    make_selector,
-    rebuild_selector
+    make_selector
 import InfrastructureSystems:
     ValueCurve,
     InputOutputCurve,

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -493,7 +493,19 @@ export generate_struct_files
 export UnitSystem # internal.jl
 
 # TODO export ComponentSelector stuff
-
+export ComponentSelector
+export ComponentSelectorElement
+export ComponentSelectorSet
+export SingleComponentSelector
+export ListComponentSelector
+export SubtypeComponentSelector
+export FilterComponentSelector
+export TopologyComponentSelector
+export subtype_to_string
+export component_to_qualified_string
+export select_components
+export get_components
+export get_subselectors
 #################################################################################
 # Imports
 
@@ -611,7 +623,17 @@ import InfrastructureSystems:
     get_raw_data_type,
     supports_time_series,
     supports_supplemental_attributes,
-    fast_deepcopy_system
+    fast_deepcopy_system,
+    ComponentSelector,
+    ComponentSelectorElement,
+    ComponentSelectorSet,
+    SingleComponentSelector,
+    ListComponentSelector,
+    SubtypeComponentSelector,
+    FilterComponentSelector,
+    component_to_qualified_string,
+    subtype_to_string,
+    NAME_DELIMETER
 import InfrastructureSystems:
     ValueCurve,
     InputOutputCurve,

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -503,7 +503,7 @@ export FilterComponentSelector
 export TopologyComponentSelector
 export subtype_to_string
 export component_to_qualified_string
-export select_components
+export make_selector
 export get_components
 export get_groups
 #################################################################################
@@ -635,7 +635,7 @@ import InfrastructureSystems:
     component_to_qualified_string,
     subtype_to_string,
     NAME_DELIMETER,
-    select_components
+    make_selector
 import InfrastructureSystems:
     ValueCurve,
     InputOutputCurve,

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -501,7 +501,9 @@ export DynamicallyGroupedComponentSelector
 export subtype_to_string
 export component_to_qualified_string
 export make_selector
+export rebuild_selector
 export get_groups
+export get_available_groups
 #################################################################################
 # Imports
 
@@ -631,7 +633,8 @@ import InfrastructureSystems:
     component_to_qualified_string,
     subtype_to_string,
     COMPONENT_NAME_DELIMITER,
-    make_selector
+    make_selector,
+    rebuild_selector
 import InfrastructureSystems:
     ValueCurve,
     InputOutputCurve,
@@ -780,5 +783,7 @@ include("models/serialization.jl")
 
 #Deprecated
 include("deprecated.jl")
+
+const GenericBattery = EnergyReservoirStorage
 
 end # module

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -625,11 +625,11 @@ import InfrastructureSystems:
     DynamicallyGroupedComponentSelector,
     NameComponentSelector,
     ListComponentSelector,
-    SubtypeComponentSelector,
+    TypeComponentSelector,
     FilterComponentSelector,
     component_to_qualified_string,
     subtype_to_string,
-    COMPONENT_NAME_DELIMETER,
+    COMPONENT_NAME_DELIMITER,
     make_selector,
     default_name
 import InfrastructureSystems:

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -492,7 +492,7 @@ export generate_struct_file
 export generate_struct_files
 export UnitSystem # internal.jl
 
-#ComponentSelector
+# ComponentSelector
 export ComponentSelector
 export ComponentSelectorElement
 export ComponentSelectorSet

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -492,6 +492,8 @@ export generate_struct_file
 export generate_struct_files
 export UnitSystem # internal.jl
 
+# TODO export ComponentSelector stuff
+
 #################################################################################
 # Imports
 
@@ -724,6 +726,7 @@ include("outages.jl")
 # Definitions of PowerSystem
 include("base.jl")
 include("subsystems.jl")
+include("component_selector.jl")
 include("data_format_conversions.jl")
 
 #Data Checks

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -786,6 +786,4 @@ include("models/serialization.jl")
 #Deprecated
 include("deprecated.jl")
 
-const GenericBattery = EnergyReservoirStorage
-
 end # module

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -344,6 +344,7 @@ export get_components
 export show_components
 export get_subcomponents
 export get_components_by_name
+export get_available_component
 export get_available_components
 export get_existing_device_types
 export get_existing_component_types
@@ -674,6 +675,9 @@ Subtypes should call InfrastructureSystemsInternal() by default, but also must
 provide a constructor that allows existing values to be deserialized.
 """
 abstract type Component <: IS.InfrastructureSystemsComponent end
+
+"Get whether this component is available for simulation or not."
+get_available(::Component) = true
 
 """ Supertype for "devices" (bus, line, etc.) """
 abstract type Device <: Component end

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -634,7 +634,7 @@ import InfrastructureSystems:
     FilterComponentSelector,
     component_to_qualified_string,
     subtype_to_string,
-    NAME_DELIMETER,
+    COMPONENT_NAME_DELIMETER,
     make_selector
 import InfrastructureSystems:
     ValueCurve,

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -506,7 +506,6 @@ export component_to_qualified_string
 export select_components
 export get_components
 export get_subselectors
-export NAME_DELIMETER
 #################################################################################
 # Imports
 

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -505,7 +505,7 @@ export subtype_to_string
 export component_to_qualified_string
 export select_components
 export get_components
-export get_subselectors
+export get_groups
 #################################################################################
 # Imports
 
@@ -627,13 +627,15 @@ import InfrastructureSystems:
     ComponentSelector,
     ComponentSelectorElement,
     ComponentSelectorSet,
+    DynamicallyGroupedComponentSelectorSet,
     SingleComponentSelector,
     ListComponentSelector,
     SubtypeComponentSelector,
     FilterComponentSelector,
     component_to_qualified_string,
     subtype_to_string,
-    NAME_DELIMETER
+    NAME_DELIMETER,
+    select_components
 import InfrastructureSystems:
     ValueCurve,
     InputOutputCurve,

--- a/src/base.jl
+++ b/src/base.jl
@@ -1262,9 +1262,6 @@ get_available_components(
         subsystem_name = subsystem_name,
     )
 
-get_available_components(selector::ComponentSelector, sys::System) =
-    filter(get_available, get_components(selector, sys))
-
 """
 Like [`get_component`](@ref) but also returns `nothing` if the component is not `get_available`.
 """

--- a/src/base.jl
+++ b/src/base.jl
@@ -99,7 +99,7 @@ sys = System(100.0; compression = CompressionSettings(
 sys = System(100.0; time_series_in_memory = true)
 ```
 """
-struct System <: IS.InfrastructureSystemsType
+struct System <: IS.SystemLike
     data::IS.SystemData
     frequency::Float64 # [Hz]
     bus_numbers::Set{Int}

--- a/src/base.jl
+++ b/src/base.jl
@@ -99,7 +99,7 @@ sys = System(100.0; compression = CompressionSettings(
 sys = System(100.0; time_series_in_memory = true)
 ```
 """
-struct System <: IS.SystemLike
+struct System <: IS.ComponentContainer
     data::IS.SystemData
     frequency::Float64 # [Hz]
     bus_numbers::Set{Int}
@@ -1220,55 +1220,10 @@ function get_components_by_name(
     return IS.get_components_by_name(T, sys.data, name)
 end
 
-"""
-Like `get_components` but returns only those components `c` for which `get_available(c)`.
-"""
-IS.get_available_components(
-    ::Type{T},
-    sys::System;
-    subsystem_name = nothing,
-) where {T <: Component} =
-    IS.get_components(get_available, T, sys; subsystem_name = subsystem_name)
-
-IS.get_available_components(
-    filter_func::Function,
-    ::Type{T},
-    sys::System;
-    subsystem_name = nothing,
-) where {T <: Component} =
-    IS.get_components(
-        x -> get_available(x) && filter_func(x),
-        T,
-        sys;
-        subsystem_name = subsystem_name,
-    )
-
-function _get_available_component(args...; kwargs...)
-    the_component = IS.get_component(args...; kwargs...)
-    return get_available(the_component) ? the_component : nothing
-end
-
-"""
-Like `get_component` but also returns `nothing` if the component is not `get_available`.
-"""
-IS.get_available_component(sys::System, args...; kwargs...) =
-    _get_available_component(sys, args...; kwargs...)
-
-IS.get_available_component(
-    arg1::Union{Base.UUID, String},
-    sys::System,
-    args...;
-    kwargs...,
-) =
-    _get_available_component(arg1, sys, args...; kwargs...)
-
-IS.get_available_component(
-    ::Type{T},
-    sys::System,
-    args...;
-    kwargs...,
-) where {T <: Component} =
-    _get_available_component(T, sys, args...; kwargs...)
+# PSY availability is a pure function of the component and the system is not needed; here we
+# implement the required IS.ComponentContainer interface
+IS.get_available(::System, component::Component) =
+    get_available(component)
 
 """
 Return true if the component is attached to the system.

--- a/src/base.jl
+++ b/src/base.jl
@@ -1238,14 +1238,39 @@ function get_components_by_name(
 end
 
 """
-Returns iterator of available components in a [`System`](@ref).
-
-`T` can be a concrete or abstract [`Component`](@ref) type from the [Type Tree](@ref)
-and must have the method `get_available` implemented.
-Call collect on the result if an array is desired.
+Like [`get_components`](@ref) but returns only those components `c` for which `get_available(c)`.
 """
-function get_available_components(::Type{T}, sys::System) where {T <: Component}
-    return get_components(get_available, T, sys)
+function get_available_components end
+
+get_available_components(
+    ::Type{T},
+    sys::System;
+    subsystem_name = nothing,
+) where {T <: Component} =
+    get_components(get_available, T, sys; subsystem_name = subsystem_name)
+
+get_available_components(
+    filter_func::Function,
+    ::Type{T},
+    sys::System;
+    subsystem_name = nothing,
+) where {T <: Component} =
+    get_components(
+        x -> get_available(x) && filter_func(x),
+        T,
+        sys;
+        subsystem_name = subsystem_name,
+    )
+
+get_available_components(selector::ComponentSelector, sys::System) =
+    filter(get_available, get_components(selector, sys))
+
+"""
+Like [`get_component`](@ref) but also returns `nothing` if the component is not `get_available`.
+"""
+function get_available_component(args...; kwargs...)
+    the_component = get_component(args...; kwargs...)
+    return get_available(the_component) ? the_component : nothing
 end
 
 """

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -153,13 +153,12 @@ function IS.get_components(
     scope_limiter = nothing,
 )
     agg_topology = get_component(selector.topology_type, sys, selector.topology_name)
-    isnothing(agg_topology) &&
-        (return Iterators.filter(x -> false, get_components(selector.component_type, sys)))
-    components = get_components_in_aggregation_topology(
-        selector.component_type,
-        sys,
-        agg_topology,
-    )
-    isnothing(scope_limiter) && (return components)
-    return Iterators.filter(scope_limiter, components)
+    isnothing(agg_topology) && return IS._make_empty_iterator(selector.component_type)
+
+    combo_filter = if isnothing(scope_limiter)
+        x -> is_component_in_aggregation_topology(x, agg_topology)
+    else
+        x -> scope_limiter(x) && is_component_in_aggregation_topology(x, agg_topology)
+    end
+    return get_components(combo_filter, selector.component_type, sys)
 end

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -8,6 +8,13 @@ get_components(e::ComponentSelector, sys::System; filterby = nothing) =
     IS.get_components(e, sys.data; filterby = filterby)
 
 """
+Get the component of the System that makes up the `ComponentSelectorElement`, `nothing` if
+there is none.
+"""
+get_component(e::ComponentSelectorElement, sys::System; filterby = nothing) =
+    IS.get_component(e, sys.data; filterby = filterby)
+
+"""
 Get the sub-selectors that make up the ComponentSelectorSet.
 """
 get_groups(e::ComponentSelectorSet, sys::System; filterby = nothing) =

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -97,7 +97,7 @@ make_selector(
     component_type::Type{<:Component},
     topology_type::Type{<:AggregationTopology},
     topology_name::AbstractString;
-    groupby::Union{Symbol, Function} = :all,
+    groupby::Union{Symbol, Function} = IS.DEFAULT_GROUPBY,
     name::Union{String, Nothing} = nothing,
 ) = TopologyComponentSelector(
     component_type,

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -113,3 +113,18 @@ function get_components(e::TopologyComponentSelector, sys::System; filterby = no
     isnothing(filterby) && (return components)
     return Iterators.filter(filterby, components)
 end
+
+# Unfortunately, there is no way to implement `in` for TopologyComponentSelector without a
+# System reference, since the aggregation topology reference is System-dependent
+function Base.in(
+    c::IS.InfrastructureSystemsComponent,
+    e::TopologyComponentSelector,
+    sys::System;
+    filterby = nothing,
+)
+    (!isnothing(filterby) && !filterby(c)) && return false
+    agg_topology = get_component(e.topology_subtype, sys, e.topology_name)
+    isnothing(agg_topology) && return false
+    return (c isa e.component_subtype) &&
+           is_component_in_aggregation_topology(c, agg_topology)
+end

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -26,7 +26,7 @@ get_groups(e::ComponentSelector, sys::System; filterby = nothing) =
 `PluralComponentSelector` represented by an `AggregationTopology` and a subtype of
 `Component`.
 """
-struct TopologyComponentSelector <: DynamicallyGroupedPluralComponentSelector
+struct TopologyComponentSelector <: DynamicallyGroupedComponentSelector
     component_subtype::Type{<:Component}
     topology_subtype::Type{<:AggregationTopology}
     topology_name::AbstractString
@@ -37,7 +37,7 @@ end
 # Construction
 """
 Make a `ComponentSelector` from an `AggregationTopology` and a type of component. Optionally
-provide a name for the `ComponentSelector`.
+provide a name and/or grouping behavior for the `ComponentSelector`.
 """
 make_selector(
     component_subtype::Type{<:Component},
@@ -50,7 +50,7 @@ make_selector(
     topology_subtype,
     topology_name,
     name,
-    groupby,
+    IS.validate_groupby(groupby),
 )
 
 # Naming

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -65,18 +65,3 @@ function get_components(e::TopologyComponentSelector, sys::System; filterby = no
     isnothing(filterby) && (return components)
     return Iterators.filter(filterby, components)
 end
-
-# Unfortunately, there is no way to implement `in` for TopologyComponentSelector without a
-# System reference, since the aggregation topology reference is System-dependent
-function Base.in(
-    c::IS.InfrastructureSystemsComponent,
-    e::TopologyComponentSelector,
-    sys::System;
-    filterby = nothing,
-)
-    (!isnothing(filterby) && !filterby(c)) && return false
-    agg_topology = get_component(e.topology_subtype, sys, e.topology_name)
-    isnothing(agg_topology) && return false
-    return (c isa e.component_subtype) &&
-           is_component_in_aggregation_topology(c, agg_topology)
-end

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -1,1 +1,49 @@
 # TODO: move parts of InfrastructureSystems.jl/src/component_selector.jl (which was copied directly from https://github.com/GabrielKS/PowerAnalytics.jl/tree/gks/entity-metric-redesign) to here
+
+# TopologyComponentSelector
+"ComponentSelectorSet represented by an AggregationTopology and a subtype of Component."
+struct TopologyComponentSelector <: ComponentSelectorSet
+    topology_subtype::Type{<:PSY.AggregationTopology}
+    topology_name::AbstractString
+    component_subtype::Type{<:Component}
+    name::Union{String, Nothing}
+end
+
+# Construction
+"""
+Make a ComponentSelector from an AggregationTopology and a subtype of Component. Optionally
+provide a name for the ComponentSelector.
+"""
+select_components(
+    topology_subtype::Type{<:PSY.AggregationTopology},
+    topology_name::AbstractString,
+    component_subtype::Type{<:Component},
+    name::Union{String, Nothing} = nothing,
+) = TopologyComponentSelector(
+    topology_subtype,
+    topology_name,
+    component_subtype,
+    name,
+)
+
+# Naming
+default_name(e::TopologyComponentSelector) =
+    component_to_qualified_string(e.topology_subtype, e.topology_name) * NAME_DELIMETER *
+    subtype_to_string(e.component_subtype)
+
+# Contents
+function get_subselectors(e::TopologyComponentSelector, sys::PSY.System)
+    return Iterators.map(select_components, get_components(e, sys))
+end
+
+function get_components(e::TopologyComponentSelector, sys::PSY.System)
+    agg_topology = get_component(e.topology_subtype, sys, e.topology_name)
+    return Iterators.filter(
+        get_available,
+        PSY.get_components_in_aggregation_topology(
+            e.component_subtype,
+            sys,
+            agg_topology,
+        ),
+    )
+end

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -5,6 +5,11 @@
 Get the components of the `System` that make up the `ComponentSelector`.
 """
 get_components(e::ComponentSelector, sys::System; filterby = nothing) =
+    IS.get_components(e, sys; filterby = filterby)
+
+# This would be cleaner if `IS.get_components === PSY.get_components` (see
+# https://github.com/NREL-Sienna/InfrastructureSystems.jl/issues/388)
+IS.get_components(e::ComponentSelector, sys::System; filterby = nothing) =
     IS.get_components(e, sys.data; filterby = filterby)
 
 """
@@ -60,13 +65,7 @@ IS.default_name(e::TopologyComponentSelector) =
     subtype_to_string(e.component_subtype)
 
 # Contents
-# We need to define `IS.get_components` to fit the interface (in particular, because the
-# common implementation of `get_groups` calls this) even though TopologyComponentSelector
-# won't work with IS system analogues. We also need to define `PSY.get_components` below
-# because the default implementation above won't work for this case. This would all be
-# easier if `IS.get_components === PSY.get_components` (see
-# https://github.com/NREL-Sienna/InfrastructureSystems.jl/issues/388).
-function IS.get_components(e::TopologyComponentSelector, sys; filterby = nothing)
+function IS.get_components(e::TopologyComponentSelector, sys::System; filterby = nothing)
     agg_topology = get_component(e.topology_subtype, sys, e.topology_name)
     isnothing(agg_topology) &&
         (return Iterators.filter(x -> false, get_components(e.component_subtype, sys)))
@@ -78,6 +77,3 @@ function IS.get_components(e::TopologyComponentSelector, sys; filterby = nothing
     isnothing(filterby) && (return components)
     return Iterators.filter(filterby, components)
 end
-
-get_components(e::TopologyComponentSelector, sys::System; filterby = nothing) =
-    IS.get_components(e, sys; filterby = filterby)

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -2,10 +2,24 @@
 # InfrastructureSystemsComponent with Component and SystemData with System
 
 """
+    get_components(selector, sys; filterby = nothing)
 Get the components of the `System` that make up the `ComponentSelector`.
+ - `filterby`: optional filter function to apply after evaluating the `ComponentSelector`
 """
 get_components(selector::ComponentSelector, sys::System; filterby = nothing) =
     IS.get_components(selector, sys; filterby = filterby)
+
+"""
+    get_components(filterby, selector, sys)
+Get the components of the `System` that make up the `ComponentSelector`.
+ - `filterby`: optional filter function to apply after evaluating the `ComponentSelector`
+"""
+get_components(
+    filterby::Union{Nothing, Function},
+    selector::ComponentSelector,
+    sys::System,
+) =
+    get_components(selector, sys; filterby = filterby)
 
 # This would be cleaner if `IS.get_components === PSY.get_components` (see
 # https://github.com/NREL-Sienna/InfrastructureSystems.jl/issues/388)
@@ -13,17 +27,45 @@ IS.get_components(selector::ComponentSelector, sys::System; filterby = nothing) 
     IS.get_components(selector, sys.data; filterby = filterby)
 
 """
+    get_component(selector, sys; filterby = nothing)
 Get the component of the `System` that makes up the `SingularComponentSelector`; `nothing`
 if there is none.
+ - `filterby`: optional filter function to apply after evaluating the `ComponentSelector`
 """
 get_component(selector::SingularComponentSelector, sys::System; filterby = nothing) =
     IS.get_component(selector, sys.data; filterby = filterby)
 
 """
+    get_component(filterby, selector, sys)
+Get the component of the `System` that makes up the `SingularComponentSelector`; `nothing`
+if there is none.
+ - `filterby`: optional filter function to apply after evaluating the `ComponentSelector`
+"""
+get_component(
+    filterby::Union{Nothing, Function},
+    selector::SingularComponentSelector,
+    sys::System,
+) =
+    get_component(selector, sys; filterby = filterby)
+
+IS.get_component(selector::ComponentSelector, sys::System; filterby = nothing) =
+    IS.get_component(selector, sys.data; filterby = filterby)
+
+"""
+    get_groups(selector, sys; filterby = nothing)
 Get the groups that make up the `ComponentSelector`.
+ - `filterby`: optional filter function to apply after evaluating the `ComponentSelector`
 """
 get_groups(selector::ComponentSelector, sys::System; filterby = nothing) =
     IS.get_groups(selector, sys; filterby = filterby)
+
+"""
+    get_groups(filterby, selector, sys)
+Get the groups that make up the `ComponentSelector`.
+ - `filterby`: optional filter function to apply after evaluating the `ComponentSelector`
+"""
+get_groups(filterby::Union{Nothing, Function}, selector::ComponentSelector, sys::System) =
+    get_groups(selector, sys; filterby = filterby)
 
 # TopologyComponentSelector
 # This one is wholly implemented in PowerSystems rather than in InfrastructureSystems because it depends on `PSY.AggregationTopology`

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -37,8 +37,8 @@ function get_components(e::ListComponentSelector, sys::System)
     )
 end
 
-function get_subselectors(e::ListComponentSelector)
-    return IS.get_subselectors(e)
+function get_subselectors(e::ListComponentSelector, sys::System)
+    return e.content
 end
 
 # SubtypeComponentSelector

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -28,7 +28,7 @@ end
 Make a ComponentSelector from an AggregationTopology and a subtype of Component. Optionally
 provide a name for the ComponentSelector.
 """
-select_components(
+make_selector(
     component_subtype::Type{<:Component},
     topology_subtype::Type{<:AggregationTopology},
     topology_name::AbstractString,
@@ -47,7 +47,7 @@ IS.default_name(e::TopologyComponentSelector) =
 
 # Contents
 function get_subselectors(e::TopologyComponentSelector, sys::System; filterby = nothing)
-    return Iterators.map(select_components, get_components(e, sys; filterby = filterby))
+    return Iterators.map(make_selector, get_components(e, sys; filterby = filterby))
 end
 
 function get_components(e::TopologyComponentSelector, sys::System; filterby = nothing)

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -2,70 +2,74 @@
 # InfrastructureSystemsComponent with Component and SystemData with System
 
 """
-    get_components(selector, sys; filterby = nothing)
+    get_components(selector, sys; scope_limiter = nothing)
 Get the components of the `System` that make up the `ComponentSelector`.
- - `filterby`: optional filter function to apply after evaluating the `ComponentSelector`
+ - `scope_limiter`: optional filter function to limit the scope of components under consideration (e.g., pass `get_available` to only evaluate the `ComponentSelector` on components marked available)
 """
-get_components(selector::ComponentSelector, sys::System; filterby = nothing) =
-    IS.get_components(selector, sys; filterby = filterby)
+get_components(selector::ComponentSelector, sys::System; scope_limiter = nothing) =
+    IS.get_components(selector, sys; scope_limiter = scope_limiter)
 
 """
-    get_components(filterby, selector, sys)
+    get_components(scope_limiter, selector, sys)
 Get the components of the `System` that make up the `ComponentSelector`.
- - `filterby`: optional filter function to apply after evaluating the `ComponentSelector`
+ - `scope_limiter`: optional filter function to limit the scope of components under consideration (e.g., pass `get_available` to only evaluate the `ComponentSelector` on components marked available)
 """
 get_components(
-    filterby::Union{Nothing, Function},
+    scope_limiter::Union{Nothing, Function},
     selector::ComponentSelector,
     sys::System,
 ) =
-    get_components(selector, sys; filterby = filterby)
+    get_components(selector, sys; scope_limiter = scope_limiter)
 
 # This would be cleaner if `IS.get_components === PSY.get_components` (see
 # https://github.com/NREL-Sienna/InfrastructureSystems.jl/issues/388)
-IS.get_components(selector::ComponentSelector, sys::System; filterby = nothing) =
-    IS.get_components(selector, sys.data; filterby = filterby)
+IS.get_components(selector::ComponentSelector, sys::System; scope_limiter = nothing) =
+    IS.get_components(selector, sys.data; scope_limiter = scope_limiter)
 
 """
-    get_component(selector, sys; filterby = nothing)
+    get_component(selector, sys; scope_limiter = nothing)
 Get the component of the `System` that makes up the `SingularComponentSelector`; `nothing`
 if there is none.
- - `filterby`: optional filter function to apply after evaluating the `ComponentSelector`
+ - `scope_limiter`: optional filter function to limit the scope of components under consideration (e.g., pass `get_available` to only evaluate the `ComponentSelector` on components marked available)
 """
-get_component(selector::SingularComponentSelector, sys::System; filterby = nothing) =
-    IS.get_component(selector, sys.data; filterby = filterby)
+get_component(selector::SingularComponentSelector, sys::System; scope_limiter = nothing) =
+    IS.get_component(selector, sys.data; scope_limiter = scope_limiter)
 
 """
-    get_component(filterby, selector, sys)
+    get_component(scope_limiter, selector, sys)
 Get the component of the `System` that makes up the `SingularComponentSelector`; `nothing`
 if there is none.
- - `filterby`: optional filter function to apply after evaluating the `ComponentSelector`
+ - `scope_limiter`: optional filter function to limit the scope of components under consideration (e.g., pass `get_available` to only evaluate the `ComponentSelector` on components marked available)
 """
 get_component(
-    filterby::Union{Nothing, Function},
+    scope_limiter::Union{Nothing, Function},
     selector::SingularComponentSelector,
     sys::System,
 ) =
-    get_component(selector, sys; filterby = filterby)
+    get_component(selector, sys; scope_limiter = scope_limiter)
 
-IS.get_component(selector::ComponentSelector, sys::System; filterby = nothing) =
-    IS.get_component(selector, sys.data; filterby = filterby)
+IS.get_component(selector::ComponentSelector, sys::System; scope_limiter = nothing) =
+    IS.get_component(selector, sys.data; scope_limiter = scope_limiter)
 
 """
-    get_groups(selector, sys; filterby = nothing)
+    get_groups(selector, sys; scope_limiter = nothing)
 Get the groups that make up the `ComponentSelector`.
- - `filterby`: optional filter function to apply after evaluating the `ComponentSelector`
+ - `scope_limiter`: optional filter function to limit the scope of components under consideration (e.g., pass `get_available` to only evaluate the `ComponentSelector` on components marked available)
 """
-get_groups(selector::ComponentSelector, sys::System; filterby = nothing) =
-    IS.get_groups(selector, sys; filterby = filterby)
+get_groups(selector::ComponentSelector, sys::System; scope_limiter = nothing) =
+    IS.get_groups(selector, sys; scope_limiter = scope_limiter)
 
 """
-    get_groups(filterby, selector, sys)
+    get_groups(scope_limiter, selector, sys)
 Get the groups that make up the `ComponentSelector`.
- - `filterby`: optional filter function to apply after evaluating the `ComponentSelector`
+ - `scope_limiter`: optional filter function to limit the scope of components under consideration (e.g., pass `get_available` to only evaluate the `ComponentSelector` on components marked available)
 """
-get_groups(filterby::Union{Nothing, Function}, selector::ComponentSelector, sys::System) =
-    get_groups(selector, sys; filterby = filterby)
+get_groups(
+    scope_limiter::Union{Nothing, Function},
+    selector::ComponentSelector,
+    sys::System,
+) =
+    get_groups(selector, sys; scope_limiter = scope_limiter)
 
 # TopologyComponentSelector
 # This one is wholly implemented in PowerSystems rather than in InfrastructureSystems because it depends on `PSY.AggregationTopology`
@@ -109,7 +113,7 @@ IS.default_name(selector::TopologyComponentSelector) =
 function IS.get_components(
     selector::TopologyComponentSelector,
     sys::System;
-    filterby = nothing,
+    scope_limiter = nothing,
 )
     agg_topology = get_component(selector.topology_type, sys, selector.topology_name)
     isnothing(agg_topology) &&
@@ -119,6 +123,6 @@ function IS.get_components(
         sys,
         agg_topology,
     )
-    isnothing(filterby) && (return components)
-    return Iterators.filter(filterby, components)
+    isnothing(scope_limiter) && (return components)
+    return Iterators.filter(scope_limiter, components)
 end

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -21,6 +21,7 @@ struct TopologyComponentSelector <: DynamicallyGroupedComponentSelectorSet
     topology_subtype::Type{<:AggregationTopology}
     topology_name::AbstractString
     name::Union{String, Nothing}
+    groupby::Union{Symbol, Function}  # TODO add validation
 end
 
 # Construction
@@ -31,13 +32,15 @@ provide a name for the ComponentSelector.
 make_selector(
     component_subtype::Type{<:Component},
     topology_subtype::Type{<:AggregationTopology},
-    topology_name::AbstractString,
+    topology_name::AbstractString;
     name::Union{String, Nothing} = nothing,
+    groupby::Union{Symbol, Function} = :all
 ) = TopologyComponentSelector(
     component_subtype,
     topology_subtype,
     topology_name,
     name,
+    groupby,
 )
 
 # Naming

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -16,7 +16,7 @@ System with the given Component's subtype and name.
 """
 select_components(component_ref::Component, name::Union{String, Nothing} = nothing) =
     IS.select_components(component_ref, name)
- 
+
 # Contents
 function get_components(e::SingleComponentSelector, sys::System)
     com = get_component(e.component_subtype, sys, e.component_name)

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -10,67 +10,16 @@ get_components(e::ComponentSelector, sys::System; filterby = nothing) =
 """
 Get the sub-selectors that make up the ComponentSelectorSet.
 """
-get_subselectors(e::ComponentSelectorSet, sys::System; filterby = nothing) =
-    IS.get_subselectors(e, sys.data; filterby = filterby)
-
-# SingleComponentSelector
-# Construction
-"""
-Make a ComponentSelector pointing to a Component with the given subtype and name. Optionally
-provide a name for the ComponentSelector.
-"""
-select_components(
-    component_subtype::Type{<:Component},
-    component_name::AbstractString,
-    name::Union{String, Nothing} = nothing,
-) = IS.select_components(component_subtype, component_name, name)
-
-"""
-Construct a ComponentSelector from a Component reference, pointing to Components in any
-System with the given Component's subtype and name.
-"""
-select_components(component_ref::Component, name::Union{String, Nothing} = nothing) =
-    IS.select_components(component_ref, name)
-
-# ListComponentSelector
-# Construction
-select_components(content::ComponentSelector...; name::Union{String, Nothing} = nothing) =
-    IS.select_components(content...; name)
-
-# SubtypeComponentSelector
-# Construction
-"""
-Make a ComponentSelector from a subtype of Component. Optionally provide a name for the
-ComponentSelectorSet.
-"""
-# name needs to be a kwarg to disambiguate from SingleComponentSelector's select_components
-select_components(
-    component_subtype::Type{<:Component};
-    name::Union{String, Nothing} = nothing,
-) = IS.select_components(component_subtype; name)
-
-# FilterComponentSelector
-# Construction
-"""
-Make a ComponentSelector from a filter function and a subtype of Component. Optionally
-provide a name for the ComponentSelector. The filter function must accept instances of
-component_subtype as a sole argument and return a Bool.
-"""
-function select_components(
-    filter_fn::Function,
-    component_subtype::Type{<:Component},
-    name::Union{String, Nothing} = nothing,
-)
-    return IS.select_components(filter_fn, component_subtype, name)
-end
+get_groups(e::ComponentSelectorSet, sys::System; filterby = nothing) =
+    IS.get_groups(e, sys.data; filterby = filterby)
 
 # TopologyComponentSelector
 # This one is wholly implemented in PowerSystems rather than in IS because it depends on AggregationTopology
 "ComponentSelectorSet represented by an AggregationTopology and a subtype of Component."
-struct TopologyComponentSelector <: ComponentSelectorSet
+struct TopologyComponentSelector <: DynamicallyGroupedComponentSelectorSet
+    component_subtype::Type{<:Component}
     topology_subtype::Type{<:AggregationTopology}
     topology_name::AbstractString
-    component_subtype::Type{<:Component}
     name::Union{String, Nothing}
 end
 
@@ -80,14 +29,14 @@ Make a ComponentSelector from an AggregationTopology and a subtype of Component.
 provide a name for the ComponentSelector.
 """
 select_components(
+    component_subtype::Type{<:Component},
     topology_subtype::Type{<:AggregationTopology},
     topology_name::AbstractString,
-    component_subtype::Type{<:Component},
     name::Union{String, Nothing} = nothing,
 ) = TopologyComponentSelector(
+    component_subtype,
     topology_subtype,
     topology_name,
-    component_subtype,
     name,
 )
 

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -1,0 +1,1 @@
+# TODO: move parts of InfrastructureSystems.jl/src/component_selector.jl (which was copied directly from https://github.com/GabrielKS/PowerAnalytics.jl/tree/gks/entity-metric-redesign) to here

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -24,6 +24,10 @@ function get_components(e::SingleComponentSelector, sys::System)
 end
 
 # ListComponentSelector
+#Construction
+select_components(content::ComponentSelector...; name::Union{String, Nothing} = nothing) =
+    IS.select_components(content...; name)
+
 #Contents
 function get_components(e::ListComponentSelector, sys::System)
     sub_components = Iterators.map(x -> get_components(x, sys), e.content)
@@ -31,6 +35,10 @@ function get_components(e::ListComponentSelector, sys::System)
         get_available,
         Iterators.flatten(sub_components),
     )
+end
+
+function get_subselectors(e::ListComponentSelector)
+    return IS.get_subselectors(e)
 end
 
 # SubtypeComponentSelector
@@ -43,15 +51,15 @@ ComponentSelectorSet.
 select_components(
     component_subtype::Type{<:Component};
     name::Union{String, Nothing} = nothing,
-) = IS.select_components(component_subtype, name)
+) = IS.select_components(component_subtype; name)
 
 # Contents
 function get_subselectors(e::SubtypeComponentSelector, sys::System)
-    return IS.get_subselectors(e, sys.data)
+    return Iterators.map(select_components, get_components(e, sys))
 end
 
 function get_components(e::SubtypeComponentSelector, sys::System)
-    return Iterators.filter(get_available, get_components(e.component_subtype, sys.data))
+    return Iterators.filter(get_available, IS.get_components(e.component_subtype, sys.data))
 end
 
 # FilterComponentSelector
@@ -71,7 +79,7 @@ end
 
 # Contents
 function get_subselectors(e::FilterComponentSelector, sys::System)
-    return IS.get_subselectors(e, sys.data)
+    return Iterators.map(select_components, get_components(e, sys))
 end
 
 function get_components(e::FilterComponentSelector, sys::System)

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -2,28 +2,31 @@
 # InfrastructureSystemsComponent with Component and SystemData with System
 
 """
-Get the components of the System that make up the ComponentSelector.
+Get the components of the `System` that make up the `ComponentSelector`.
 """
 get_components(e::ComponentSelector, sys::System; filterby = nothing) =
     IS.get_components(e, sys.data; filterby = filterby)
 
 """
-Get the component of the System that makes up the `ComponentSelectorElement`, `nothing` if
-there is none.
+Get the component of the `System` that makes up the `SingularComponentSelector`; `nothing`
+if there is none.
 """
-get_component(e::ComponentSelectorElement, sys::System; filterby = nothing) =
+get_component(e::SingularComponentSelector, sys::System; filterby = nothing) =
     IS.get_component(e, sys.data; filterby = filterby)
 
 """
-Get the sub-selectors that make up the ComponentSelectorSet.
+Get the groups that make up the `ComponentSelector`.
 """
-get_groups(e::ComponentSelectorSet, sys::System; filterby = nothing) =
+get_groups(e::ComponentSelector, sys::System; filterby = nothing) =
     IS.get_groups(e, sys.data; filterby = filterby)
 
 # TopologyComponentSelector
-# This one is wholly implemented in PowerSystems rather than in IS because it depends on AggregationTopology
-"ComponentSelectorSet represented by an AggregationTopology and a subtype of Component."
-struct TopologyComponentSelector <: DynamicallyGroupedComponentSelectorSet
+# This one is wholly implemented in PowerSystems rather than in InfrastructureSystems because it depends on `PSY.AggregationTopology`
+"""
+`PluralComponentSelector` represented by an `AggregationTopology` and a subtype of
+`Component`.
+"""
+struct TopologyComponentSelector <: DynamicallyGroupedPluralComponentSelector
     component_subtype::Type{<:Component}
     topology_subtype::Type{<:AggregationTopology}
     topology_name::AbstractString
@@ -33,15 +36,15 @@ end
 
 # Construction
 """
-Make a ComponentSelector from an AggregationTopology and a subtype of Component. Optionally
-provide a name for the ComponentSelector.
+Make a `ComponentSelector` from an `AggregationTopology` and a type of component. Optionally
+provide a name for the `ComponentSelector`.
 """
 make_selector(
     component_subtype::Type{<:Component},
     topology_subtype::Type{<:AggregationTopology},
     topology_name::AbstractString;
     name::Union{String, Nothing} = nothing,
-    groupby::Union{Symbol, Function} = :all
+    groupby::Union{Symbol, Function} = :all,
 ) = TopologyComponentSelector(
     component_subtype,
     topology_subtype,
@@ -53,13 +56,10 @@ make_selector(
 # Naming
 IS.default_name(e::TopologyComponentSelector) =
     component_to_qualified_string(e.topology_subtype, e.topology_name) *
-    COMPONENT_NAME_DELIMETER * subtype_to_string(e.component_subtype)
+    COMPONENT_NAME_DELIMETER *
+    subtype_to_string(e.component_subtype)
 
 # Contents
-function get_subselectors(e::TopologyComponentSelector, sys::System; filterby = nothing)
-    return Iterators.map(make_selector, get_components(e, sys; filterby = filterby))
-end
-
 function get_components(e::TopologyComponentSelector, sys::System; filterby = nothing)
     agg_topology = get_component(e.topology_subtype, sys, e.topology_name)
     isnothing(agg_topology) &&

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -4,14 +4,14 @@
 """
 Get the components of the System that make up the ComponentSelector.
 """
-get_components(e::ComponentSelector, sys::System) =
-    IS.get_components(e, sys.data)
+get_components(e::ComponentSelector, sys::System; filterby = nothing) =
+    IS.get_components(e, sys.data; filterby = filterby)
 
 """
 Get the sub-selectors that make up the ComponentSelectorSet.
 """
-get_subselectors(e::ComponentSelectorSet, sys::System) =
-    IS.get_subselectors(e, sys.data)
+get_subselectors(e::ComponentSelectorSet, sys::System; filterby = nothing) =
+    IS.get_subselectors(e, sys.data; filterby = filterby)
 
 # SingleComponentSelector
 # Construction
@@ -97,15 +97,19 @@ IS.default_name(e::TopologyComponentSelector) =
     subtype_to_string(e.component_subtype)
 
 # Contents
-function get_subselectors(e::TopologyComponentSelector, sys::System)
-    return Iterators.map(select_components, get_components(e, sys))
+function get_subselectors(e::TopologyComponentSelector, sys::System; filterby = nothing)
+    return Iterators.map(select_components, get_components(e, sys; filterby = filterby))
 end
 
-function get_components(e::TopologyComponentSelector, sys::System)
+function get_components(e::TopologyComponentSelector, sys::System; filterby = nothing)
     agg_topology = get_component(e.topology_subtype, sys, e.topology_name)
-    return get_components_in_aggregation_topology(
+    isnothing(agg_topology) &&
+        (return Iterators.filter(x -> false, get_components(e.component_subtype, sys)))
+    components = get_components_in_aggregation_topology(
         e.component_subtype,
         sys,
         agg_topology,
     )
+    isnothing(filterby) && (return components)
+    return Iterators.filter(filterby, components)
 end

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -162,3 +162,10 @@ function IS.get_components(
     end
     return get_components(combo_filter, selector.component_type, sys)
 end
+
+# Alternative functions for only available components
+get_available_components(selector::ComponentSelector, sys::System) =
+    get_components(selector, sys; scope_limiter = get_available)
+
+get_available_groups(selector::ComponentSelector, sys::System) =
+    get_groups(selector, sys; scope_limiter = get_available)

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -1,9 +1,90 @@
-# TODO: move parts of InfrastructureSystems.jl/src/component_selector.jl (which was copied directly from https://github.com/GabrielKS/PowerAnalytics.jl/tree/gks/entity-metric-redesign) to here
+# SingleComponentSelector
+# Construction
+"""
+Make a ComponentSelector pointing to a Component with the given subtype and name. Optionally
+provide a name for the ComponentSelector.
+"""
+select_components(
+    component_subtype::Type{<:Component},
+    component_name::AbstractString,
+    name::Union{String, Nothing} = nothing,
+) = IS.select_components(component_subtype, component_name, name)
+
+"""
+Construct a ComponentSelector from a Component reference, pointing to Components in any
+System with the given Component's subtype and name.
+"""
+select_components(component_ref::Component, name::Union{String, Nothing} = nothing) =
+    IS.select_components(component_ref, name)
+ 
+# Contents
+function get_components(e::SingleComponentSelector, sys::System)
+    com = get_component(e.component_subtype, sys, e.component_name)
+    return (com === nothing || !get_available(com)) ? [] : [com]
+end
+
+# ListComponentSelector
+#Contents
+function get_components(e::ListComponentSelector, sys::System)
+    sub_components = Iterators.map(x -> get_components(x, sys), e.content)
+    return Iterators.filter(
+        get_available,
+        Iterators.flatten(sub_components),
+    )
+end
+
+# SubtypeComponentSelector
+# Construction
+"""
+Make a ComponentSelector from a subtype of Component. Optionally provide a name for the
+ComponentSelectorSet.
+"""
+# name needs to be a kwarg to disambiguate from SingleComponentSelector's select_components
+select_components(
+    component_subtype::Type{<:Component};
+    name::Union{String, Nothing} = nothing,
+) = IS.select_components(component_subtype, name)
+
+# Contents
+function get_subselectors(e::SubtypeComponentSelector, sys::System)
+    return IS.get_subselectors(e, sys.data)
+end
+
+function get_components(e::SubtypeComponentSelector, sys::System)
+    return Iterators.filter(get_available, get_components(e.component_subtype, sys.data))
+end
+
+# FilterComponentSelector
+# Construction
+"""
+Make a ComponentSelector from a filter function and a subtype of Component. Optionally
+provide a name for the ComponentSelector. The filter function must accept instances of
+component_subtype as a sole argument and return a Bool.
+"""
+function select_components(
+    filter_fn::Function,
+    component_subtype::Type{<:Component},
+    name::Union{String, Nothing} = nothing,
+)
+    return IS.select_components(filter_fn, component_subtype, name)
+end
+
+# Contents
+function get_subselectors(e::FilterComponentSelector, sys::System)
+    return IS.get_subselectors(e, sys.data)
+end
+
+function get_components(e::FilterComponentSelector, sys::System)
+    return Iterators.filter(
+        get_available,
+        IS.get_components(e.filter_fn, e.component_subtype, sys.data),
+    )
+end
 
 # TopologyComponentSelector
 "ComponentSelectorSet represented by an AggregationTopology and a subtype of Component."
 struct TopologyComponentSelector <: ComponentSelectorSet
-    topology_subtype::Type{<:PSY.AggregationTopology}
+    topology_subtype::Type{<:AggregationTopology}
     topology_name::AbstractString
     component_subtype::Type{<:Component}
     name::Union{String, Nothing}
@@ -15,7 +96,7 @@ Make a ComponentSelector from an AggregationTopology and a subtype of Component.
 provide a name for the ComponentSelector.
 """
 select_components(
-    topology_subtype::Type{<:PSY.AggregationTopology},
+    topology_subtype::Type{<:AggregationTopology},
     topology_name::AbstractString,
     component_subtype::Type{<:Component},
     name::Union{String, Nothing} = nothing,
@@ -31,16 +112,18 @@ default_name(e::TopologyComponentSelector) =
     component_to_qualified_string(e.topology_subtype, e.topology_name) * NAME_DELIMETER *
     subtype_to_string(e.component_subtype)
 
+get_name(e::TopologyComponentSelector) = (e.name !== nothing) ? e.name : default_name(e)
+
 # Contents
-function get_subselectors(e::TopologyComponentSelector, sys::PSY.System)
+function get_subselectors(e::TopologyComponentSelector, sys::System)
     return Iterators.map(select_components, get_components(e, sys))
 end
 
-function get_components(e::TopologyComponentSelector, sys::PSY.System)
+function get_components(e::TopologyComponentSelector, sys::System)
     agg_topology = get_component(e.topology_subtype, sys, e.topology_name)
     return Iterators.filter(
         get_available,
-        PSY.get_components_in_aggregation_topology(
+        get_components_in_aggregation_topology(
             e.component_subtype,
             sys,
             agg_topology,

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -52,8 +52,8 @@ make_selector(
 
 # Naming
 IS.default_name(e::TopologyComponentSelector) =
-    component_to_qualified_string(e.topology_subtype, e.topology_name) * NAME_DELIMETER *
-    subtype_to_string(e.component_subtype)
+    component_to_qualified_string(e.topology_subtype, e.topology_name) *
+    COMPONENT_NAME_DELIMETER * subtype_to_string(e.component_subtype)
 
 # Contents
 function get_subselectors(e::TopologyComponentSelector, sys::System; filterby = nothing)

--- a/src/get_components_interface.jl
+++ b/src/get_components_interface.jl
@@ -68,11 +68,22 @@ get_components(
     IS.get_components(filter_func, T, sys; subsystem_name = subsystem_name)
 
 """
+    get_components(scope_limiter, selector, sys)
+Get the components of the `System` that make up the `ComponentSelector`.
+"""
+get_components(
+    scope_limiter::Union{Function, Nothing},
+    selector::ComponentSelector,
+    sys::System,
+) =
+    IS.get_components(scope_limiter, selector, sys)
+
+"""
     get_components(selector, sys)
 Get the components of the `System` that make up the `ComponentSelector`.
 """
-get_components(selector::ComponentSelector, sys::System; kwargs...) =
-    IS.get_components(selector, sys; kwargs...)
+get_components(selector::ComponentSelector, sys::System) =
+    IS.get_components(selector, sys)
 
 # get_component
 """
@@ -94,12 +105,24 @@ get_component(::Type{T}, sys::System, name::AbstractString) where {T <: Componen
     IS.get_component(T, sys, name)
 
 """
+    get_component(scope_limiter, selector, sys)
+Get the component of the `System` that makes up the `SingularComponentSelector`; `nothing`
+if there is none.
+"""
+get_component(
+    scope_limiter::Union{Function, Nothing},
+    selector::SingularComponentSelector,
+    sys::System,
+) =
+    IS.get_component(scope_limiter, selector, sys)
+
+"""
     get_component(selector, sys)
 Get the component of the `System` that makes up the `SingularComponentSelector`; `nothing`
 if there is none.
 """
-get_component(selector::SingularComponentSelector, sys::System; kwargs...) =
-    IS.get_component(selector, sys; kwargs...)
+get_component(selector::SingularComponentSelector, sys::System) =
+    IS.get_component(selector, sys)
 
 # get_available_components
 """
@@ -122,6 +145,17 @@ get_available_components(
     subsystem_name = nothing,
 ) where {T <: Component} =
     IS.get_available_components(filter_func, T, sys; subsystem_name = subsystem_name)
+
+"""
+    get_available_components(scope_limiter, selector, sys)
+Get the available components of the collection that make up the `ComponentSelector`.
+"""
+get_available_components(
+    scope_limiter::Union{Function, Nothing},
+    selector::ComponentSelector,
+    sys::System,
+) =
+    IS.get_available_components(scope_limiter, selector::ComponentSelector, sys::System)
 
 """
     get_available_components(selector, sys)
@@ -148,22 +182,51 @@ get_available_component(::Type{T}, sys::System, args...; kwargs...) where {T <: 
 Like [`get_component`](@ref) but also returns `nothing` if the component is not `get_available`.
 """
 get_available_component(
-    arg1::IS.SingularComponentSelector,
+    scope_limiter::Union{Function, Nothing},
+    selector::IS.SingularComponentSelector,
     sys::System,
-    args...;
-    kwargs...,
 ) =
-    IS.get_available_component(arg1, sys, args...; kwargs...)
+    IS.get_available_component(scope_limiter, selector, sys)
+
+"""
+Like [`get_component`](@ref) but also returns `nothing` if the component is not `get_available`.
+"""
+get_available_component(
+    selector::IS.SingularComponentSelector,
+    sys::System,
+) =
+    IS.get_available_component(selector, sys)
 
 # get_groups
+"""
+    get_groups(scope_limiter, selector, sys)
+Get the groups that make up the `ComponentSelector`.
+"""
+get_groups(
+    scope_limiter::Union{Function, Nothing},
+    selector::ComponentSelector,
+    sys::System,
+) =
+    IS.get_groups(scope_limiter, selector, sys)
+
 """
     get_groups(selector, sys)
 Get the groups that make up the `ComponentSelector`.
 """
-get_groups(selector::ComponentSelector, sys::System; kwargs...) =
-    IS.get_groups(selector, sys; kwargs...)
+get_groups(selector::ComponentSelector, sys::System) =
+    IS.get_groups(selector, sys)
 
 # get_available_groups
+"""
+Like [`get_groups`](@ref) but as if the `System` only contained its available components.
+"""
+get_available_groups(
+    scope_limiter::Union{Function, Nothing},
+    selector::ComponentSelector,
+    sys::System,
+) =
+    IS.get_available_groups(scope_limiter, selector, sys)
+
 """
 Like [`get_groups`](@ref) but as if the `System` only contained its available components.
 """

--- a/src/get_components_interface.jl
+++ b/src/get_components_interface.jl
@@ -1,0 +1,167 @@
+# The longstanding status quo in Sienna has been for `PSY.get_components` to be distinct
+# from `IS.get_components`, mostly so that PowerSystems users aren't confused by all the
+# InfrastructureSystems methods. This lack of a unified interface on "things with
+# components" has begun to cause problems, most notably for ComponentSelector. Therefore,
+# the new plan is:
+#   1. Implement, wherever relevant, methods of the IS `get_components`-like functions
+#      listed below on PSY data structures.
+#   2. Add, in this file, methods of the PSY `get_components`-like functions that purely
+#      redirect to the IS versions and have the documentation PSY users should see. Never
+#      add actual functionality in these PSY methods; they must only redirect to the IS
+#      versions.
+#   3. In downstream Sienna packages like PowerSimulations that seek to add their own
+#      `get_components`-like methods on their own data structures that show up in
+#      user-friendly documentation, do the same thing: add the implementation in the IS
+#      method and add a PSY method that purely redirects.
+#   4. Internal code designed to work with all "things with components" should use the IS
+#      functions, not the PSY ones.
+
+# This design preserves the simplified interface presented to the casual PSY user while
+# allowing for better cross-package integration behind the scenes. It also enables a quick
+# switch to a design where we no longer maintain two versions of each `get_components`-like
+# function at the cost of slightly more confusing documentation -- simply import the IS
+# versions into PowerSystems and delete this file (and analogous redirects in downstream
+# packages). See https://github.com/NREL-Sienna/InfrastructureSystems.jl/issues/388.
+
+# Here is the current list of "`get_components`-like functions" to which this plan applies:
+#  - `get_components`
+#  - `get_component`
+#  - `get_available_components`
+#  - `get_available_component`
+#  - `get_groups`
+#  - `get_available_groups`
+
+# get_components
+"""
+Returns an iterator of components. T can be concrete or abstract.
+Call collect on the result if an array is desired.
+
+# Examples
+```julia
+iter = PowerSystems.get_components(ThermalStandard, sys)
+iter = PowerSystems.get_components(Generator, sys)
+iter = PowerSystems.get_components(x -> PowerSystems.get_available(x), Generator, sys)
+thermal_gens = get_components(ThermalStandard, sys) do gen
+    get_available(gen)
+end
+generators = collect(PowerSystems.get_components(Generator, sys))
+
+```
+
+See also: [`iterate_components`](@ref)
+"""
+get_components(::Type{T}, sys::System; subsystem_name = nothing) where {T <: Component} =
+    IS.get_components(T, sys; subsystem_name = subsystem_name)
+
+"""
+    get_components(selector, sys)
+Get the components of the `System` that make up the `ComponentSelector`.
+"""
+get_components(selector::ComponentSelector, sys::System; kwargs...) =
+    IS.get_components(selector, sys; kwargs...)
+
+"""
+Return a vector of components that are attached to the supplemental attribute.
+"""
+get_components(sys::System, attribute::SupplementalAttribute) =
+    IS.get_components(sys, attribute)
+
+get_components(
+    filter_func::Function,
+    ::Type{T},
+    sys::System;
+    subsystem_name = nothing,
+) where {T <: Component} =
+    IS.get_components(filter_func, T, sys; subsystem_name = subsystem_name)
+
+# get_component
+"""
+Get the component by UUID.
+"""
+get_component(sys::System, uuid::Base.UUID) = IS.get_component(sys, uuid)
+get_component(sys::System, uuid::String) = IS.get_component(sys, Base.UUID(uuid))
+
+"""
+Get the component of type T with name. Returns nothing if no component matches. If T is an abstract
+type then the names of components across all subtypes of T must be unique.
+
+See [`get_components_by_name`](@ref) for abstract types with non-unique names across subtypes.
+
+Throws ArgumentError if T is not a concrete type and there is more than one component with
+    requested name
+"""
+get_component(::Type{T}, sys::System, name::AbstractString) where {T <: Component} =
+    IS.get_component(T, sys, name)
+
+"""
+    get_component(selector, sys)
+Get the component of the `System` that makes up the `SingularComponentSelector`; `nothing`
+if there is none.
+"""
+get_component(selector::SingularComponentSelector, sys::System; kwargs...) =
+    IS.get_component(selector, sys; kwargs...)
+
+# get_available_components
+"""
+Like [`get_components`](@ref) but returns only those components `c` for which `get_available(c)`.
+"""
+get_available_components(
+    ::Type{T},
+    sys::System;
+    subsystem_name = nothing,
+) where {T <: Component} =
+    IS.get_available_components(T, sys; subsystem_name = subsystem_name)
+
+get_available_components(
+    filter_func::Function,
+    ::Type{T},
+    sys::System;
+    subsystem_name = nothing,
+) where {T <: Component} =
+    IS.get_available_components(filter_func, T, sys; subsystem_name = subsystem_name)
+
+"""
+    get_available_components(selector, sys)
+Get the available components of the collection that make up the `ComponentSelector`.
+"""
+get_available_components(selector::ComponentSelector, sys::System) =
+    IS.get_available_components(selector::ComponentSelector, sys::System)
+
+# get_available_component
+"""
+Like [`get_component`](@ref) but also returns `nothing` if the component is not `get_available`.
+"""
+get_available_component(sys::System, args...; kwargs...) =
+    IS.get_available_component(sys, args...; kwargs...)
+
+"""
+Like [`get_component`](@ref) but also returns `nothing` if the component is not `get_available`.
+"""
+get_available_component(::Type{T}, sys::System, args...; kwargs...) where {T <: Component} =
+    IS.get_available_component(T, sys, args...; kwargs...)
+
+"""
+Like [`get_component`](@ref) but also returns `nothing` if the component is not `get_available`.
+"""
+get_available_component(
+    arg1::IS.SingularComponentSelector,
+    sys::System,
+    args...;
+    kwargs...,
+) =
+    IS.get_available_component(arg1, sys, args...; kwargs...)
+
+# get_groups
+"""
+    get_groups(selector, sys)
+Get the groups that make up the `ComponentSelector`.
+"""
+get_groups(selector::ComponentSelector, sys::System; kwargs...) =
+    IS.get_groups(selector, sys; kwargs...)
+
+# get_available_groups
+"""
+Like [`get_groups`](@ref) but as if the `System` only contained its available components.
+"""
+get_available_groups(selector::ComponentSelector, sys::System) =
+    IS.get_available_groups(selector, sys)

--- a/src/get_components_interface.jl
+++ b/src/get_components_interface.jl
@@ -33,22 +33,25 @@
 
 # get_components
 """
-Returns an iterator of components. T can be concrete or abstract.
+Return an iterator of components of a given `Type` from a [`System`](@ref).
+
+`T` can be a concrete or abstract [`Component`](@ref) type from the [Type Tree](@ref).
 Call collect on the result if an array is desired.
 
 # Examples
 ```julia
-iter = PowerSystems.get_components(ThermalStandard, sys)
-iter = PowerSystems.get_components(Generator, sys)
-iter = PowerSystems.get_components(x -> PowerSystems.get_status(x), ThermalStandard, sys)
-thermal_gens = get_components(ThermalStandard, sys) do gen
-    get_status(gen)
-end
-generators = collect(PowerSystems.get_components(Generator, sys))
-
+iter = get_components(ThermalStandard, sys)
+iter = get_components(Generator, sys)
+generators = collect(get_components(Generator, sys))
 ```
 
-See also: [`iterate_components`](@ref)
+See also: [`iterate_components`](@ref), [`get_components` with a filter](@ref get_components(
+    filter_func::Function,
+    ::Type{T},
+    sys::System;
+    subsystem_name = nothing,
+) where {T <: Component}),
+[`get_available_components`](@ref), [`get_buses`](@ref)
 """
 get_components(::Type{T}, sys::System; subsystem_name = nothing) where {T <: Component} =
     IS.get_components(T, sys; subsystem_name = subsystem_name)
@@ -59,7 +62,27 @@ Return a vector of components that are attached to the supplemental attribute.
 get_components(sys::System, attribute::SupplementalAttribute) =
     IS.get_components(sys, attribute)
 
-"Variant of `get_components` that applies a filter function."
+"""
+Return an iterator of components of a given `Type` from a [`System`](@ref), using an
+additional filter
+
+`T` can be a concrete or abstract [`Component`](@ref) type from the [Type Tree](@ref).
+Call collect on the result if an array is desired.
+
+# Examples
+```julia
+iter_coal = get_components(x -> get_fuel(x) == ThermalFuels.COAL, Generator, sys)
+pv_gens =
+    collect(get_components(x -> get_prime_mover_type(x) == PrimeMovers.PVe, Generator, sys))
+```
+
+See also: [`get_components`](@ref get_components(
+    ::Type{T},
+    sys::System;
+    subsystem_name = nothing,
+) where {T <: Component}), [`get_available_components`](@ref),
+[`get_buses`](@ref)
+"""
 get_components(
     filter_func::Function,
     ::Type{T},

--- a/src/get_components_interface.jl
+++ b/src/get_components_interface.jl
@@ -59,6 +59,7 @@ Return a vector of components that are attached to the supplemental attribute.
 get_components(sys::System, attribute::SupplementalAttribute) =
     IS.get_components(sys, attribute)
 
+"Variant of `get_components` that applies a filter function."
 get_components(
     filter_func::Function,
     ::Type{T},
@@ -68,7 +69,6 @@ get_components(
     IS.get_components(filter_func, T, sys; subsystem_name = subsystem_name)
 
 """
-    get_components(scope_limiter, selector, sys)
 Get the components of the `System` that make up the `ComponentSelector`.
 """
 get_components(
@@ -79,7 +79,6 @@ get_components(
     IS.get_components(scope_limiter, selector, sys)
 
 """
-    get_components(selector, sys)
 Get the components of the `System` that make up the `ComponentSelector`.
 """
 get_components(selector::ComponentSelector, sys::System) =
@@ -105,7 +104,6 @@ get_component(::Type{T}, sys::System, name::AbstractString) where {T <: Componen
     IS.get_component(T, sys, name)
 
 """
-    get_component(scope_limiter, selector, sys)
 Get the component of the `System` that makes up the `SingularComponentSelector`; `nothing`
 if there is none.
 """
@@ -117,7 +115,6 @@ get_component(
     IS.get_component(scope_limiter, selector, sys)
 
 """
-    get_component(selector, sys)
 Get the component of the `System` that makes up the `SingularComponentSelector`; `nothing`
 if there is none.
 """
@@ -147,7 +144,6 @@ get_available_components(
     IS.get_available_components(filter_func, T, sys; subsystem_name = subsystem_name)
 
 """
-    get_available_components(scope_limiter, selector, sys)
 Get the available components of the collection that make up the `ComponentSelector`.
 """
 get_available_components(
@@ -158,7 +154,6 @@ get_available_components(
     IS.get_available_components(scope_limiter, selector::ComponentSelector, sys::System)
 
 """
-    get_available_components(selector, sys)
 Get the available components of the collection that make up the `ComponentSelector`.
 """
 get_available_components(selector::ComponentSelector, sys::System) =
@@ -199,7 +194,6 @@ get_available_component(
 
 # get_groups
 """
-    get_groups(scope_limiter, selector, sys)
 Get the groups that make up the `ComponentSelector`.
 """
 get_groups(
@@ -210,7 +204,6 @@ get_groups(
     IS.get_groups(scope_limiter, selector, sys)
 
 """
-    get_groups(selector, sys)
 Get the groups that make up the `ComponentSelector`.
 """
 get_groups(selector::ComponentSelector, sys::System) =

--- a/src/get_components_interface.jl
+++ b/src/get_components_interface.jl
@@ -40,9 +40,9 @@ Call collect on the result if an array is desired.
 ```julia
 iter = PowerSystems.get_components(ThermalStandard, sys)
 iter = PowerSystems.get_components(Generator, sys)
-iter = PowerSystems.get_components(x -> PowerSystems.get_available(x), Generator, sys)
+iter = PowerSystems.get_components(x -> PowerSystems.get_status(x), ThermalStandard, sys)
 thermal_gens = get_components(ThermalStandard, sys) do gen
-    get_available(gen)
+    get_status(gen)
 end
 generators = collect(PowerSystems.get_components(Generator, sys))
 
@@ -52,13 +52,6 @@ See also: [`iterate_components`](@ref)
 """
 get_components(::Type{T}, sys::System; subsystem_name = nothing) where {T <: Component} =
     IS.get_components(T, sys; subsystem_name = subsystem_name)
-
-"""
-    get_components(selector, sys)
-Get the components of the `System` that make up the `ComponentSelector`.
-"""
-get_components(selector::ComponentSelector, sys::System; kwargs...) =
-    IS.get_components(selector, sys; kwargs...)
 
 """
 Return a vector of components that are attached to the supplemental attribute.
@@ -74,12 +67,19 @@ get_components(
 ) where {T <: Component} =
     IS.get_components(filter_func, T, sys; subsystem_name = subsystem_name)
 
+"""
+    get_components(selector, sys)
+Get the components of the `System` that make up the `ComponentSelector`.
+"""
+get_components(selector::ComponentSelector, sys::System; kwargs...) =
+    IS.get_components(selector, sys; kwargs...)
+
 # get_component
 """
 Get the component by UUID.
 """
 get_component(sys::System, uuid::Base.UUID) = IS.get_component(sys, uuid)
-get_component(sys::System, uuid::String) = IS.get_component(sys, Base.UUID(uuid))
+get_component(sys::System, uuid::String) = IS.get_component(sys, uuid)
 
 """
 Get the component of type T with name. Returns nothing if no component matches. If T is an abstract
@@ -112,6 +112,9 @@ get_available_components(
 ) where {T <: Component} =
     IS.get_available_components(T, sys; subsystem_name = subsystem_name)
 
+get_available_components(sys::System, attribute::SupplementalAttribute) =
+    IS.get_available_components(sys, attribute)
+
 get_available_components(
     filter_func::Function,
     ::Type{T},
@@ -129,10 +132,11 @@ get_available_components(selector::ComponentSelector, sys::System) =
 
 # get_available_component
 """
-Like [`get_component`](@ref) but also returns `nothing` if the component is not `get_available`.
+Get the available component by UUID.
 """
-get_available_component(sys::System, args...; kwargs...) =
-    IS.get_available_component(sys, args...; kwargs...)
+get_available_component(sys::System, uuid::Base.UUID) =
+    IS.get_available_component(sys, uuid)
+get_available_component(sys::System, uuid::String) = IS.get_available_component(sys, uuid)
 
 """
 Like [`get_component`](@ref) but also returns `nothing` if the component is not `get_available`.

--- a/src/get_components_interface.jl
+++ b/src/get_components_interface.jl
@@ -92,7 +92,9 @@ get_components(
     IS.get_components(filter_func, T, sys; subsystem_name = subsystem_name)
 
 """
-Get the components of the `System` that make up the `ComponentSelector`.
+Get the components of the `System` that make up the `ComponentSelector`. Optionally specify
+a filter function `scope_limiter` as the first argument to limit the components that should
+be considered.
 """
 get_components(
     scope_limiter::Union{Function, Nothing},
@@ -128,7 +130,8 @@ get_component(::Type{T}, sys::System, name::AbstractString) where {T <: Componen
 
 """
 Get the component of the `System` that makes up the `SingularComponentSelector`; `nothing`
-if there is none.
+if there is none. Optionally specify a filter function `scope_limiter` as the first argument
+to limit the components that should be considered.
 """
 get_component(
     scope_limiter::Union{Function, Nothing},
@@ -168,6 +171,8 @@ get_available_components(
 
 """
 Get the available components of the collection that make up the `ComponentSelector`.
+Optionally specify a filter function `scope_limiter` as the first argument to further limit
+the components that should be considered.
 """
 get_available_components(
     scope_limiter::Union{Function, Nothing},
@@ -197,7 +202,9 @@ get_available_component(::Type{T}, sys::System, args...; kwargs...) where {T <: 
     IS.get_available_component(T, sys, args...; kwargs...)
 
 """
-Like [`get_component`](@ref) but also returns `nothing` if the component is not `get_available`.
+Like [`get_component`](@ref) but also returns `nothing` if the component is not
+`get_available`. Optionally specify a filter function `scope_limiter` as the first argument
+to limit the components that should be considered.
 """
 get_available_component(
     scope_limiter::Union{Function, Nothing},
@@ -217,7 +224,8 @@ get_available_component(
 
 # get_groups
 """
-Get the groups that make up the `ComponentSelector`.
+Get the groups that make up the `ComponentSelector`. Optionally specify a filter function
+`scope_limiter` as the first argument to limit the components that should be considered.
 """
 get_groups(
     scope_limiter::Union{Function, Nothing},
@@ -235,6 +243,8 @@ get_groups(selector::ComponentSelector, sys::System) =
 # get_available_groups
 """
 Like [`get_groups`](@ref) but as if the `System` only contained its available components.
+Optionally specify a filter function `scope_limiter` as the first argument to limit the
+components that should be considered.
 """
 get_available_groups(
     scope_limiter::Union{Function, Nothing},

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -4,7 +4,7 @@ function Base.summary(sys::System)
     return "System (base power $(get_base_power(sys)))"
 end
 
-function Base.show(io::IO, ::MIME"text/plain", sys::System)
+function Base.show(io::IO, sys::System)
     show_system_table(io, sys; backend = Val(:auto))
 
     if IS.get_num_components(sys.data.components) > 0
@@ -15,6 +15,8 @@ function Base.show(io::IO, ::MIME"text/plain", sys::System)
     IS.show_time_series_data(io, sys.data; backend = Val(:auto))
     return
 end
+
+Base.show(io::IO, ::MIME"text/plain", sys::System) = show(io, sys)
 
 function Base.show(io::IO, ::MIME"text/html", sys::System)
     show_system_table(io, sys; backend = Val(:html), standalone = false)

--- a/test/common.jl
+++ b/test/common.jl
@@ -7,6 +7,8 @@ mutable struct TestRenDevice <: RenewableGen
     name::String
 end
 
+struct NonexistentComponent <: StaticInjection end
+
 """Return the first component of type component_type that matches the name of other."""
 function get_component_by_name(sys::System, component_type, other::Component)
     for component in get_components(component_type, sys)

--- a/test/test_component_selector.jl
+++ b/test/test_component_selector.jl
@@ -70,9 +70,9 @@ end
     @test get_component(ThermalStandard, test_sys, "Solitude") in the_components
     @test get_component(RenewableDispatch, test_sys, "WindBusA") in the_components
 
-    @test collect(get_subselectors(select_components(), test_sys)) ==
+    @test collect(get_subselectors(select_components())) ==
           Vector{ComponentSelector}()
-    the_subselectors = collect(get_subselectors(test_list_ent, test_sys))
+    the_subselectors = collect(get_subselectors(test_list_ent))
     @test length(the_subselectors) == 2
     @test comp_ent_1 in the_subselectors
     @test comp_ent_2 in the_subselectors

--- a/test/test_component_selector.jl
+++ b/test/test_component_selector.jl
@@ -27,9 +27,9 @@ end
           named_test_gen_ent
 
     # Construction
-    @test select_components(ThermalStandard, "Solitude") == test_gen_ent
-    @test select_components(ThermalStandard, "Solitude", "SolGen") == named_test_gen_ent
-    @test select_components(gen_solitude) == test_gen_ent
+    @test make_selector(ThermalStandard, "Solitude") == test_gen_ent
+    @test make_selector(ThermalStandard, "Solitude", "SolGen") == named_test_gen_ent
+    @test make_selector(gen_solitude) == test_gen_ent
 
     # Naming
     @test get_name(test_gen_ent) == "ThermalStandard__Solitude"
@@ -37,25 +37,25 @@ end
     @test IS.default_name(test_gen_ent) == "ThermalStandard__Solitude"
 
     # Contents
-    @test collect(get_components(select_components(NonexistentComponent, ""), test_sys)) ==
+    @test collect(get_components(make_selector(NonexistentComponent, ""), test_sys)) ==
           Vector{Component}()
     the_components = collect(get_components(test_gen_ent, test_sys))
     @test length(the_components) == 1
     @test typeof(first(the_components)) == ThermalStandard
     @test get_name(first(the_components)) == "Solitude"
     @test collect(
-        get_components(select_components(gen_sundance), test_sys; filterby = get_available),
+        get_components(make_selector(gen_sundance), test_sys; filterby = get_available),
     ) ==
           Vector{Component}()
 
     @test gen_solitude in test_gen_ent
     @test !(gen_sundance in test_gen_ent)
-    @test !in(gen_sundance, select_components(gen_sundance); filterby = get_available)
+    @test !in(gen_sundance, make_selector(gen_sundance); filterby = get_available)
 end
 
 @testset "Test ListComponentSelector" begin
-    comp_ent_1 = select_components(ThermalStandard, "Sundance")
-    comp_ent_2 = select_components(RenewableDispatch, "WindBusA")
+    comp_ent_1 = make_selector(ThermalStandard, "Sundance")
+    comp_ent_2 = make_selector(RenewableDispatch, "WindBusA")
     test_list_ent = ListComponentSelector((comp_ent_1, comp_ent_2), nothing)
     named_test_list_ent = ListComponentSelector((comp_ent_1, comp_ent_2), "TwoComps")
 
@@ -65,8 +65,8 @@ end
           named_test_list_ent
 
     # Construction
-    @test select_components(comp_ent_1, comp_ent_2;) == test_list_ent
-    @test select_components(comp_ent_1, comp_ent_2; name = "TwoComps") ==
+    @test make_selector(comp_ent_1, comp_ent_2;) == test_list_ent
+    @test make_selector(comp_ent_1, comp_ent_2; name = "TwoComps") ==
           named_test_list_ent
 
     # Naming
@@ -75,7 +75,7 @@ end
     @test get_name(named_test_list_ent) == "TwoComps"
 
     # Contents
-    @test collect(get_components(select_components(), test_sys)) == Vector{Component}()
+    @test collect(get_components(make_selector(), test_sys)) == Vector{Component}()
     the_components = collect(get_components(test_list_ent, test_sys))
     @test length(the_components) == 2
     @test gen_sundance in the_components
@@ -84,7 +84,7 @@ end
         gen_sundance in
         collect(get_components(test_list_ent, test_sys; filterby = get_available)))
 
-    @test collect(get_subselectors(select_components(), test_sys)) ==
+    @test collect(get_subselectors(make_selector(), test_sys)) ==
           Vector{ComponentSelector}()
     the_subselectors = collect(get_subselectors(test_list_ent, test_sys))
     @test length(the_subselectors) == 2
@@ -105,8 +105,8 @@ end
     @test SubtypeComponentSelector(ThermalStandard, "Thermals") == named_test_sub_ent
 
     # Construction
-    @test select_components(ThermalStandard) == test_sub_ent
-    @test select_components(ThermalStandard; name = "Thermals") == named_test_sub_ent
+    @test make_selector(ThermalStandard) == test_sub_ent
+    @test make_selector(ThermalStandard; name = "Thermals") == named_test_sub_ent
 
     # Naming
     @test get_name(test_sub_ent) == "ThermalStandard"
@@ -116,7 +116,7 @@ end
     # Contents
     answer = sort_name!(get_components(ThermalStandard, test_sys))
 
-    @test collect(get_components(select_components(NonexistentComponent), test_sys)) ==
+    @test collect(get_components(make_selector(NonexistentComponent), test_sys)) ==
           Vector{Component}()
     the_components = sort_name!(get_components(test_sub_ent, test_sys))
     @test all(the_components .== answer)
@@ -124,10 +124,10 @@ end
         gen_sundance in
         collect(get_components(test_sub_ent, test_sys; filterby = get_available)))
 
-    @test collect(get_subselectors(select_components(NonexistentComponent), test_sys)) ==
+    @test collect(get_subselectors(make_selector(NonexistentComponent), test_sys)) ==
           Vector{ComponentSelectorElement}()
     the_subselectors = sort_name!(get_subselectors(test_sub_ent, test_sys))
-    @test all(the_subselectors .== select_components.(answer))
+    @test all(the_subselectors .== make_selector.(answer))
     @test !(
         gen_sundance in
         collect(get_subselectors(test_sub_ent, test_sys; filterby = get_available)))
@@ -151,20 +151,20 @@ end
           test_topo_ent2
 
     # Construction
-    @test select_components(Area, "1", ThermalStandard) == test_topo_ent1
-    @test select_components(LoadZone, "2", StaticInjection, "Zone_2") == test_topo_ent2
+    @test make_selector(Area, "1", ThermalStandard) == test_topo_ent1
+    @test make_selector(LoadZone, "2", StaticInjection, "Zone_2") == test_topo_ent2
 
     # Naming
     @test get_name(test_topo_ent1) == "Area__1__ThermalStandard"
     @test get_name(test_topo_ent2) == "Zone_2"
 
     # Contents
-    empty_topo_ent = select_components(Area, "1", NonexistentComponent)
+    empty_topo_ent = make_selector(Area, "1", NonexistentComponent)
     @test collect(get_components(empty_topo_ent, test_sys2)) == Vector{Component}()
     @test collect(get_subselectors(empty_topo_ent, test_sys2)) ==
           Vector{ComponentSelectorElement}()
 
-    nonexistent_topo_ent = select_components(Area, "NonexistentArea", ThermalStandard)
+    nonexistent_topo_ent = make_selector(Area, "NonexistentArea", ThermalStandard)
     @test collect(get_components(nonexistent_topo_ent, test_sys2)) == Vector{Component}()
     @test collect(get_subselectors(nonexistent_topo_ent, test_sys2)) ==
           Vector{ComponentSelectorElement}()
@@ -191,7 +191,7 @@ end
         @test length(collect(get_components(ent, test_sys2; filterby = x -> false))) == 0
 
         the_subselectors = get_subselectors(ent, test_sys2)
-        @test all(sort_name!(the_subselectors) .== sort_name!(select_components.(ans)))
+        @test all(sort_name!(the_subselectors) .== sort_name!(make_selector.(ans)))
         @test Set(collect(get_subselectors(ent, test_sys2; filterby = x -> true))) ==
               Set(the_subselectors)
         @test length(collect(get_subselectors(ent, test_sys2; filterby = x -> false))) == 0
@@ -203,7 +203,7 @@ end
         gen_sundance2 in
         collect(get_components(test_topo_ent1, test_sys2; filterby = get_available)))
     @test !(
-        select_components(gen_sundance2) in
+        make_selector(gen_sundance2) in
         collect(get_subselectors(test_topo_ent1, test_sys2; filterby = get_available)))
 
     @test in(gen_sundance2, test_topo_ent1, test_sys2)
@@ -224,15 +224,15 @@ end
           named_test_filter_ent
 
     # Construction
-    @test select_components(starts_with_s, ThermalStandard) == test_filter_ent
-    @test select_components(starts_with_s, ThermalStandard, "ThermStartsWithS") ==
+    @test make_selector(starts_with_s, ThermalStandard) == test_filter_ent
+    @test make_selector(starts_with_s, ThermalStandard, "ThermStartsWithS") ==
           named_test_filter_ent
     bad_input_fn(x::Integer) = true  # Should always fail to construct
     specific_input_fn(x::RenewableDispatch) = true  # Should require compatible subtype
-    @test_throws ArgumentError select_components(bad_input_fn, ThermalStandard)
-    @test_throws ArgumentError select_components(specific_input_fn, Component)
-    @test_throws ArgumentError select_components(specific_input_fn, ThermalStandard)
-    @test select_components(specific_input_fn, RenewableDispatch) isa Any  # test absence of error
+    @test_throws ArgumentError make_selector(bad_input_fn, ThermalStandard)
+    @test_throws ArgumentError make_selector(specific_input_fn, Component)
+    @test_throws ArgumentError make_selector(specific_input_fn, ThermalStandard)
+    @test make_selector(specific_input_fn, RenewableDispatch) isa Any  # test absence of error
 
     # Naming
     @test get_name(test_filter_ent) == "starts_with_s__ThermalStandard"
@@ -242,10 +242,10 @@ end
     answer = filter(starts_with_s, collect(get_components(ThermalStandard, test_sys)))
 
     @test collect(
-        get_components(select_components(x -> true, NonexistentComponent), test_sys),
+        get_components(make_selector(x -> true, NonexistentComponent), test_sys),
     ) ==
           Vector{Component}()
-    @test collect(get_components(select_components(x -> false, Component), test_sys)) ==
+    @test collect(get_components(make_selector(x -> false, Component), test_sys)) ==
           Vector{Component}()
     @test all(collect(get_components(test_filter_ent, test_sys)) .== answer)
     @test !(
@@ -253,17 +253,17 @@ end
         collect(get_components(test_filter_ent, test_sys; filterby = get_available)))
 
     @test collect(
-        get_subselectors(select_components(x -> true, NonexistentComponent), test_sys),
+        get_subselectors(make_selector(x -> true, NonexistentComponent), test_sys),
     ) == Vector{ComponentSelectorElement}()
-    @test collect(get_subselectors(select_components(x -> false, Component), test_sys)) ==
+    @test collect(get_subselectors(make_selector(x -> false, Component), test_sys)) ==
           Vector{ComponentSelectorElement}()
     @test all(
-        collect(get_subselectors(test_filter_ent, test_sys)) .== select_components.(answer),
+        collect(get_subselectors(test_filter_ent, test_sys)) .== make_selector.(answer),
     )
     @test !(
         gen_sundance in
         collect(get_components(test_filter_ent, test_sys; filterby = get_available)))
     @test !(
-        select_components(gen_sundance) in
+        make_selector(gen_sundance) in
         collect(get_subselectors(test_filter_ent, test_sys; filterby = get_available)))
 end

--- a/test/test_component_selector.jl
+++ b/test/test_component_selector.jl
@@ -60,6 +60,8 @@ end
         ),
     ) ==
           Vector{Component}()
+    @test collect(get_available_components(make_selector(gen_sundance), test_sys)) ==
+          Vector{Component}()
     @test IS.get_component(test_gen_ent, test_sys; scope_limiter = x -> true) ==
           first(the_components)
     @test isnothing(IS.get_component(test_gen_ent, test_sys; scope_limiter = x -> false))
@@ -126,6 +128,7 @@ end
     @test !(
         gen_sundance in
         collect(get_components_rt(test_sub_ent, test_sys; scope_limiter = get_available)))
+    @test !(gen_sundance in collect(get_available_components(test_sub_ent, test_sys)))
 
     # Grouping inherits from `DynamicallyGroupedComponentSelector` and is tested elsewhere
 end
@@ -228,12 +231,7 @@ end
         collect(
             get_components_rt(test_filter_ent, test_sys; scope_limiter = get_available),
         ))
-
-    @test !(
-        gen_sundance in
-        collect(
-            get_components_rt(test_filter_ent, test_sys; scope_limiter = get_available),
-        ))
+    @test !(gen_sundance in collect(get_available_components(test_filter_ent, test_sys)))
 end
 
 @testset "Test DynamicallyGroupedComponentSelector grouping" begin
@@ -277,6 +275,14 @@ end
                     groupby = x -> length(get_name(x))), test_sys),
         ),
     ) == 3
+
+    # Test proper handling of availability
+    sel = make_selector(ThermalStandard; groupby = :each)
+    @test length(get_groups(sel, test_sys2)) >
+          length(get_available_groups(sel, test_sys2)) ==
+          length(get_available_components(sel, test_sys2)) ==
+          length(get_available_components(ThermalStandard, test_sys2)) ==
+          length(get_components(get_available, ThermalStandard, test_sys2))
 end
 
 @testset "Test alternative interfaces" begin

--- a/test/test_component_selector.jl
+++ b/test/test_component_selector.jl
@@ -9,6 +9,9 @@ sort_name(x) = sort(collect(x); by = get_name)
     @test subtype_to_string(ThermalStandard) == "ThermalStandard"
     @test component_to_qualified_string(ThermalStandard, "Solitude") ==
           "ThermalStandard__Solitude"
+    @test component_to_qualified_string(
+        PSY.get_component(ThermalStandard, test_sys, "Solitude")) ==
+          "ThermalStandard__Solitude"
 end
 
 @testset "Test SingleComponentSelector" begin

--- a/test/test_component_selector.jl
+++ b/test/test_component_selector.jl
@@ -1,0 +1,211 @@
+# TODO copied directly from https://github.com/GabrielKS/PowerAnalytics.jl/tree/gks/entity-metric-redesign, will require major refactor
+
+test_sys = PSB.build_system(PSB.PSITestSystems, "c_sys5_all_components")
+test_sys2 = PSB.build_system(PSB.PSISystems, "5_bus_hydro_uc_sys")
+
+struct NonexistentComponent <: StaticInjection end  # <: Component
+
+sort_name(x) = sort(collect(x); by = get_name)
+
+@testset "Test helper functions" begin
+    @test subtype_to_string(ThermalStandard) == "ThermalStandard"
+    @test component_to_qualified_string(ThermalStandard, "Solitude") ==
+          "ThermalStandard__Solitude"
+    @test component_to_qualified_string(
+        PSY.get_component(ThermalStandard, test_sys, "Solitude"),
+    ) == "ThermalStandard__Solitude"
+end
+
+@testset "Test SingleComponentSelector" begin
+    test_gen_ent = PA.SingleComponentSelector(ThermalStandard, "Solitude", nothing)
+    named_test_gen_ent = PA.SingleComponentSelector(ThermalStandard, "Solitude", "SolGen")
+
+    # Equality
+    @test PA.SingleComponentSelector(ThermalStandard, "Solitude", nothing) == test_gen_ent
+    @test PA.SingleComponentSelector(ThermalStandard, "Solitude", "SolGen") ==
+          named_test_gen_ent
+
+    # Construction
+    @test select_components(ThermalStandard, "Solitude") == test_gen_ent
+    @test select_components(ThermalStandard, "Solitude", "SolGen") == named_test_gen_ent
+    @test select_components(get_component(ThermalStandard, test_sys, "Solitude")) ==
+          test_gen_ent
+
+    # Naming
+    @test get_name(test_gen_ent) == "ThermalStandard__Solitude"
+    @test get_name(named_test_gen_ent) == "SolGen"
+    @test default_name(test_gen_ent) == "ThermalStandard__Solitude"
+
+    # Contents
+    @test collect(get_components(select_components(NonexistentComponent, ""), test_sys)) ==
+          Vector{Component}()
+    the_components = collect(get_components(test_gen_ent, test_sys))
+    @test length(the_components) == 1
+    @test typeof(first(the_components)) == ThermalStandard
+    @test get_name(first(the_components)) == "Solitude"
+end
+
+@testset "Test ListComponentSelector" begin
+    comp_ent_1 = select_components(ThermalStandard, "Solitude")
+    comp_ent_2 = select_components(RenewableDispatch, "WindBusA")
+    test_list_ent = PA.ListComponentSelector((comp_ent_1, comp_ent_2), nothing)
+    named_test_list_ent = PA.ListComponentSelector((comp_ent_1, comp_ent_2), "TwoComps")
+
+    # Equality
+    @test PA.ListComponentSelector((comp_ent_1, comp_ent_2), nothing) == test_list_ent
+    @test PA.ListComponentSelector((comp_ent_1, comp_ent_2), "TwoComps") ==
+          named_test_list_ent
+
+    # Construction
+    @test select_components(comp_ent_1, comp_ent_2) == test_list_ent
+    @test select_components(comp_ent_1, comp_ent_2; name = "TwoComps") ==
+          named_test_list_ent
+
+    # Naming
+    @test get_name(test_list_ent) ==
+          "[ThermalStandard__Solitude, RenewableDispatch__WindBusA]"
+    @test get_name(named_test_list_ent) == "TwoComps"
+
+    # Contents
+    @test collect(get_components(select_components(), test_sys)) == Vector{Component}()
+    the_components = collect(get_components(test_list_ent, test_sys))
+    @test length(the_components) == 2
+    @test get_component(ThermalStandard, test_sys, "Solitude") in the_components
+    @test get_component(RenewableDispatch, test_sys, "WindBusA") in the_components
+
+    @test collect(get_subselectors(select_components(), test_sys)) ==
+          Vector{ComponentSelector}()
+    the_subselectors = collect(get_subselectors(test_list_ent, test_sys))
+    @test length(the_subselectors) == 2
+    @test comp_ent_1 in the_subselectors
+    @test comp_ent_2 in the_subselectors
+end
+
+@testset "Test SubtypeComponentSelector" begin
+    test_sub_ent = PA.SubtypeComponentSelector(ThermalStandard, nothing)
+    named_test_sub_ent = PA.SubtypeComponentSelector(ThermalStandard, "Thermals")
+
+    # Equality
+    @test PA.SubtypeComponentSelector(ThermalStandard, nothing) == test_sub_ent
+    @test PA.SubtypeComponentSelector(ThermalStandard, "Thermals") == named_test_sub_ent
+
+    # Construction
+    @test select_components(ThermalStandard) == test_sub_ent
+    @test select_components(ThermalStandard; name = "Thermals") == named_test_sub_ent
+
+    # Naming
+    @test get_name(test_sub_ent) == "ThermalStandard"
+    @test get_name(named_test_sub_ent) == "Thermals"
+    @test default_name(test_sub_ent) == "ThermalStandard"
+
+    # Contents
+    answer = sort_name(get_components(ThermalStandard, test_sys))
+
+    @test collect(get_components(select_components(NonexistentComponent), test_sys)) ==
+          Vector{Component}()
+    the_components = sort_name(get_components(test_sub_ent, test_sys))
+    @test all(the_components .== answer)
+
+    @test collect(get_subselectors(select_components(NonexistentComponent), test_sys)) ==
+          Vector{ComponentSelectorElement}()
+    the_subselectors = sort_name(get_subselectors(test_sub_ent, test_sys))
+    @test all(the_subselectors .== select_components.(answer))
+end
+
+@testset "Test TopologyComponentSelector" begin
+    topo1 = get_component(Area, test_sys2, "1")
+    topo2 = get_component(LoadZone, test_sys2, "2")
+    test_topo_ent1 = PA.TopologyComponentSelector(Area, "1", ThermalStandard, nothing)
+    test_topo_ent2 = PA.TopologyComponentSelector(LoadZone, "2", StaticInjection, "Zone_2")
+    @assert (test_topo_ent1 !== nothing) && (test_topo_ent2 !== nothing) "Relies on an out-of-date `5_bus_hydro_uc_sys` definition"
+
+    # Equality
+    @test PA.TopologyComponentSelector(Area, "1", ThermalStandard, nothing) ==
+          test_topo_ent1
+    @test PA.TopologyComponentSelector(LoadZone, "2", StaticInjection, "Zone_2") ==
+          test_topo_ent2
+
+    # Construction
+    @test select_components(Area, "1", ThermalStandard) == test_topo_ent1
+    @test select_components(LoadZone, "2", StaticInjection, "Zone_2") == test_topo_ent2
+
+    # Naming
+    @test get_name(test_topo_ent1) == "Area__1__ThermalStandard"
+    @test get_name(test_topo_ent2) == "Zone_2"
+
+    # Contents
+    empty_topo_ent = select_components(Area, "1", NonexistentComponent)
+    @test collect(get_components(empty_topo_ent, test_sys2)) == Vector{Component}()
+    @test collect(get_subselectors(empty_topo_ent, test_sys2)) ==
+          Vector{ComponentSelectorElement}()
+
+    answers =
+        sort_name.((
+            PSY.get_components_in_aggregation_topology(
+                ThermalStandard,
+                test_sys2,
+                get_component(Area, test_sys2, "1"),
+            ),
+            PSY.get_components_in_aggregation_topology(
+                StaticInjection,
+                test_sys2,
+                get_component(LoadZone, test_sys2, "2"),
+            )))
+    for (ent, ans) in zip((test_topo_ent1, test_topo_ent2), answers)
+        @assert length(ans) > 0 "Relies on an out-of-date `5_bus_hydro_uc_sys` definition"
+
+        the_components = sort_name(get_components(ent, test_sys2))
+        @test all(the_components .== ans)
+
+        the_subselectors = sort_name(get_subselectors(ent, test_sys2))
+        @test all(the_subselectors .== sort_name(select_components.(ans)))
+    end
+end
+
+@testset "Test FilterComponentSelector" begin
+    starts_with_s(x) = lowercase(first(get_name(x))) == 's'
+    test_filter_ent = PA.FilterComponentSelector(starts_with_s, ThermalStandard, nothing)
+    named_test_filter_ent =
+        PA.FilterComponentSelector(starts_with_s, ThermalStandard, "ThermStartsWithS")
+
+    # Equality
+    @test PA.FilterComponentSelector(starts_with_s, ThermalStandard, nothing) ==
+          test_filter_ent
+    @test PA.FilterComponentSelector(starts_with_s, ThermalStandard, "ThermStartsWithS") ==
+          named_test_filter_ent
+
+    # Construction
+    @test select_components(starts_with_s, ThermalStandard) == test_filter_ent
+    @test select_components(starts_with_s, ThermalStandard, "ThermStartsWithS") ==
+          named_test_filter_ent
+    bad_input_fn(x::Integer) = true  # Should always fail to construct
+    specific_input_fn(x::RenewableDispatch) = true  # Should require compatible subtype
+    @test_throws ArgumentError select_components(bad_input_fn, ThermalStandard)
+    @test_throws ArgumentError select_components(specific_input_fn, Component)
+    @test_throws ArgumentError select_components(specific_input_fn, ThermalStandard)
+    @test select_components(specific_input_fn, RenewableDispatch) isa Any  # test absence of error
+
+    # Naming
+    @test get_name(test_filter_ent) == "starts_with_s__ThermalStandard"
+    @test get_name(named_test_filter_ent) == "ThermStartsWithS"
+
+    # Contents
+    answer = filter(starts_with_s, collect(get_components(ThermalStandard, test_sys)))
+
+    @test collect(
+        get_components(select_components(x -> true, NonexistentComponent), test_sys),
+    ) ==
+          Vector{Component}()
+    @test collect(get_components(select_components(x -> false, Component), test_sys)) ==
+          Vector{Component}()
+    @test all(collect(get_components(test_filter_ent, test_sys)) .== answer)
+
+    @test collect(
+        get_subselectors(select_components(x -> true, NonexistentComponent), test_sys),
+    ) == Vector{ComponentSelectorElement}()
+    @test collect(get_subselectors(select_components(x -> false, Component), test_sys)) ==
+          Vector{ComponentSelectorElement}()
+    @test all(
+        collect(get_subselectors(test_filter_ent, test_sys)) .== select_components.(answer),
+    )
+end

--- a/test/test_component_selector.jl
+++ b/test/test_component_selector.jl
@@ -3,8 +3,6 @@
 test_sys = PSB.build_system(PSB.PSITestSystems, "c_sys5_all_components")
 test_sys2 = PSB.build_system(PSB.PSISystems, "5_bus_hydro_uc_sys")
 
-struct NonexistentComponent <: StaticInjection end  # <: Component
-
 sort_name(x) = sort(collect(x); by = get_name)
 
 @testset "Test helper functions" begin

--- a/test/test_component_selector.jl
+++ b/test/test_component_selector.jl
@@ -70,9 +70,9 @@ end
     @test get_component(ThermalStandard, test_sys, "Solitude") in the_components
     @test get_component(RenewableDispatch, test_sys, "WindBusA") in the_components
 
-    @test collect(get_subselectors(select_components())) ==
+    @test collect(get_subselectors(select_components(), test_sys)) ==
           Vector{ComponentSelector}()
-    the_subselectors = collect(get_subselectors(test_list_ent))
+    the_subselectors = collect(get_subselectors(test_list_ent, test_sys))
     @test length(the_subselectors) == 2
     @test comp_ent_1 in the_subselectors
     @test comp_ent_2 in the_subselectors

--- a/test/test_component_selector.jl
+++ b/test/test_component_selector.jl
@@ -205,11 +205,10 @@ end
         ThermalStandard, starts_with_s, :all, "ThermStartsWithS") == named_test_filter_ent
 
     # Construction
-    @test make_selector(ThermalStandard, starts_with_s) == test_filter_ent
     @test make_selector(starts_with_s, ThermalStandard) == test_filter_ent
-    @test make_selector(ThermalStandard, starts_with_s; name = "ThermStartsWithS") ==
+    @test make_selector(starts_with_s, ThermalStandard; name = "ThermStartsWithS") ==
           named_test_filter_ent
-    @test make_selector(ThermalStandard, starts_with_s; groupby = string) isa
+    @test make_selector(starts_with_s, ThermalStandard; groupby = string) isa
           PSY.FilterComponentSelector
 
     # Naming
@@ -220,10 +219,10 @@ end
     answer = filter(starts_with_s, collect(get_components_rt(ThermalStandard, test_sys)))
 
     @test collect(
-        get_components_rt(make_selector(NonexistentComponent, x -> true), test_sys),
+        get_components_rt(make_selector(x -> true, NonexistentComponent), test_sys),
     ) ==
           Vector{Component}()
-    @test collect(get_components_rt(make_selector(Component, x -> false), test_sys)) ==
+    @test collect(get_components_rt(make_selector(x -> false, Component), test_sys)) ==
           Vector{Component}()
     @test all(collect(get_components_rt(test_filter_ent, test_sys)) .== answer)
     @test !(

--- a/test/test_component_selector.jl
+++ b/test/test_component_selector.jl
@@ -11,18 +11,15 @@ sort_name(x) = sort(collect(x); by = get_name)
     @test subtype_to_string(ThermalStandard) == "ThermalStandard"
     @test component_to_qualified_string(ThermalStandard, "Solitude") ==
           "ThermalStandard__Solitude"
-    @test component_to_qualified_string(
-        PSY.get_component(ThermalStandard, test_sys, "Solitude"),
-    ) == "ThermalStandard__Solitude"
 end
 
 @testset "Test SingleComponentSelector" begin
-    test_gen_ent = PA.SingleComponentSelector(ThermalStandard, "Solitude", nothing)
-    named_test_gen_ent = PA.SingleComponentSelector(ThermalStandard, "Solitude", "SolGen")
+    test_gen_ent = SingleComponentSelector(ThermalStandard, "Solitude", nothing)
+    named_test_gen_ent = SingleComponentSelector(ThermalStandard, "Solitude", "SolGen")
 
     # Equality
-    @test PA.SingleComponentSelector(ThermalStandard, "Solitude", nothing) == test_gen_ent
-    @test PA.SingleComponentSelector(ThermalStandard, "Solitude", "SolGen") ==
+    @test SingleComponentSelector(ThermalStandard, "Solitude", nothing) == test_gen_ent
+    @test SingleComponentSelector(ThermalStandard, "Solitude", "SolGen") ==
           named_test_gen_ent
 
     # Construction
@@ -34,7 +31,7 @@ end
     # Naming
     @test get_name(test_gen_ent) == "ThermalStandard__Solitude"
     @test get_name(named_test_gen_ent) == "SolGen"
-    @test default_name(test_gen_ent) == "ThermalStandard__Solitude"
+    @test IS.default_name(test_gen_ent) == "ThermalStandard__Solitude"
 
     # Contents
     @test collect(get_components(select_components(NonexistentComponent, ""), test_sys)) ==
@@ -48,16 +45,16 @@ end
 @testset "Test ListComponentSelector" begin
     comp_ent_1 = select_components(ThermalStandard, "Solitude")
     comp_ent_2 = select_components(RenewableDispatch, "WindBusA")
-    test_list_ent = PA.ListComponentSelector((comp_ent_1, comp_ent_2), nothing)
-    named_test_list_ent = PA.ListComponentSelector((comp_ent_1, comp_ent_2), "TwoComps")
+    test_list_ent = ListComponentSelector((comp_ent_1, comp_ent_2), nothing)
+    named_test_list_ent = ListComponentSelector((comp_ent_1, comp_ent_2), "TwoComps")
 
     # Equality
-    @test PA.ListComponentSelector((comp_ent_1, comp_ent_2), nothing) == test_list_ent
-    @test PA.ListComponentSelector((comp_ent_1, comp_ent_2), "TwoComps") ==
+    @test ListComponentSelector((comp_ent_1, comp_ent_2), nothing) == test_list_ent
+    @test ListComponentSelector((comp_ent_1, comp_ent_2), "TwoComps") ==
           named_test_list_ent
 
     # Construction
-    @test select_components(comp_ent_1, comp_ent_2) == test_list_ent
+    @test select_components(comp_ent_1, comp_ent_2;) == test_list_ent
     @test select_components(comp_ent_1, comp_ent_2; name = "TwoComps") ==
           named_test_list_ent
 
@@ -82,12 +79,12 @@ end
 end
 
 @testset "Test SubtypeComponentSelector" begin
-    test_sub_ent = PA.SubtypeComponentSelector(ThermalStandard, nothing)
-    named_test_sub_ent = PA.SubtypeComponentSelector(ThermalStandard, "Thermals")
+    test_sub_ent = SubtypeComponentSelector(ThermalStandard, nothing)
+    named_test_sub_ent = SubtypeComponentSelector(ThermalStandard, "Thermals")
 
     # Equality
-    @test PA.SubtypeComponentSelector(ThermalStandard, nothing) == test_sub_ent
-    @test PA.SubtypeComponentSelector(ThermalStandard, "Thermals") == named_test_sub_ent
+    @test SubtypeComponentSelector(ThermalStandard, nothing) == test_sub_ent
+    @test SubtypeComponentSelector(ThermalStandard, "Thermals") == named_test_sub_ent
 
     # Construction
     @test select_components(ThermalStandard) == test_sub_ent
@@ -96,7 +93,7 @@ end
     # Naming
     @test get_name(test_sub_ent) == "ThermalStandard"
     @test get_name(named_test_sub_ent) == "Thermals"
-    @test default_name(test_sub_ent) == "ThermalStandard"
+    @test IS.default_name(test_sub_ent) == "ThermalStandard"
 
     # Contents
     answer = sort_name(get_components(ThermalStandard, test_sys))
@@ -115,14 +112,14 @@ end
 @testset "Test TopologyComponentSelector" begin
     topo1 = get_component(Area, test_sys2, "1")
     topo2 = get_component(LoadZone, test_sys2, "2")
-    test_topo_ent1 = PA.TopologyComponentSelector(Area, "1", ThermalStandard, nothing)
-    test_topo_ent2 = PA.TopologyComponentSelector(LoadZone, "2", StaticInjection, "Zone_2")
+    test_topo_ent1 = TopologyComponentSelector(Area, "1", ThermalStandard, nothing)
+    test_topo_ent2 = TopologyComponentSelector(LoadZone, "2", StaticInjection, "Zone_2")
     @assert (test_topo_ent1 !== nothing) && (test_topo_ent2 !== nothing) "Relies on an out-of-date `5_bus_hydro_uc_sys` definition"
 
     # Equality
-    @test PA.TopologyComponentSelector(Area, "1", ThermalStandard, nothing) ==
+    @test TopologyComponentSelector(Area, "1", ThermalStandard, nothing) ==
           test_topo_ent1
-    @test PA.TopologyComponentSelector(LoadZone, "2", StaticInjection, "Zone_2") ==
+    @test TopologyComponentSelector(LoadZone, "2", StaticInjection, "Zone_2") ==
           test_topo_ent2
 
     # Construction
@@ -141,12 +138,12 @@ end
 
     answers =
         sort_name.((
-            PSY.get_components_in_aggregation_topology(
+            get_components_in_aggregation_topology(
                 ThermalStandard,
                 test_sys2,
                 get_component(Area, test_sys2, "1"),
             ),
-            PSY.get_components_in_aggregation_topology(
+            get_components_in_aggregation_topology(
                 StaticInjection,
                 test_sys2,
                 get_component(LoadZone, test_sys2, "2"),
@@ -164,14 +161,14 @@ end
 
 @testset "Test FilterComponentSelector" begin
     starts_with_s(x) = lowercase(first(get_name(x))) == 's'
-    test_filter_ent = PA.FilterComponentSelector(starts_with_s, ThermalStandard, nothing)
+    test_filter_ent = FilterComponentSelector(starts_with_s, ThermalStandard, nothing)
     named_test_filter_ent =
-        PA.FilterComponentSelector(starts_with_s, ThermalStandard, "ThermStartsWithS")
+        FilterComponentSelector(starts_with_s, ThermalStandard, "ThermStartsWithS")
 
     # Equality
-    @test PA.FilterComponentSelector(starts_with_s, ThermalStandard, nothing) ==
+    @test FilterComponentSelector(starts_with_s, ThermalStandard, nothing) ==
           test_filter_ent
-    @test PA.FilterComponentSelector(starts_with_s, ThermalStandard, "ThermStartsWithS") ==
+    @test FilterComponentSelector(starts_with_s, ThermalStandard, "ThermStartsWithS") ==
           named_test_filter_ent
 
     # Construction

--- a/test/test_component_selector.jl
+++ b/test/test_component_selector.jl
@@ -110,8 +110,10 @@ end
     @test PSY.TypeComponentSelector(ThermalStandard, :all, "Thermals") == named_test_sub_ent
 
     # Construction
-    @test make_selector(ThermalStandard) == test_sub_ent
-    @test make_selector(ThermalStandard; name = "Thermals") == named_test_sub_ent
+    @test make_selector(ThermalStandard) == make_selector(ThermalStandard; groupby = :each)
+    @test make_selector(ThermalStandard; groupby = :all) == test_sub_ent
+    @test make_selector(ThermalStandard; groupby = :all, name = "Thermals") ==
+          named_test_sub_ent
     @test make_selector(ThermalStandard; groupby = string) isa PSY.TypeComponentSelector
 
     # Naming
@@ -149,8 +151,11 @@ end
           test_topo_ent2
 
     # Construction
-    @test make_selector(ThermalStandard, Area, "1") == test_topo_ent1
-    @test make_selector(StaticInjection, LoadZone, "2"; name = "Zone_2") == test_topo_ent2
+    @test make_selector(ThermalStandard, Area, "1") ==
+          make_selector(ThermalStandard, Area, "1"; groupby = :each)
+    @test make_selector(ThermalStandard, Area, "1"; groupby = :all) == test_topo_ent1
+    @test make_selector(StaticInjection, LoadZone, "2"; groupby = :all, name = "Zone_2") ==
+          test_topo_ent2
     @test make_selector(StaticInjection, LoadZone, "2"; groupby = string) isa
           PSY.TopologyComponentSelector
 
@@ -205,9 +210,15 @@ end
         ThermalStandard, starts_with_s, :all, "ThermStartsWithS") == named_test_filter_ent
 
     # Construction
-    @test make_selector(starts_with_s, ThermalStandard) == test_filter_ent
-    @test make_selector(starts_with_s, ThermalStandard; name = "ThermStartsWithS") ==
-          named_test_filter_ent
+    @test make_selector(starts_with_s, ThermalStandard) ==
+          make_selector(starts_with_s, ThermalStandard; groupby = :each)
+    @test make_selector(starts_with_s, ThermalStandard; groupby = :all) == test_filter_ent
+    @test make_selector(
+        starts_with_s,
+        ThermalStandard;
+        groupby = :all,
+        name = "ThermStartsWithS",
+    ) == named_test_filter_ent
     @test make_selector(starts_with_s, ThermalStandard; groupby = string) isa
           PSY.FilterComponentSelector
 
@@ -239,7 +250,7 @@ end
 
     all_selector = make_selector(ThermalStandard, Area, "1"; groupby = :all)
     each_selector = make_selector(ThermalStandard, Area, "1"; groupby = :each)
-    @test make_selector(ThermalStandard, Area, "1") == all_selector
+    @test make_selector(ThermalStandard, Area, "1") == each_selector
     @test_throws ArgumentError make_selector(ThermalStandard, Area, "1"; groupby = :other)
     # @show get_name.(get_components_rt(all_selector, test_sys2))
     partition_selector = make_selector(ThermalStandard, Area, "1";

--- a/test/test_component_selector.jl
+++ b/test/test_component_selector.jl
@@ -284,13 +284,3 @@ end
           length(get_available_components(ThermalStandard, test_sys2)) ==
           length(get_components(get_available, ThermalStandard, test_sys2))
 end
-
-@testset "Test alternative interfaces" begin
-    selector = make_selector(ThermalStandard, "Solitude")
-    @test collect(get_components_rt(selector, test_sys; scope_limiter = x -> true)) ==
-          collect(get_components_rt(x -> true, selector, test_sys))
-    @test get_component(selector, test_sys; scope_limiter = x -> true) ==
-          get_component(x -> true, selector, test_sys)
-    @test collect(get_groups(selector, test_sys; scope_limiter = x -> true)) ==
-          collect(get_groups(x -> true, selector, test_sys))
-end

--- a/test/test_component_selector.jl
+++ b/test/test_component_selector.jl
@@ -62,9 +62,10 @@ end
           Vector{Component}()
     @test collect(get_available_components(make_selector(gen_sundance), test_sys)) ==
           Vector{Component}()
-    @test IS.get_component(test_gen_ent, test_sys; scope_limiter = x -> true) ==
+    @test get_component(test_gen_ent, test_sys; scope_limiter = x -> true) ==
           first(the_components)
-    @test isnothing(IS.get_component(test_gen_ent, test_sys; scope_limiter = x -> false))
+    @test isnothing(get_component(test_gen_ent, test_sys; scope_limiter = x -> false))
+    @test isnothing(get_available_component(make_selector(gen_sundance), test_sys))
 
     @test only(get_groups(test_gen_ent, test_sys)) == test_gen_ent
 end
@@ -348,7 +349,8 @@ end
 end
 
 @testset "Test special cases" begin
-    # https://github.com/NREL-Sienna/InfrastructureSystems.jl/issues/388 can cause issues here
-    # TODO
-    # get_components_rt(make_selector(make_selector(ThermalStandard, Area, "1")), test_sys)
+    # Can error if the `PSY.get_components` vs. `IS.get_components` stuff is not functioning correctly
+    agg_selectors = [make_selector(ThermalStandard, Area, "1"),
+        make_selector(ThermalStandard, Area, "1")]
+    get_components_rt(make_selector(agg_selectors...), test_sys)
 end

--- a/test/test_component_selector.jl
+++ b/test/test_component_selector.jl
@@ -34,7 +34,6 @@ end
     # Naming
     @test get_name(test_gen_ent) == "ThermalStandard__Solitude"
     @test get_name(named_test_gen_ent) == "SolGen"
-    @test PSY.default_name(test_gen_ent) == "ThermalStandard__Solitude"
 
     # Contents
     @test collect(get_components(make_selector(NonexistentComponent, ""), test_sys)) ==
@@ -91,12 +90,12 @@ end
 end
 
 @testset "Test TypeComponentSelector" begin
-    test_sub_ent = PSY.TypeComponentSelector(ThermalStandard, nothing, :all)
-    named_test_sub_ent = PSY.TypeComponentSelector(ThermalStandard, "Thermals", :all)
+    test_sub_ent = PSY.TypeComponentSelector(ThermalStandard, :all, nothing)
+    named_test_sub_ent = PSY.TypeComponentSelector(ThermalStandard, :all, "Thermals")
 
     # Equality
-    @test PSY.TypeComponentSelector(ThermalStandard, nothing, :all) == test_sub_ent
-    @test PSY.TypeComponentSelector(ThermalStandard, "Thermals", :all) == named_test_sub_ent
+    @test PSY.TypeComponentSelector(ThermalStandard, :all, nothing) == test_sub_ent
+    @test PSY.TypeComponentSelector(ThermalStandard, :all, "Thermals") == named_test_sub_ent
 
     # Construction
     @test make_selector(ThermalStandard) == test_sub_ent
@@ -106,7 +105,6 @@ end
     # Naming
     @test get_name(test_sub_ent) == "ThermalStandard"
     @test get_name(named_test_sub_ent) == "Thermals"
-    @test PSY.default_name(test_sub_ent) == "ThermalStandard"
 
     # Contents
     answer = sort_name!(get_components(ThermalStandard, test_sys))
@@ -127,14 +125,14 @@ end
     topo2 = get_component(LoadZone, test_sys2, "2")
     @assert !isnothing(topo1) && !isnothing(topo2) "Relies on an out-of-date `5_bus_hydro_uc_sys` definition"
     test_topo_ent1 =
-        PSY.TopologyComponentSelector(ThermalStandard, Area, "1", nothing, :all)
+        PSY.TopologyComponentSelector(ThermalStandard, Area, "1", :all, nothing)
     test_topo_ent2 =
-        PSY.TopologyComponentSelector(StaticInjection, LoadZone, "2", "Zone_2", :all)
+        PSY.TopologyComponentSelector(StaticInjection, LoadZone, "2", :all, "Zone_2")
 
     # Equality
-    @test PSY.TopologyComponentSelector(ThermalStandard, Area, "1", nothing, :all) ==
+    @test PSY.TopologyComponentSelector(ThermalStandard, Area, "1", :all, nothing) ==
           test_topo_ent1
-    @test PSY.TopologyComponentSelector(StaticInjection, LoadZone, "2", "Zone_2", :all) ==
+    @test PSY.TopologyComponentSelector(StaticInjection, LoadZone, "2", :all, "Zone_2") ==
           test_topo_ent2
 
     # Construction
@@ -181,15 +179,15 @@ end
 @testset "Test FilterComponentSelector" begin
     starts_with_s(x) = lowercase(first(get_name(x))) == 's'
     test_filter_ent =
-        PSY.FilterComponentSelector(ThermalStandard, starts_with_s, nothing, :all)
+        PSY.FilterComponentSelector(ThermalStandard, starts_with_s, :all, nothing)
     named_test_filter_ent = PSY.FilterComponentSelector(
-        ThermalStandard, starts_with_s, "ThermStartsWithS", :all)
+        ThermalStandard, starts_with_s, :all, "ThermStartsWithS")
 
     # Equality
-    @test PSY.FilterComponentSelector(ThermalStandard, starts_with_s, nothing, :all) ==
+    @test PSY.FilterComponentSelector(ThermalStandard, starts_with_s, :all, nothing) ==
           test_filter_ent
     @test PSY.FilterComponentSelector(
-        ThermalStandard, starts_with_s, "ThermStartsWithS", :all) == named_test_filter_ent
+        ThermalStandard, starts_with_s, :all, "ThermStartsWithS") == named_test_filter_ent
 
     # Construction
     @test make_selector(ThermalStandard, starts_with_s) == test_filter_ent

--- a/test/test_component_selector.jl
+++ b/test/test_component_selector.jl
@@ -294,3 +294,22 @@ end
           length(get_available_components(ThermalStandard, test_sys2)) ==
           length(get_components(get_available, ThermalStandard, test_sys2))
 end
+
+@testset "Test rebuild_selector" begin
+    @assert !(PSY.NameComponentSelector <: PSY.DynamicallyGroupedComponentSelector)
+    @assert PSY.TopologyComponentSelector <: PSY.DynamicallyGroupedComponentSelector
+
+    sel1::PSY.NameComponentSelector =
+        make_selector(ThermalStandard, "Component1"; name = "oldname")
+    sel2::PSY.TopologyComponentSelector =
+        make_selector(ThermalStandard, Area, "1"; groupby = :all)
+
+    @test rebuild_selector(sel1; name = "newname") ==
+          make_selector(ThermalStandard, "Component1"; name = "newname")
+    @test_throws Exception rebuild_selector(sel1; groupby = :each)
+
+    @test rebuild_selector(sel2; name = "newname") ==
+          make_selector(ThermalStandard, Area, "1"; name = "newname", groupby = :all)
+    @test rebuild_selector(sel2; name = "newname", groupby = :each) ==
+          make_selector(ThermalStandard, Area, "1"; name = "newname", groupby = :each)
+end

--- a/test/test_component_selector.jl
+++ b/test/test_component_selector.jl
@@ -44,12 +44,16 @@ end
     @test typeof(first(the_components)) == ThermalStandard
     @test get_name(first(the_components)) == "Solitude"
     @test collect(
-        get_components(make_selector(gen_sundance), test_sys; filterby = get_available),
+        get_components(
+            make_selector(gen_sundance),
+            test_sys;
+            scope_limiter = get_available,
+        ),
     ) ==
           Vector{Component}()
-    @test IS.get_component(test_gen_ent, test_sys; filterby = x -> true) ==
+    @test IS.get_component(test_gen_ent, test_sys; scope_limiter = x -> true) ==
           first(the_components)
-    @test isnothing(IS.get_component(test_gen_ent, test_sys; filterby = x -> false))
+    @test isnothing(IS.get_component(test_gen_ent, test_sys; scope_limiter = x -> false))
 
     @test only(get_groups(test_gen_ent, test_sys)) == test_gen_ent
 end
@@ -113,7 +117,7 @@ end
     @test all(the_components .== answer)
     @test !(
         gen_sundance in
-        collect(get_components(test_sub_ent, test_sys; filterby = get_available)))
+        collect(get_components(test_sub_ent, test_sys; scope_limiter = get_available)))
 
     # Grouping inherits from `DynamicallyGroupedComponentSelector` and is tested elsewhere
 end
@@ -167,9 +171,10 @@ end
 
         the_components = get_components(ent, test_sys2)
         @test all(sort_name!(the_components) .== ans)
-        @test Set(collect(get_components(ent, test_sys2; filterby = x -> true))) ==
+        @test Set(collect(get_components(ent, test_sys2; scope_limiter = x -> true))) ==
               Set(the_components)
-        @test length(collect(get_components(ent, test_sys2; filterby = x -> false))) == 0
+        @test length(collect(get_components(ent, test_sys2; scope_limiter = x -> false))) ==
+              0
     end
 end
 
@@ -210,11 +215,11 @@ end
     @test all(collect(get_components(test_filter_ent, test_sys)) .== answer)
     @test !(
         gen_sundance in
-        collect(get_components(test_filter_ent, test_sys; filterby = get_available)))
+        collect(get_components(test_filter_ent, test_sys; scope_limiter = get_available)))
 
     @test !(
         gen_sundance in
-        collect(get_components(test_filter_ent, test_sys; filterby = get_available)))
+        collect(get_components(test_filter_ent, test_sys; scope_limiter = get_available)))
 end
 
 @testset "Test DynamicallyGroupedComponentSelector grouping" begin
@@ -238,7 +243,7 @@ end
     @test length(
         collect(
             get_groups(each_selector, test_sys2;
-                filterby = x -> length(get_name(x)) == 8),
+                scope_limiter = x -> length(get_name(x)) == 8),
         ),
     ) == 2
     @test Set(get_name.(get_groups(partition_selector, test_sys2))) ==
@@ -246,7 +251,7 @@ end
     @test length(
         collect(
             get_groups(partition_selector, test_sys2;
-                filterby = x -> length(get_name(x)) == 8),
+                scope_limiter = x -> length(get_name(x)) == 8),
         ),
     ) == 1
 
@@ -262,10 +267,10 @@ end
 
 @testset "Test alternative interfaces" begin
     selector = make_selector(ThermalStandard, "Solitude")
-    @test get_components(selector, test_sys; filterby = x -> true) ==
+    @test get_components(selector, test_sys; scope_limiter = x -> true) ==
           get_components(x -> true, selector, test_sys)
-    @test get_component(selector, test_sys; filterby = x -> true) ==
+    @test get_component(selector, test_sys; scope_limiter = x -> true) ==
           get_component(x -> true, selector, test_sys)
-    @test get_groups(selector, test_sys; filterby = x -> true) ==
+    @test get_groups(selector, test_sys; scope_limiter = x -> true) ==
           get_groups(x -> true, selector, test_sys)
 end

--- a/test/test_component_selector.jl
+++ b/test/test_component_selector.jl
@@ -17,13 +17,13 @@ sort_name!(x) = sort!(collect(x); by = get_name)
     @test component_to_qualified_string(gen_solitude) == "ThermalStandard__Solitude"
 end
 
-@testset "Test SingleComponentSelector" begin
-    test_gen_ent = SingleComponentSelector(ThermalStandard, "Solitude", nothing)
-    named_test_gen_ent = SingleComponentSelector(ThermalStandard, "Solitude", "SolGen")
+@testset "Test NameComponentSelector" begin
+    test_gen_ent = NameComponentSelector(ThermalStandard, "Solitude", nothing)
+    named_test_gen_ent = NameComponentSelector(ThermalStandard, "Solitude", "SolGen")
 
     # Equality
-    @test SingleComponentSelector(ThermalStandard, "Solitude", nothing) == test_gen_ent
-    @test SingleComponentSelector(ThermalStandard, "Solitude", "SolGen") ==
+    @test NameComponentSelector(ThermalStandard, "Solitude", nothing) == test_gen_ent
+    @test NameComponentSelector(ThermalStandard, "Solitude", "SolGen") ==
           named_test_gen_ent
 
     # Construction
@@ -125,7 +125,7 @@ end
         collect(get_components(test_sub_ent, test_sys; filterby = get_available)))
 
     @test collect(get_subselectors(make_selector(NonexistentComponent), test_sys)) ==
-          Vector{ComponentSelectorElement}()
+          Vector{SingularComponentSelector}()
     the_subselectors = sort_name!(get_subselectors(test_sub_ent, test_sys))
     @test all(the_subselectors .== make_selector.(answer))
     @test !(
@@ -162,12 +162,12 @@ end
     empty_topo_ent = make_selector(Area, "1", NonexistentComponent)
     @test collect(get_components(empty_topo_ent, test_sys2)) == Vector{Component}()
     @test collect(get_subselectors(empty_topo_ent, test_sys2)) ==
-          Vector{ComponentSelectorElement}()
+          Vector{SingularComponentSelector}()
 
     nonexistent_topo_ent = make_selector(Area, "NonexistentArea", ThermalStandard)
     @test collect(get_components(nonexistent_topo_ent, test_sys2)) == Vector{Component}()
     @test collect(get_subselectors(nonexistent_topo_ent, test_sys2)) ==
-          Vector{ComponentSelectorElement}()
+          Vector{SingularComponentSelector}()
 
     answers =
         sort_name!.((
@@ -254,9 +254,9 @@ end
 
     @test collect(
         get_subselectors(make_selector(x -> true, NonexistentComponent), test_sys),
-    ) == Vector{ComponentSelectorElement}()
+    ) == Vector{SingularComponentSelector}()
     @test collect(get_subselectors(make_selector(x -> false, Component), test_sys)) ==
-          Vector{ComponentSelectorElement}()
+          Vector{SingularComponentSelector}()
     @test all(
         collect(get_subselectors(test_filter_ent, test_sys)) .== make_selector.(answer),
     )

--- a/test/test_component_selector.jl
+++ b/test/test_component_selector.jl
@@ -1,5 +1,3 @@
-# TODO copied directly from https://github.com/GabrielKS/PowerAnalytics.jl/tree/gks/entity-metric-redesign, will require major refactor
-
 test_sys = PSB.build_system(PSB.PSITestSystems, "c_sys5_all_components")
 test_sys2 = PSB.build_system(PSB.PSISystems, "5_bus_hydro_uc_sys")
 

--- a/test/test_component_selector.jl
+++ b/test/test_component_selector.jl
@@ -246,4 +246,13 @@ end
                 filterby = x -> length(get_name(x)) == 8),
         ),
     ) == 1
+
+    # Also test briefly with something from IS
+    @assert PSY.SubtypeComponentSelector <: DynamicallyGroupedComponentSelector
+    @test length(
+        collect(
+            get_groups(make_selector(ThermalStandard;
+                    groupby = x -> length(get_name(x))), test_sys),
+        ),
+    ) == 3
 end

--- a/test/test_component_selector.jl
+++ b/test/test_component_selector.jl
@@ -47,6 +47,9 @@ end
         get_components(make_selector(gen_sundance), test_sys; filterby = get_available),
     ) ==
           Vector{Component}()
+    @test IS.get_component(test_gen_ent, test_sys; filterby = x -> true) ==
+          first(the_components)
+    @test isnothing(IS.get_component(test_gen_ent, test_sys; filterby = x -> false))
 
     @test only(get_groups(test_gen_ent, test_sys)) == test_gen_ent
 end
@@ -185,6 +188,7 @@ end
 
     # Construction
     @test make_selector(ThermalStandard, starts_with_s) == test_filter_ent
+    @test make_selector(starts_with_s, ThermalStandard) == test_filter_ent
     @test make_selector(ThermalStandard, starts_with_s; name = "ThermStartsWithS") ==
           named_test_filter_ent
     @test make_selector(ThermalStandard, starts_with_s; groupby = string) isa
@@ -254,4 +258,14 @@ end
                     groupby = x -> length(get_name(x))), test_sys),
         ),
     ) == 3
+end
+
+@testset "Test alternative interfaces" begin
+    selector = make_selector(ThermalStandard, "Solitude")
+    @test get_components(selector, test_sys; filterby = x -> true) ==
+          get_components(x -> true, selector, test_sys)
+    @test get_component(selector, test_sys; filterby = x -> true) ==
+          get_component(x -> true, selector, test_sys)
+    @test get_groups(selector, test_sys; filterby = x -> true) ==
+          get_groups(x -> true, selector, test_sys)
 end

--- a/test/test_component_selector.jl
+++ b/test/test_component_selector.jl
@@ -83,19 +83,18 @@ end
     @test length(the_groups) == 2
 end
 
-@testset "Test SubtypeComponentSelector" begin
-    test_sub_ent = PSY.SubtypeComponentSelector(ThermalStandard, nothing, :all)
-    named_test_sub_ent = PSY.SubtypeComponentSelector(ThermalStandard, "Thermals", :all)
+@testset "Test TypeComponentSelector" begin
+    test_sub_ent = PSY.TypeComponentSelector(ThermalStandard, nothing, :all)
+    named_test_sub_ent = PSY.TypeComponentSelector(ThermalStandard, "Thermals", :all)
 
     # Equality
-    @test PSY.SubtypeComponentSelector(ThermalStandard, nothing, :all) == test_sub_ent
-    @test PSY.SubtypeComponentSelector(ThermalStandard, "Thermals", :all) ==
-          named_test_sub_ent
+    @test PSY.TypeComponentSelector(ThermalStandard, nothing, :all) == test_sub_ent
+    @test PSY.TypeComponentSelector(ThermalStandard, "Thermals", :all) == named_test_sub_ent
 
     # Construction
     @test make_selector(ThermalStandard) == test_sub_ent
     @test make_selector(ThermalStandard; name = "Thermals") == named_test_sub_ent
-    @test make_selector(ThermalStandard; groupby = string) isa PSY.SubtypeComponentSelector
+    @test make_selector(ThermalStandard; groupby = string) isa PSY.TypeComponentSelector
 
     # Naming
     @test get_name(test_sub_ent) == "ThermalStandard"
@@ -248,7 +247,7 @@ end
     ) == 1
 
     # Also test briefly with something from IS
-    @assert PSY.SubtypeComponentSelector <: DynamicallyGroupedComponentSelector
+    @assert PSY.TypeComponentSelector <: DynamicallyGroupedComponentSelector
     @test length(
         collect(
             get_groups(make_selector(ThermalStandard;

--- a/test/test_component_selector.jl
+++ b/test/test_component_selector.jl
@@ -54,17 +54,17 @@ end
     @test get_name(first(the_components)) == "Solitude"
     @test collect(
         get_components_rt(
+            get_available,
             make_selector(gen_sundance),
-            test_sys;
-            scope_limiter = get_available,
+            test_sys,
         ),
     ) ==
           Vector{Component}()
     @test collect(get_available_components(make_selector(gen_sundance), test_sys)) ==
           Vector{Component}()
-    @test get_component(test_gen_ent, test_sys; scope_limiter = x -> true) ==
+    @test get_component(x -> true, test_gen_ent, test_sys) ==
           first(the_components)
-    @test isnothing(get_component(test_gen_ent, test_sys; scope_limiter = x -> false))
+    @test isnothing(get_component(x -> false, test_gen_ent, test_sys))
     @test isnothing(get_available_component(make_selector(gen_sundance), test_sys))
 
     @test only(get_groups(test_gen_ent, test_sys)) == test_gen_ent
@@ -130,7 +130,7 @@ end
     @test all(the_components .== answer)
     @test !(
         gen_sundance in
-        collect(get_components_rt(test_sub_ent, test_sys; scope_limiter = get_available)))
+        collect(get_components_rt(get_available, test_sub_ent, test_sys)))
     @test !(gen_sundance in collect(get_available_components(test_sub_ent, test_sys)))
 
     # Grouping inherits from `DynamicallyGroupedComponentSelector` and is tested elsewhere
@@ -188,10 +188,10 @@ end
 
         the_components = get_components_rt(ent, test_sys2)
         @test all(sort_name!(the_components) .== ans)
-        @test Set(collect(get_components_rt(ent, test_sys2; scope_limiter = x -> true))) ==
+        @test Set(collect(get_components_rt(x -> true, ent, test_sys2))) ==
               Set(the_components)
         @test length(
-            collect(get_components_rt(ent, test_sys2; scope_limiter = x -> false)),
+            collect(get_components_rt(x -> false, ent, test_sys2)),
         ) ==
               0
     end
@@ -240,7 +240,7 @@ end
     @test !(
         gen_sundance in
         collect(
-            get_components_rt(test_filter_ent, test_sys; scope_limiter = get_available),
+            get_components_rt(get_available, test_filter_ent, test_sys),
         ))
     @test !(gen_sundance in collect(get_available_components(test_filter_ent, test_sys)))
 end
@@ -282,16 +282,14 @@ end
     ))
     @test length(
         collect(
-            get_groups(each_selector, test_sys2;
-                scope_limiter = x -> length(get_name(x)) == 8),
+            get_groups(x -> length(get_name(x)) == 8, each_selector, test_sys2),
         ),
     ) == 2
     @test Set(get_name.(get_groups(partition_selector, test_sys2))) ==
           Set(["true", "false"])
     @test length(
         collect(
-            get_groups(partition_selector, test_sys2;
-                scope_limiter = x -> length(get_name(x)) == 8),
+            get_groups(x -> length(get_name(x)) == 8, partition_selector, test_sys2),
         ),
     ) == 1
 

--- a/test/test_powersystemconstructors.jl
+++ b/test/test_powersystemconstructors.jl
@@ -104,7 +104,7 @@ end
     # If that isn't appropriate for this type, add it to types_to_skip below.
     # You can also call test_accessors wherever an instance has been created.
 
-    types_to_skip = (TestDevice, TestRenDevice)
+    types_to_skip = (TestDevice, TestRenDevice, NonexistentComponent)
     types = vcat(
         IS.get_all_concrete_subtypes(Component),
         IS.get_all_concrete_subtypes(DynamicComponent),
@@ -121,7 +121,7 @@ end
 
 @testset "Test required accessor functions of subtypes of Component " begin
     types = IS.get_all_concrete_subtypes(Component)
-    types_to_skip = (TestDevice, TestRenDevice)
+    types_to_skip = (TestDevice, TestRenDevice, NonexistentComponent)
     sort!(types; by = x -> string(x))
     for ps_type in types
         ps_type in types_to_skip && continue

--- a/test/test_system.jl
+++ b/test/test_system.jl
@@ -7,6 +7,11 @@
     generator = get_component(ThermalStandard, sys, get_name(generators[1]))
     @test IS.get_uuid(generator) == IS.get_uuid(generators[1])
     @test_throws(IS.ArgumentError, add_component!(sys, generator))
+    @test get_available_component(ThermalStandard, sys, get_name(generators[1])) ===
+          generator
+    set_available!(generator, false)
+    @test isnothing(get_available_component(ThermalStandard, sys, get_name(generators[1])))
+    set_available!(generator, true)
 
     generators2 = get_components_by_name(ThermalGen, sys, get_name(generators[1]))
     @test length(generators2) == 1
@@ -21,6 +26,7 @@
     )
     @test isempty(get_components(x -> (!get_available(x)), ThermalStandard, sys))
     @test !isempty(get_available_components(ThermalStandard, sys))
+    @test !isempty(get_available_components(x -> true, ThermalStandard, sys))
     # Test get_bus* functionality.
     bus_numbers = Vector{Int}()
     for bus in get_components(ACBus, sys)


### PR DESCRIPTION
Successor to https://github.com/NREL-Sienna/PowerSystems.jl/pull/1079 and companion to/depends on https://github.com/NREL-Sienna/InfrastructureSystems.jl/pull/342. Adds an immutable, lazy, system-independent representation of a grouped set of components. For more details and a demonstration, see https://github.nrel.gov/gkonars/PowerAnalytics-demos/blob/main/component_selector_pr_demo.ipynb.