### PR TITLE
Add `fast_deepcopy_system` function, fix bug 1233, fix `compare_values` bug

### DIFF
--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -606,7 +606,8 @@ import InfrastructureSystems:
     get_y_coords,
     get_raw_data_type,
     supports_time_series,
-    supports_supplemental_attributes
+    supports_supplemental_attributes,
+    fast_deepcopy_system
 import InfrastructureSystems:
     ValueCurve,
     InputOutputCurve,

--- a/src/base.jl
+++ b/src/base.jl
@@ -2425,7 +2425,7 @@ function IS.compare_values(
             if !compare_uuids
                 name1 = get_name(val1)
                 name2 = get_name(val2)
-                if !match_fn(name1, name2)
+                if !_fetch_match_fn(match_fn)(name1, name2)
                     @error "values do not match" T name name1 name2
                     match = false
                 end

--- a/src/base.jl
+++ b/src/base.jl
@@ -133,7 +133,7 @@ struct System <: IS.InfrastructureSystemsType
                 "unit_system kwarg ignored. The value in SystemUnitsSetting takes precedence"
             )
         end
-        bus_numbers = Set{Int}()
+        bus_numbers = Set(get_number.(IS.get_components(ACBus, data)))
         return new(
             data,
             frequency,
@@ -2662,3 +2662,39 @@ function check_time_series_consistency(sys::System, ::Type{T}) where {T <: TimeS
 end
 
 stores_time_series_in_memory(sys::System) = IS.stores_time_series_in_memory(sys.data)
+
+"""
+Make a `deepcopy` of a [`System`](@ref) more quickly by skipping the copying of time
+series and/or supplemental attributes.
+
+# Arguments
+
+  - `data::System`: the `System` to copy
+  - `skip_time_series::Bool = true`: whether to skip copying time series
+  - `skip_supplemental_attributes::Bool = true`: whether to skip copying supplemental
+    attributes
+
+Note that setting both `skip_time_series` and `skip_supplemental_attributes` to `false`
+results in the same behavior as `deepcopy` with no performance improvement.
+"""
+function fast_deepcopy_system(
+    sys::System;
+    skip_time_series::Bool = true,
+    skip_supplemental_attributes::Bool = true,
+)
+    new_data = IS.fast_deepcopy_system(
+        sys.data;
+        skip_time_series = skip_time_series,
+        skip_supplemental_attributes = skip_supplemental_attributes,
+    )
+    new_sys = System(
+        new_data,
+        deepcopy(sys.units_settings),
+        deepcopy(sys.internal);
+        runchecks = deepcopy(sys.runchecks[]),
+        frequency = deepcopy(sys.frequency),
+        time_series_directory = deepcopy(sys.time_series_directory),
+        name = deepcopy(sys.metadata.name),
+        description = deepcopy(sys.metadata.description))
+    return new_sys
+end

--- a/src/base.jl
+++ b/src/base.jl
@@ -2696,5 +2696,9 @@ function fast_deepcopy_system(
         time_series_directory = deepcopy(sys.time_series_directory),
         name = deepcopy(sys.metadata.name),
         description = deepcopy(sys.metadata.description))
+    # deepcopying sys.data separately from sys.units_settings broke the shared units references, so we have to fix them here
+    for comp in iterate_components(new_sys)
+        comp.internal.units_info = new_sys.units_settings
+    end
     return new_sys
 end

--- a/test/test_dynamic_generator.jl
+++ b/test/test_dynamic_generator.jl
@@ -482,6 +482,7 @@ end
     @test dynamics[1] == Gen1AVR
     @test get_dynamic_injector(static_gen) == Gen1AVR
     @test get_base_power(static_gen) == get_base_power(Gen1AVR)
+    @test PSY.compare_values(static_gen, deepcopy(static_gen))
 
     remove_component!(sys, Gen1AVR)
     @test isnothing(get_dynamic_injector(static_gen))

--- a/test/test_system.jl
+++ b/test/test_system.jl
@@ -429,6 +429,10 @@ end
                 [:time_series_manager, :supplemental_attribute_manager][[skip_ts, skip_sa]],
             ),
         )
+
+        # We copy the SystemData separately from the other System fields, so the egal-ity of these references could get broken
+        generator = get_component(ThermalStandard, sys2, "322_CT_6")
+        @test sys2.units_settings === generator.internal.units_info
     end
 end
 


### PR DESCRIPTION
This feature constitutes the PSY implementation of https://github.com/NREL-Sienna/PowerSystems.jl/issues/1231. It adds a function `fast_deepcopy_system` that makes a `deepcopy` of a `System` more quickly by skipping the copying of time series and/or supplemental attributes. As part of the implementation, I also fix issue #1233.

Depends on https://github.com/NREL-Sienna/InfrastructureSystems.jl/pull/421.