### PR TITLE
Add `with_units_base` feature

### DIFF
--- a/docs/src/explanation/per_unit.md
+++ b/docs/src/explanation/per_unit.md
@@ -19,8 +19,11 @@ These three unit bases allow easy conversion between unit systems.
 This allows `PowerSystems.jl` users to input data in the formats they have available,
 as well as view data in the unit system that is most intuitive to them.
 
-You can get and set the unit system setting of a `System` with [`get_units_base`](@ref)
-and [`set_units_base_system!`](@ref).
+You can get and set the unit system setting of a `System` with [`get_units_base`](@ref) and
+[`set_units_base_system!`](@ref). To support a less stateful style of programming,
+`PowerSystems.jl` provides the `Logging.with_logger`-inspired "context manager"-type
+function [`with_units_base`](@ref), which sets the unit system to a particular value,
+performs some action, then automatically sets the unit system back to its previous value.
 
 Conversion between unit systems does not change
 the stored parameter values. Instead, unit system conversions are made when accessing

--- a/docs/src/tutorials/creating_system.md
+++ b/docs/src/tutorials/creating_system.md
@@ -357,6 +357,18 @@ get_rating(retrieved_component)
 See that now the data is now 1.0 (5.0 MVA per-unitized by the generator (i.e., the device's)
 `base_power` of 5.0 MVA), which is the format we used to originally define the device.
 
+As a shortcut to temporarily set the `System`'s unit system to a particular value, perform
+some action, and then automatically set it back to what it was before, we can use
+`with_units_base` and a [`do` block](https://docs.julialang.org/en/v1/manual/functions/#Do-Block-Syntax-for-Function-Arguments):
+
+```@repl basics
+with_units_base(sys, "NATURAL_UNITS") do
+    # Everything inside this block will run as if the unit system were NATURAL_UNITS
+    get_rating(retrieved_component)
+end
+get_units_base(sys)  # Unit system goes back to previous value when the block ends
+```
+
 Recall that if you ever need to check a `System`'s settings, including the unit system being
 used by all the getter functions, you can always just print the `System`:
 

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -416,6 +416,7 @@ export set_description!
 export get_base_power
 export get_frequency
 export set_units_base_system!
+export with_units_base
 export to_json
 export from_json
 export serialize

--- a/src/base.jl
+++ b/src/base.jl
@@ -523,8 +523,6 @@ _set_units_base!(system::System, settings::String) =
     _set_units_base!(system::System, UNIT_SYSTEM_MAPPING[uppercase(settings)])
 
 """
-`set_units_base_system!(system::System, units::Union{UnitSystem, String})`
-
 Sets the units base for the getter functions on the devices. It modifies the behavior of all getter functions
 
 # Examples
@@ -551,10 +549,8 @@ function get_units_base(system::System)
 end
 
 """
-`with_units_base(function, system, units::Union{UnitSystem, String})`
-
-A "context manager" similar to `Logging.with_logger` that sets the system's units base to
-the given value, executes the function, then sets the units base back.
+A "context manager" that sets the [`System`](@ref)'s [units base](@ref per_unit) to the
+given value, executes the function, then sets the units base back.
 
 # Examples
 ```julia

--- a/src/base.jl
+++ b/src/base.jl
@@ -513,36 +513,48 @@ function set_units_setting!(
     return
 end
 
+function _set_units_base!(system::System, settings::UnitSystem)
+    to_change = (system.units_settings.unit_system != settings)
+    to_change && (system.units_settings.unit_system = settings)
+    return (to_change, settings)
+end
+
+_set_units_base!(system::System, settings::String) =
+    _set_units_base!(system::System, UNIT_SYSTEM_MAPPING[uppercase(settings)])
+
 """
+`set_units_base_system!(system::System, units::Union{UnitSystem, String})`
+
 Sets the units base for the getter functions on the devices. It modifies the behavior of all getter functions
+
+# Examples
+```julia
+set_units_base_system!(sys, "NATURAL_UNITS")
+```
+```julia
+set_units_base_system!(sys, UnitSystem.SYSTEM_BASE)
+```
 """
-function set_units_base_system!(system::System, settings::String)
-    set_units_base_system!(system::System, UNIT_SYSTEM_MAPPING[uppercase(settings)])
+function set_units_base_system!(system::System, units::Union{UnitSystem, String})
+    changed, new_units = _set_units_base!(system::System, units)
+    changed && @info "Unit System changed to $new_units"
     return
 end
 
-function set_units_base_system!(system::System, settings::UnitSystem)
-    if system.units_settings.unit_system != settings
-        system.units_settings.unit_system = settings
-        @info "Unit System changed to $settings"
-    end
-    return
-end
+_get_units_base(system::System) = system.units_settings.unit_system
 
 """
 Get the system's [unit base](@ref per_unit))
 """
 function get_units_base(system::System)
-    return string(system.units_settings.unit_system)
+    return string(_get_units_base(system))
 end
 
 """
-`with_units_base(function, system, units::Union{UnitSystem, String}; suppress_units_info = true)`
+`with_units_base(function, system, units::Union{UnitSystem, String})`
 
-A "context manager" similar to [`Logging.with_logger`](@ref) that sets the system's units
-base to the given value, executes the function, then sets the units base back. If
-`suppress_units_info`, suppresses logging below `Warn` from internal calls made to
-facilitate this. Not thread safe.
+A "context manager" similar to `Logging.with_logger` that sets the system's units base to
+the given value, executes the function, then sets the units base back.
 
 # Examples
 ```julia
@@ -552,23 +564,13 @@ end
 # now active_power_mw is in natural units no matter what units base the system is in
 ```
 """
-function with_units_base(f::Function, sys::System, units::Union{UnitSystem, String};
-    suppress_units_info = true)
-    units_logger = if suppress_units_info
-        x -> Logging.with_logger(x, Logging.SimpleLogger(Logging.Warn))
-    else
-        x -> x()
-    end
-    old_units = get_units_base(sys)
-    units_logger() do
-        set_units_base_system!(sys, units)
-    end
+function with_units_base(f::Function, sys::System, units::Union{UnitSystem, String})
+    old_units = _get_units_base(sys)
+    _set_units_base!(sys, units)
     try
         f()
     finally
-        units_logger() do
-            set_units_base_system!(sys, old_units)
-        end
+        _set_units_base!(sys, old_units)
     end
 end
 

--- a/test/test_system.jl
+++ b/test/test_system.jl
@@ -215,6 +215,14 @@ end
     @test get_units_base(sys) == "DEVICE_BASE"
     set_units_base_system!(sys, "SYSTEM_BASE")
     @test get_units_base(sys) == "SYSTEM_BASE"
+
+    gen = get_component(ThermalStandard, sys, "322_CT_6")
+    active_power_mw = with_units_base(sys, UnitSystem.NATURAL_UNITS) do
+        get_active_power(gen)
+    end
+    @test get_units_base(sys) == "SYSTEM_BASE"
+    set_units_base_system!(sys, UnitSystem.NATURAL_UNITS)
+    @test active_power_mw == get_active_power(gen)
 end
 
 @testset "Test add_time_series multiple components" begin


### PR DESCRIPTION
Closes https://github.com/NREL-Sienna/PowerSystems.jl/issues/1229 by adding a new exported function `with_units_base` that serves as a "context manager" to execute a block of code as if the system's units base were set to a particular value.