### PR TITLE
[DRAFT] [PSY5] Add 3W Transformer Struct

### DIFF
--- a/docs/src/explanation/per_unit.md
+++ b/docs/src/explanation/per_unit.md
@@ -19,8 +19,11 @@ These three unit bases allow easy conversion between unit systems.
 This allows `PowerSystems.jl` users to input data in the formats they have available,
 as well as view data in the unit system that is most intuitive to them.
 
-You can get and set the unit system setting of a `System` with [`get_units_base`](@ref)
-and [`set_units_base_system!`](@ref).
+You can get and set the unit system setting of a `System` with [`get_units_base`](@ref) and
+[`set_units_base_system!`](@ref). To support a less stateful style of programming,
+`PowerSystems.jl` provides the `Logging.with_logger`-inspired "context manager"-type
+function [`with_units_base`](@ref), which sets the unit system to a particular value,
+performs some action, then automatically sets the unit system back to its previous value.
 
 Conversion between unit systems does not change
 the stored parameter values. Instead, unit system conversions are made when accessing

--- a/docs/src/tutorials/creating_system.md
+++ b/docs/src/tutorials/creating_system.md
@@ -357,6 +357,18 @@ get_rating(retrieved_component)
 See that now the data is now 1.0 (5.0 MVA per-unitized by the generator (i.e., the device's)
 `base_power` of 5.0 MVA), which is the format we used to originally define the device.
 
+As a shortcut to temporarily set the `System`'s unit system to a particular value, perform
+some action, and then automatically set it back to what it was before, we can use
+`with_units_base` and a [`do` block](https://docs.julialang.org/en/v1/manual/functions/#Do-Block-Syntax-for-Function-Arguments):
+
+```@repl basics
+with_units_base(sys, "NATURAL_UNITS") do
+    # Everything inside this block will run as if the unit system were NATURAL_UNITS
+    get_rating(retrieved_component)
+end
+get_units_base(sys)  # Unit system goes back to previous value when the block ends
+```
+
 Recall that if you ever need to check a `System`'s settings, including the unit system being
 used by all the getter functions, you can always just print the `System`:
 

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -39,6 +39,7 @@ export TModelHVDCLine
 export Transformer2W
 export TapTransformer
 export PhaseShiftingTransformer
+export Transformer3W
 
 # from IS function_data.jl
 export FunctionData

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -416,6 +416,7 @@ export set_description!
 export get_base_power
 export get_frequency
 export set_units_base_system!
+export with_units_base
 export to_json
 export from_json
 export serialize

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -1011,6 +1011,292 @@
             "supertype": "ACBranch"
         },
         {
+            "struct_name": "Transformer3W",
+            "docstring": "A 3-winding transformer.\n\nThe model uses an equivalent star model with a star (hidden) bus. The user must transform the data to use `CW = CZ = CM = 1` and `COD1 = COD2 = COD3 = 0` (no voltage control) if taken from a PSS/E 3W transformer model. Three equivalent impedances (connecting each side to the star bus) are required to define the model. Shunt conductance (iron losses) and magnetizing susceptance can be considered from the star bus to ground. The model is described in Chapter 3.6 in J.D. Glover, M.S. Sarma and T. Overbye: Power Systems Analysis and Design.",
+            "fields": [
+                {
+                    "null_value": "init",
+                    "name": "name",
+                    "comment": "Name of the component. Components of the same type (e.g., `PowerLoad`) must have unique names, but components of different types (e.g., `PowerLoad` and `ACBus`) can have the same name",
+                    "exclude_setter": true,
+                    "data_type": "String"
+                },
+                {
+                    "null_value": "false",
+                    "name": "available",
+                    "comment": "Indicator of whether the component is connected and online (`true`) or disconnected, offline, or down (`false`). Unavailable components are excluded during simulations",
+                    "data_type": "Bool"
+                },
+                {
+                    "null_value": "Arc(ACBus(nothing), ACBus(nothing))",
+                    "name": "primary_secondary_arc",
+                    "comment": "An [`Arc`](@ref) defining this transformer `from` a primary bus `to` a secondary bus",
+                    "data_type": "Arc"
+                },
+                {
+                    "null_value": "Arc(ACBus(nothing), ACBus(nothing))",
+                    "name": "secondary_tertiary_arc",
+                    "comment": "An [`Arc`](@ref) defining this transformer `from` a secondary bus `to` a tertiary bus",
+                    "data_type": "Arc"
+                },
+                {
+                    "null_value": "Arc(ACBus(nothing), ACBus(nothing))",
+                    "name": "primary_tertiary_arc",
+                    "comment": "An [`Arc`](@ref) defining this transformer `from` a primary bus `to` a tertiary bus",
+                    "data_type": "Arc"
+                },
+                {
+                    "name": "star_bus",
+                    "comment": "Star (hidden) Bus that this component (equivalent model) is connected to",
+                    "null_value": "ACBus(nothing)",
+                    "data_type": "ACBus"
+                },
+                {
+                    "name": "active_power_flow_primary",
+                    "comment": "Initial condition of active power flow through the transformer primary side to star (hidden) bus (MW)",
+                    "null_value": "0.0",
+                    "data_type": "Float64",
+                    "needs_conversion": true
+                },
+                {
+                    "name": "reactive_power_flow_primary",
+                    "comment": "Initial condition of reactive power flow through the transformer primary side to star (hidden) bus (MW)",
+                    "null_value": "0.0",
+                    "data_type": "Float64",
+                    "needs_conversion": true
+                },
+                {
+                    "name": "active_power_flow_secondary",
+                    "comment": "Initial condition of active power flow through the transformer secondary side to star (hidden) bus (MW)",
+                    "null_value": "0.0",
+                    "data_type": "Float64",
+                    "needs_conversion": true
+                },
+                {
+                    "name": "reactive_power_flow_secondary",
+                    "comment": "Initial condition of reactive power flow through the transformer secondary side to star (hidden) bus (MW)",
+                    "null_value": "0.0",
+                    "data_type": "Float64",
+                    "needs_conversion": true
+                },
+                {
+                    "name": "active_power_flow_tertiary",
+                    "comment": "Initial condition of active power flow through the transformer tertiary side to star (hidden) bus (MW)",
+                    "null_value": "0.0",
+                    "data_type": "Float64",
+                    "needs_conversion": true
+                },
+                {
+                    "name": "reactive_power_flow_tertiary",
+                    "comment": "Initial condition of reactive power flow through the transformer tertiary side to star (hidden) bus (MW)",
+                    "null_value": "0.0",
+                    "data_type": "Float64",
+                    "needs_conversion": true
+                },
+                {
+                    "null_value": "0.0",
+                    "name": "r_primary",
+                    "data_type": "Float64",
+                    "comment": "Equivalent resistance in pu ([`SYSTEM_BASE`](@ref per_unit)) from primary to star (hidden) bus.",
+                    "valid_range": {
+                        "min": -2,
+                        "max": 4
+                    },
+                    "validation_action": "warn"
+                },
+                {
+                    "null_value": "0.0",
+                    "name": "x_primary",
+                    "data_type": "Float64",
+                    "comment": "Equivalent reactance in pu ([`SYSTEM_BASE`](@ref per_unit)) from primary to star (hidden) bus.",
+                    "valid_range": {
+                        "min": -2,
+                        "max": 4
+                    },
+                    "validation_action": "warn"
+                },
+                {
+                    "null_value": "0.0",
+                    "name": "r_secondary",
+                    "data_type": "Float64",
+                    "comment": "Equivalent resistance in pu ([`SYSTEM_BASE`](@ref per_unit)) from secondary to star (hidden) bus.",
+                    "valid_range": {
+                        "min": -2,
+                        "max": 4
+                    },
+                    "validation_action": "warn"
+                },
+                {
+                    "null_value": "0.0",
+                    "name": "x_secondary",
+                    "data_type": "Float64",
+                    "comment": "Equivalent reactance in pu ([`SYSTEM_BASE`](@ref per_unit)) from secondary to star (hidden) bus.",
+                    "valid_range": {
+                        "min": -2,
+                        "max": 4
+                    },
+                    "validation_action": "warn"
+                },
+                {
+                    "null_value": "0.0",
+                    "name": "r_tertiary",
+                    "data_type": "Float64",
+                    "comment": "Equivalent resistance in pu ([`SYSTEM_BASE`](@ref per_unit)) from tertiary to star (hidden) bus.",
+                    "valid_range": {
+                        "min": -2,
+                        "max": 4
+                    },
+                    "validation_action": "warn"
+                },
+                {
+                    "null_value": "0.0",
+                    "name": "x_tertiary",
+                    "data_type": "Float64",
+                    "comment": "Equivalent reactance in pu ([`SYSTEM_BASE`](@ref per_unit)) from tertiary to star (hidden) bus.",
+                    "valid_range": {
+                        "min": -2,
+                        "max": 4
+                    },
+                    "validation_action": "warn"
+                },
+                {
+                    "name": "rating",
+                    "comment": "Thermal rating (MVA). Flow through the transformer must be between -`rating` and `rating`. When defining a transformer before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to",
+                    "null_value": "nothing",
+                    "data_type": "Union{Nothing, Float64}",
+                    "valid_range": {
+                        "min": 0,
+                        "max": null
+                    },
+                    "validation_action": "error",
+                    "needs_conversion": true
+                },
+                {
+                    "null_value": "0.0",
+                    "name": "r_12",
+                    "data_type": "Float64",
+                    "comment": "Measured resistance in pu ([`SYSTEM_BASE`](@ref per_unit)) from primary to secondary windings (R1-2 with CZ = 1 in PSS/E).",
+                    "valid_range": {
+                        "min": 0,
+                        "max": 4
+                    },
+                    "validation_action": "warn"
+                },
+                {
+                    "null_value": "0.0",
+                    "name": "x_12",
+                    "data_type": "Float64",
+                    "comment": "Measured reactance in pu ([`SYSTEM_BASE`](@ref per_unit)) from primary to secondary windings (X1-2 with CZ = 1 in PSS/E).",
+                    "valid_range": {
+                        "min": 0,
+                        "max": 4
+                    },
+                    "validation_action": "warn"
+                },
+                {
+                    "null_value": "0.0",
+                    "name": "r_23",
+                    "data_type": "Float64",
+                    "comment": "Measured resistance in pu ([`SYSTEM_BASE`](@ref per_unit)) from secondary to tertiary windings (R2-3 with CZ = 1 in PSS/E).",
+                    "valid_range": {
+                        "min": 0,
+                        "max": 4
+                    },
+                    "validation_action": "warn"
+                },
+                {
+                    "null_value": "0.0",
+                    "name": "x_23",
+                    "data_type": "Float64",
+                    "comment": "Measured reactance in pu ([`SYSTEM_BASE`](@ref per_unit)) from secondary to tertiary windings (X2-3 with CZ = 1 in PSS/E).",
+                    "valid_range": {
+                        "min": 0,
+                        "max": 4
+                    },
+                    "validation_action": "warn"
+                },
+                {
+                    "null_value": "0.0",
+                    "name": "r_13",
+                    "data_type": "Float64",
+                    "comment": "Measured resistance in pu ([`SYSTEM_BASE`](@ref per_unit)) from primary to tertiary windings (R1-3 with CZ = 1 in PSS/E).",
+                    "valid_range": {
+                        "min": 0,
+                        "max": 4
+                    },
+                    "validation_action": "warn"
+                },
+                {
+                    "null_value": "0.0",
+                    "name": "x_13",
+                    "data_type": "Float64",
+                    "comment": "Measured reactance in pu ([`SYSTEM_BASE`](@ref per_unit)) from primary to tertiary windings (X1-3 with CZ = 1 in PSS/E).",
+                    "valid_range": {
+                        "min": 0,
+                        "max": 4
+                    },
+                    "validation_action": "warn"
+                },
+                {
+                    "name": "g",
+                    "null_value": "0.0",
+                    "data_type": "Float64",
+                    "comment": "Shunt conductance in pu ([`SYSTEM_BASE`](@ref per_unit)) from star (hidden) bus to ground (MAG1 in PSS/E).",
+                    "default": "0.0"
+                },
+                {
+                    "name": "b",
+                    "null_value": "0.0",
+                    "data_type": "Float64",
+                    "comment": "Shunt susceptance in pu ([`SYSTEM_BASE`](@ref per_unit)) from star (hidden) bus to ground (MAG2 in PSS/E).",
+                    "default": "0.0"
+                },
+                {
+                    "null_value": "0.0",
+                    "name": "primary_turns_ratio",
+                    "data_type": "Float64",
+                    "comment": "Primary side off-nominal turns ratio in p.u. with respect to connected primary bus (WINDV1 with CW = 1 in PSS/E).",
+                    "default": "1.0"
+                },
+                {
+                    "null_value": "0.0",
+                    "name": "secondary_turns_ratio",
+                    "data_type": "Float64",
+                    "comment": "Secondary side off-nominal turns ratio in p.u. with respect to connected secondary bus (WINDV2 with CW = 1 in PSS/E).",
+                    "default": "1.0"
+                },
+                {
+                    "null_value": "0.0",
+                    "name": "tertiary_turns_ratio",
+                    "data_type": "Float64",
+                    "comment": "Tertiary side off-nominal turns ratio in p.u. with respect to connected tertiary bus (WINDV3 with CW = 1 in PSS/E).",
+                    "default": "1.0"
+                },
+                {
+                    "name": "services",
+                    "data_type": "Vector{Service}",
+                    "comment": "Services that this device contributes to",
+                    "null_value": "Device[]",
+                    "default": "Device[]"
+                },
+                {
+                    "name": "ext",
+                    "comment": "An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation, such as latitude and longitude.",
+                    "data_type": "Dict{String, Any}",
+                    "null_value": "Dict{String, Any}()",
+                    "default": "Dict{String, Any}()"
+                },
+                {
+                    "name": "internal",
+                    "comment": "(**Do not modify.**) PowerSystems.jl internal reference",
+                    "data_type": "InfrastructureSystemsInternal",
+                    "internal_default": "InfrastructureSystemsInternal()",
+                    "exclude_setter": true
+                }
+            ],
+            "supertype": "ACBranch"
+        },
+        {
             "struct_name": "TwoTerminalHVDCLine",
             "docstring": "A High Voltage DC line, which must be connected to an [`ACBus`](@ref) on each end.\n\nThis model is appropriate for operational simulations with a linearized DC power flow approximation with losses proportional to the power flow. For modeling a DC network, see [`TModelHVDCLine`](@ref)",
             "fields": [

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -1273,6 +1273,51 @@
                     "default": "1.0"
                 },
                 {
+                    "null_value": "false",
+                    "name": "available_primary",
+                    "data_type": "Bool",
+                    "comment": "Status if primary winding is available or not.",
+                    "default": "true"
+                },
+                {
+                    "null_value": "false",
+                    "name": "available_secondary",
+                    "data_type": "Bool",
+                    "comment": "Status if primary winding is available or not.",
+                    "default": "true"
+                },
+                {
+                    "null_value": "false",
+                    "name": "available_tertiary",
+                    "data_type": "Bool",
+                    "comment": "Status if primary winding is available or not.",
+                    "default": "true"
+                },
+                {
+                    "null_value": "0.0",
+                    "name": "rating_primary",
+                    "data_type": "Float64",
+                    "comment": "Rating (in MVA) for primary winding.",
+                    "default": "0.0",
+                    "needs_conversion": true
+                },
+                {
+                    "null_value": "0.0",
+                    "name": "rating_secondary",
+                    "data_type": "Float64",
+                    "comment": "Rating (in MVA) for secondary winding.",
+                    "default": "0.0",
+                    "needs_conversion": true
+                },
+                {
+                    "null_value": "0.0",
+                    "name": "rating_tertiary",
+                    "data_type": "Float64",
+                    "comment": "Rating (in MVA) for tertiary winding.",
+                    "default": "0.0",
+                    "needs_conversion": true
+                },
+                {
                     "name": "services",
                     "data_type": "Vector{Service}",
                     "comment": "Services that this device contributes to",

--- a/src/models/generated/Transformer3W.jl
+++ b/src/models/generated/Transformer3W.jl
@@ -36,6 +36,12 @@ This file is auto-generated. Do not edit.
         primary_turns_ratio::Float64
         secondary_turns_ratio::Float64
         tertiary_turns_ratio::Float64
+        available_primary::Bool
+        available_secondary::Bool
+        available_tertiary::Bool
+        rating_primary::Float64
+        rating_secondary::Float64
+        rating_tertiary::Float64
         services::Vector{Service}
         ext::Dict{String, Any}
         internal::InfrastructureSystemsInternal
@@ -76,6 +82,12 @@ The model uses an equivalent star model with a star (hidden) bus. The user must 
 - `primary_turns_ratio::Float64`: (default: `1.0`) Primary side off-nominal turns ratio in p.u. with respect to connected primary bus (WINDV1 with CW = 1 in PSS/E).
 - `secondary_turns_ratio::Float64`: (default: `1.0`) Secondary side off-nominal turns ratio in p.u. with respect to connected secondary bus (WINDV2 with CW = 1 in PSS/E).
 - `tertiary_turns_ratio::Float64`: (default: `1.0`) Tertiary side off-nominal turns ratio in p.u. with respect to connected tertiary bus (WINDV3 with CW = 1 in PSS/E).
+- `available_primary::Bool`: (default: `true`) Status if primary winding is available or not.
+- `available_secondary::Bool`: (default: `true`) Status if primary winding is available or not.
+- `available_tertiary::Bool`: (default: `true`) Status if primary winding is available or not.
+- `rating_primary::Float64`: (default: `0.0`) Rating (in MVA) for primary winding.
+- `rating_secondary::Float64`: (default: `0.0`) Rating (in MVA) for secondary winding.
+- `rating_tertiary::Float64`: (default: `0.0`) Rating (in MVA) for tertiary winding.
 - `services::Vector{Service}`: (default: `Device[]`) Services that this device contributes to
 - `ext::Dict{String, Any}`: (default: `Dict{String, Any}()`) An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation, such as latitude and longitude.
 - `internal::InfrastructureSystemsInternal`: (**Do not modify.**) PowerSystems.jl internal reference
@@ -141,6 +153,18 @@ mutable struct Transformer3W <: ACBranch
     secondary_turns_ratio::Float64
     "Tertiary side off-nominal turns ratio in p.u. with respect to connected tertiary bus (WINDV3 with CW = 1 in PSS/E)."
     tertiary_turns_ratio::Float64
+    "Status if primary winding is available or not."
+    available_primary::Bool
+    "Status if primary winding is available or not."
+    available_secondary::Bool
+    "Status if primary winding is available or not."
+    available_tertiary::Bool
+    "Rating (in MVA) for primary winding."
+    rating_primary::Float64
+    "Rating (in MVA) for secondary winding."
+    rating_secondary::Float64
+    "Rating (in MVA) for tertiary winding."
+    rating_tertiary::Float64
     "Services that this device contributes to"
     services::Vector{Service}
     "An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation, such as latitude and longitude."
@@ -149,12 +173,12 @@ mutable struct Transformer3W <: ACBranch
     internal::InfrastructureSystemsInternal
 end
 
-function Transformer3W(name, available, primary_secondary_arc, secondary_tertiary_arc, primary_tertiary_arc, star_bus, active_power_flow_primary, reactive_power_flow_primary, active_power_flow_secondary, reactive_power_flow_secondary, active_power_flow_tertiary, reactive_power_flow_tertiary, r_primary, x_primary, r_secondary, x_secondary, r_tertiary, x_tertiary, rating, r_12, x_12, r_23, x_23, r_13, x_13, g=0.0, b=0.0, primary_turns_ratio=1.0, secondary_turns_ratio=1.0, tertiary_turns_ratio=1.0, services=Device[], ext=Dict{String, Any}(), )
-    Transformer3W(name, available, primary_secondary_arc, secondary_tertiary_arc, primary_tertiary_arc, star_bus, active_power_flow_primary, reactive_power_flow_primary, active_power_flow_secondary, reactive_power_flow_secondary, active_power_flow_tertiary, reactive_power_flow_tertiary, r_primary, x_primary, r_secondary, x_secondary, r_tertiary, x_tertiary, rating, r_12, x_12, r_23, x_23, r_13, x_13, g, b, primary_turns_ratio, secondary_turns_ratio, tertiary_turns_ratio, services, ext, InfrastructureSystemsInternal(), )
+function Transformer3W(name, available, primary_secondary_arc, secondary_tertiary_arc, primary_tertiary_arc, star_bus, active_power_flow_primary, reactive_power_flow_primary, active_power_flow_secondary, reactive_power_flow_secondary, active_power_flow_tertiary, reactive_power_flow_tertiary, r_primary, x_primary, r_secondary, x_secondary, r_tertiary, x_tertiary, rating, r_12, x_12, r_23, x_23, r_13, x_13, g=0.0, b=0.0, primary_turns_ratio=1.0, secondary_turns_ratio=1.0, tertiary_turns_ratio=1.0, available_primary=true, available_secondary=true, available_tertiary=true, rating_primary=0.0, rating_secondary=0.0, rating_tertiary=0.0, services=Device[], ext=Dict{String, Any}(), )
+    Transformer3W(name, available, primary_secondary_arc, secondary_tertiary_arc, primary_tertiary_arc, star_bus, active_power_flow_primary, reactive_power_flow_primary, active_power_flow_secondary, reactive_power_flow_secondary, active_power_flow_tertiary, reactive_power_flow_tertiary, r_primary, x_primary, r_secondary, x_secondary, r_tertiary, x_tertiary, rating, r_12, x_12, r_23, x_23, r_13, x_13, g, b, primary_turns_ratio, secondary_turns_ratio, tertiary_turns_ratio, available_primary, available_secondary, available_tertiary, rating_primary, rating_secondary, rating_tertiary, services, ext, InfrastructureSystemsInternal(), )
 end
 
-function Transformer3W(; name, available, primary_secondary_arc, secondary_tertiary_arc, primary_tertiary_arc, star_bus, active_power_flow_primary, reactive_power_flow_primary, active_power_flow_secondary, reactive_power_flow_secondary, active_power_flow_tertiary, reactive_power_flow_tertiary, r_primary, x_primary, r_secondary, x_secondary, r_tertiary, x_tertiary, rating, r_12, x_12, r_23, x_23, r_13, x_13, g=0.0, b=0.0, primary_turns_ratio=1.0, secondary_turns_ratio=1.0, tertiary_turns_ratio=1.0, services=Device[], ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
-    Transformer3W(name, available, primary_secondary_arc, secondary_tertiary_arc, primary_tertiary_arc, star_bus, active_power_flow_primary, reactive_power_flow_primary, active_power_flow_secondary, reactive_power_flow_secondary, active_power_flow_tertiary, reactive_power_flow_tertiary, r_primary, x_primary, r_secondary, x_secondary, r_tertiary, x_tertiary, rating, r_12, x_12, r_23, x_23, r_13, x_13, g, b, primary_turns_ratio, secondary_turns_ratio, tertiary_turns_ratio, services, ext, internal, )
+function Transformer3W(; name, available, primary_secondary_arc, secondary_tertiary_arc, primary_tertiary_arc, star_bus, active_power_flow_primary, reactive_power_flow_primary, active_power_flow_secondary, reactive_power_flow_secondary, active_power_flow_tertiary, reactive_power_flow_tertiary, r_primary, x_primary, r_secondary, x_secondary, r_tertiary, x_tertiary, rating, r_12, x_12, r_23, x_23, r_13, x_13, g=0.0, b=0.0, primary_turns_ratio=1.0, secondary_turns_ratio=1.0, tertiary_turns_ratio=1.0, available_primary=true, available_secondary=true, available_tertiary=true, rating_primary=0.0, rating_secondary=0.0, rating_tertiary=0.0, services=Device[], ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+    Transformer3W(name, available, primary_secondary_arc, secondary_tertiary_arc, primary_tertiary_arc, star_bus, active_power_flow_primary, reactive_power_flow_primary, active_power_flow_secondary, reactive_power_flow_secondary, active_power_flow_tertiary, reactive_power_flow_tertiary, r_primary, x_primary, r_secondary, x_secondary, r_tertiary, x_tertiary, rating, r_12, x_12, r_23, x_23, r_13, x_13, g, b, primary_turns_ratio, secondary_turns_ratio, tertiary_turns_ratio, available_primary, available_secondary, available_tertiary, rating_primary, rating_secondary, rating_tertiary, services, ext, internal, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -190,6 +214,12 @@ function Transformer3W(::Nothing)
         primary_turns_ratio=0.0,
         secondary_turns_ratio=0.0,
         tertiary_turns_ratio=0.0,
+        available_primary=false,
+        available_secondary=false,
+        available_tertiary=false,
+        rating_primary=0.0,
+        rating_secondary=0.0,
+        rating_tertiary=0.0,
         services=Device[],
         ext=Dict{String, Any}(),
     )
@@ -255,6 +285,18 @@ get_primary_turns_ratio(value::Transformer3W) = value.primary_turns_ratio
 get_secondary_turns_ratio(value::Transformer3W) = value.secondary_turns_ratio
 """Get [`Transformer3W`](@ref) `tertiary_turns_ratio`."""
 get_tertiary_turns_ratio(value::Transformer3W) = value.tertiary_turns_ratio
+"""Get [`Transformer3W`](@ref) `available_primary`."""
+get_available_primary(value::Transformer3W) = value.available_primary
+"""Get [`Transformer3W`](@ref) `available_secondary`."""
+get_available_secondary(value::Transformer3W) = value.available_secondary
+"""Get [`Transformer3W`](@ref) `available_tertiary`."""
+get_available_tertiary(value::Transformer3W) = value.available_tertiary
+"""Get [`Transformer3W`](@ref) `rating_primary`."""
+get_rating_primary(value::Transformer3W) = get_value(value, value.rating_primary)
+"""Get [`Transformer3W`](@ref) `rating_secondary`."""
+get_rating_secondary(value::Transformer3W) = get_value(value, value.rating_secondary)
+"""Get [`Transformer3W`](@ref) `rating_tertiary`."""
+get_rating_tertiary(value::Transformer3W) = get_value(value, value.rating_tertiary)
 """Get [`Transformer3W`](@ref) `services`."""
 get_services(value::Transformer3W) = value.services
 """Get [`Transformer3W`](@ref) `ext`."""
@@ -320,6 +362,18 @@ set_primary_turns_ratio!(value::Transformer3W, val) = value.primary_turns_ratio 
 set_secondary_turns_ratio!(value::Transformer3W, val) = value.secondary_turns_ratio = val
 """Set [`Transformer3W`](@ref) `tertiary_turns_ratio`."""
 set_tertiary_turns_ratio!(value::Transformer3W, val) = value.tertiary_turns_ratio = val
+"""Set [`Transformer3W`](@ref) `available_primary`."""
+set_available_primary!(value::Transformer3W, val) = value.available_primary = val
+"""Set [`Transformer3W`](@ref) `available_secondary`."""
+set_available_secondary!(value::Transformer3W, val) = value.available_secondary = val
+"""Set [`Transformer3W`](@ref) `available_tertiary`."""
+set_available_tertiary!(value::Transformer3W, val) = value.available_tertiary = val
+"""Set [`Transformer3W`](@ref) `rating_primary`."""
+set_rating_primary!(value::Transformer3W, val) = value.rating_primary = set_value(value, val)
+"""Set [`Transformer3W`](@ref) `rating_secondary`."""
+set_rating_secondary!(value::Transformer3W, val) = value.rating_secondary = set_value(value, val)
+"""Set [`Transformer3W`](@ref) `rating_tertiary`."""
+set_rating_tertiary!(value::Transformer3W, val) = value.rating_tertiary = set_value(value, val)
 """Set [`Transformer3W`](@ref) `services`."""
 set_services!(value::Transformer3W, val) = value.services = val
 """Set [`Transformer3W`](@ref) `ext`."""

--- a/src/models/generated/Transformer3W.jl
+++ b/src/models/generated/Transformer3W.jl
@@ -1,0 +1,326 @@
+#=
+This file is auto-generated. Do not edit.
+=#
+
+#! format: off
+
+"""
+    mutable struct Transformer3W <: ACBranch
+        name::String
+        available::Bool
+        primary_secondary_arc::Arc
+        secondary_tertiary_arc::Arc
+        primary_tertiary_arc::Arc
+        star_bus::ACBus
+        active_power_flow_primary::Float64
+        reactive_power_flow_primary::Float64
+        active_power_flow_secondary::Float64
+        reactive_power_flow_secondary::Float64
+        active_power_flow_tertiary::Float64
+        reactive_power_flow_tertiary::Float64
+        r_primary::Float64
+        x_primary::Float64
+        r_secondary::Float64
+        x_secondary::Float64
+        r_tertiary::Float64
+        x_tertiary::Float64
+        rating::Union{Nothing, Float64}
+        r_12::Float64
+        x_12::Float64
+        r_23::Float64
+        x_23::Float64
+        r_13::Float64
+        x_13::Float64
+        g::Float64
+        b::Float64
+        primary_turns_ratio::Float64
+        secondary_turns_ratio::Float64
+        tertiary_turns_ratio::Float64
+        services::Vector{Service}
+        ext::Dict{String, Any}
+        internal::InfrastructureSystemsInternal
+    end
+
+A 3-winding transformer.
+
+The model uses an equivalent star model with a star (hidden) bus. The user must transform the data to use `CW = CZ = CM = 1` and `COD1 = COD2 = COD3 = 0` (no voltage control) if taken from a PSS/E 3W transformer model. Three equivalent impedances (connecting each side to the star bus) are required to define the model. Shunt conductance (iron losses) and magnetizing susceptance can be considered from the star bus to ground. The model is described in Chapter 3.6 in J.D. Glover, M.S. Sarma and T. Overbye: Power Systems Analysis and Design.
+
+# Arguments
+- `name::String`: Name of the component. Components of the same type (e.g., `PowerLoad`) must have unique names, but components of different types (e.g., `PowerLoad` and `ACBus`) can have the same name
+- `available::Bool`: Indicator of whether the component is connected and online (`true`) or disconnected, offline, or down (`false`). Unavailable components are excluded during simulations
+- `primary_secondary_arc::Arc`: An [`Arc`](@ref) defining this transformer `from` a primary bus `to` a secondary bus
+- `secondary_tertiary_arc::Arc`: An [`Arc`](@ref) defining this transformer `from` a secondary bus `to` a tertiary bus
+- `primary_tertiary_arc::Arc`: An [`Arc`](@ref) defining this transformer `from` a primary bus `to` a tertiary bus
+- `star_bus::ACBus`: Star (hidden) Bus that this component (equivalent model) is connected to
+- `active_power_flow_primary::Float64`: Initial condition of active power flow through the transformer primary side to star (hidden) bus (MW)
+- `reactive_power_flow_primary::Float64`: Initial condition of reactive power flow through the transformer primary side to star (hidden) bus (MW)
+- `active_power_flow_secondary::Float64`: Initial condition of active power flow through the transformer secondary side to star (hidden) bus (MW)
+- `reactive_power_flow_secondary::Float64`: Initial condition of reactive power flow through the transformer secondary side to star (hidden) bus (MW)
+- `active_power_flow_tertiary::Float64`: Initial condition of active power flow through the transformer tertiary side to star (hidden) bus (MW)
+- `reactive_power_flow_tertiary::Float64`: Initial condition of reactive power flow through the transformer tertiary side to star (hidden) bus (MW)
+- `r_primary::Float64`: Equivalent resistance in pu ([`SYSTEM_BASE`](@ref per_unit)) from primary to star (hidden) bus., validation range: `(-2, 4)`
+- `x_primary::Float64`: Equivalent reactance in pu ([`SYSTEM_BASE`](@ref per_unit)) from primary to star (hidden) bus., validation range: `(-2, 4)`
+- `r_secondary::Float64`: Equivalent resistance in pu ([`SYSTEM_BASE`](@ref per_unit)) from secondary to star (hidden) bus., validation range: `(-2, 4)`
+- `x_secondary::Float64`: Equivalent reactance in pu ([`SYSTEM_BASE`](@ref per_unit)) from secondary to star (hidden) bus., validation range: `(-2, 4)`
+- `r_tertiary::Float64`: Equivalent resistance in pu ([`SYSTEM_BASE`](@ref per_unit)) from tertiary to star (hidden) bus., validation range: `(-2, 4)`
+- `x_tertiary::Float64`: Equivalent reactance in pu ([`SYSTEM_BASE`](@ref per_unit)) from tertiary to star (hidden) bus., validation range: `(-2, 4)`
+- `rating::Union{Nothing, Float64}`: Thermal rating (MVA). Flow through the transformer must be between -`rating` and `rating`. When defining a transformer before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to, validation range: `(0, nothing)`
+- `r_12::Float64`: Measured resistance in pu ([`SYSTEM_BASE`](@ref per_unit)) from primary to secondary windings (R1-2 with CZ = 1 in PSS/E)., validation range: `(0, 4)`
+- `x_12::Float64`: Measured reactance in pu ([`SYSTEM_BASE`](@ref per_unit)) from primary to secondary windings (X1-2 with CZ = 1 in PSS/E)., validation range: `(0, 4)`
+- `r_23::Float64`: Measured resistance in pu ([`SYSTEM_BASE`](@ref per_unit)) from secondary to tertiary windings (R2-3 with CZ = 1 in PSS/E)., validation range: `(0, 4)`
+- `x_23::Float64`: Measured reactance in pu ([`SYSTEM_BASE`](@ref per_unit)) from secondary to tertiary windings (X2-3 with CZ = 1 in PSS/E)., validation range: `(0, 4)`
+- `r_13::Float64`: Measured resistance in pu ([`SYSTEM_BASE`](@ref per_unit)) from primary to tertiary windings (R1-3 with CZ = 1 in PSS/E)., validation range: `(0, 4)`
+- `x_13::Float64`: Measured reactance in pu ([`SYSTEM_BASE`](@ref per_unit)) from primary to tertiary windings (X1-3 with CZ = 1 in PSS/E)., validation range: `(0, 4)`
+- `g::Float64`: (default: `0.0`) Shunt conductance in pu ([`SYSTEM_BASE`](@ref per_unit)) from star (hidden) bus to ground (MAG1 in PSS/E).
+- `b::Float64`: (default: `0.0`) Shunt susceptance in pu ([`SYSTEM_BASE`](@ref per_unit)) from star (hidden) bus to ground (MAG2 in PSS/E).
+- `primary_turns_ratio::Float64`: (default: `1.0`) Primary side off-nominal turns ratio in p.u. with respect to connected primary bus (WINDV1 with CW = 1 in PSS/E).
+- `secondary_turns_ratio::Float64`: (default: `1.0`) Secondary side off-nominal turns ratio in p.u. with respect to connected secondary bus (WINDV2 with CW = 1 in PSS/E).
+- `tertiary_turns_ratio::Float64`: (default: `1.0`) Tertiary side off-nominal turns ratio in p.u. with respect to connected tertiary bus (WINDV3 with CW = 1 in PSS/E).
+- `services::Vector{Service}`: (default: `Device[]`) Services that this device contributes to
+- `ext::Dict{String, Any}`: (default: `Dict{String, Any}()`) An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation, such as latitude and longitude.
+- `internal::InfrastructureSystemsInternal`: (**Do not modify.**) PowerSystems.jl internal reference
+"""
+mutable struct Transformer3W <: ACBranch
+    "Name of the component. Components of the same type (e.g., `PowerLoad`) must have unique names, but components of different types (e.g., `PowerLoad` and `ACBus`) can have the same name"
+    name::String
+    "Indicator of whether the component is connected and online (`true`) or disconnected, offline, or down (`false`). Unavailable components are excluded during simulations"
+    available::Bool
+    "An [`Arc`](@ref) defining this transformer `from` a primary bus `to` a secondary bus"
+    primary_secondary_arc::Arc
+    "An [`Arc`](@ref) defining this transformer `from` a secondary bus `to` a tertiary bus"
+    secondary_tertiary_arc::Arc
+    "An [`Arc`](@ref) defining this transformer `from` a primary bus `to` a tertiary bus"
+    primary_tertiary_arc::Arc
+    "Star (hidden) Bus that this component (equivalent model) is connected to"
+    star_bus::ACBus
+    "Initial condition of active power flow through the transformer primary side to star (hidden) bus (MW)"
+    active_power_flow_primary::Float64
+    "Initial condition of reactive power flow through the transformer primary side to star (hidden) bus (MW)"
+    reactive_power_flow_primary::Float64
+    "Initial condition of active power flow through the transformer secondary side to star (hidden) bus (MW)"
+    active_power_flow_secondary::Float64
+    "Initial condition of reactive power flow through the transformer secondary side to star (hidden) bus (MW)"
+    reactive_power_flow_secondary::Float64
+    "Initial condition of active power flow through the transformer tertiary side to star (hidden) bus (MW)"
+    active_power_flow_tertiary::Float64
+    "Initial condition of reactive power flow through the transformer tertiary side to star (hidden) bus (MW)"
+    reactive_power_flow_tertiary::Float64
+    "Equivalent resistance in pu ([`SYSTEM_BASE`](@ref per_unit)) from primary to star (hidden) bus."
+    r_primary::Float64
+    "Equivalent reactance in pu ([`SYSTEM_BASE`](@ref per_unit)) from primary to star (hidden) bus."
+    x_primary::Float64
+    "Equivalent resistance in pu ([`SYSTEM_BASE`](@ref per_unit)) from secondary to star (hidden) bus."
+    r_secondary::Float64
+    "Equivalent reactance in pu ([`SYSTEM_BASE`](@ref per_unit)) from secondary to star (hidden) bus."
+    x_secondary::Float64
+    "Equivalent resistance in pu ([`SYSTEM_BASE`](@ref per_unit)) from tertiary to star (hidden) bus."
+    r_tertiary::Float64
+    "Equivalent reactance in pu ([`SYSTEM_BASE`](@ref per_unit)) from tertiary to star (hidden) bus."
+    x_tertiary::Float64
+    "Thermal rating (MVA). Flow through the transformer must be between -`rating` and `rating`. When defining a transformer before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to"
+    rating::Union{Nothing, Float64}
+    "Measured resistance in pu ([`SYSTEM_BASE`](@ref per_unit)) from primary to secondary windings (R1-2 with CZ = 1 in PSS/E)."
+    r_12::Float64
+    "Measured reactance in pu ([`SYSTEM_BASE`](@ref per_unit)) from primary to secondary windings (X1-2 with CZ = 1 in PSS/E)."
+    x_12::Float64
+    "Measured resistance in pu ([`SYSTEM_BASE`](@ref per_unit)) from secondary to tertiary windings (R2-3 with CZ = 1 in PSS/E)."
+    r_23::Float64
+    "Measured reactance in pu ([`SYSTEM_BASE`](@ref per_unit)) from secondary to tertiary windings (X2-3 with CZ = 1 in PSS/E)."
+    x_23::Float64
+    "Measured resistance in pu ([`SYSTEM_BASE`](@ref per_unit)) from primary to tertiary windings (R1-3 with CZ = 1 in PSS/E)."
+    r_13::Float64
+    "Measured reactance in pu ([`SYSTEM_BASE`](@ref per_unit)) from primary to tertiary windings (X1-3 with CZ = 1 in PSS/E)."
+    x_13::Float64
+    "Shunt conductance in pu ([`SYSTEM_BASE`](@ref per_unit)) from star (hidden) bus to ground (MAG1 in PSS/E)."
+    g::Float64
+    "Shunt susceptance in pu ([`SYSTEM_BASE`](@ref per_unit)) from star (hidden) bus to ground (MAG2 in PSS/E)."
+    b::Float64
+    "Primary side off-nominal turns ratio in p.u. with respect to connected primary bus (WINDV1 with CW = 1 in PSS/E)."
+    primary_turns_ratio::Float64
+    "Secondary side off-nominal turns ratio in p.u. with respect to connected secondary bus (WINDV2 with CW = 1 in PSS/E)."
+    secondary_turns_ratio::Float64
+    "Tertiary side off-nominal turns ratio in p.u. with respect to connected tertiary bus (WINDV3 with CW = 1 in PSS/E)."
+    tertiary_turns_ratio::Float64
+    "Services that this device contributes to"
+    services::Vector{Service}
+    "An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation, such as latitude and longitude."
+    ext::Dict{String, Any}
+    "(**Do not modify.**) PowerSystems.jl internal reference"
+    internal::InfrastructureSystemsInternal
+end
+
+function Transformer3W(name, available, primary_secondary_arc, secondary_tertiary_arc, primary_tertiary_arc, star_bus, active_power_flow_primary, reactive_power_flow_primary, active_power_flow_secondary, reactive_power_flow_secondary, active_power_flow_tertiary, reactive_power_flow_tertiary, r_primary, x_primary, r_secondary, x_secondary, r_tertiary, x_tertiary, rating, r_12, x_12, r_23, x_23, r_13, x_13, g=0.0, b=0.0, primary_turns_ratio=1.0, secondary_turns_ratio=1.0, tertiary_turns_ratio=1.0, services=Device[], ext=Dict{String, Any}(), )
+    Transformer3W(name, available, primary_secondary_arc, secondary_tertiary_arc, primary_tertiary_arc, star_bus, active_power_flow_primary, reactive_power_flow_primary, active_power_flow_secondary, reactive_power_flow_secondary, active_power_flow_tertiary, reactive_power_flow_tertiary, r_primary, x_primary, r_secondary, x_secondary, r_tertiary, x_tertiary, rating, r_12, x_12, r_23, x_23, r_13, x_13, g, b, primary_turns_ratio, secondary_turns_ratio, tertiary_turns_ratio, services, ext, InfrastructureSystemsInternal(), )
+end
+
+function Transformer3W(; name, available, primary_secondary_arc, secondary_tertiary_arc, primary_tertiary_arc, star_bus, active_power_flow_primary, reactive_power_flow_primary, active_power_flow_secondary, reactive_power_flow_secondary, active_power_flow_tertiary, reactive_power_flow_tertiary, r_primary, x_primary, r_secondary, x_secondary, r_tertiary, x_tertiary, rating, r_12, x_12, r_23, x_23, r_13, x_13, g=0.0, b=0.0, primary_turns_ratio=1.0, secondary_turns_ratio=1.0, tertiary_turns_ratio=1.0, services=Device[], ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+    Transformer3W(name, available, primary_secondary_arc, secondary_tertiary_arc, primary_tertiary_arc, star_bus, active_power_flow_primary, reactive_power_flow_primary, active_power_flow_secondary, reactive_power_flow_secondary, active_power_flow_tertiary, reactive_power_flow_tertiary, r_primary, x_primary, r_secondary, x_secondary, r_tertiary, x_tertiary, rating, r_12, x_12, r_23, x_23, r_13, x_13, g, b, primary_turns_ratio, secondary_turns_ratio, tertiary_turns_ratio, services, ext, internal, )
+end
+
+# Constructor for demo purposes; non-functional.
+function Transformer3W(::Nothing)
+    Transformer3W(;
+        name="init",
+        available=false,
+        primary_secondary_arc=Arc(ACBus(nothing), ACBus(nothing)),
+        secondary_tertiary_arc=Arc(ACBus(nothing), ACBus(nothing)),
+        primary_tertiary_arc=Arc(ACBus(nothing), ACBus(nothing)),
+        star_bus=ACBus(nothing),
+        active_power_flow_primary=0.0,
+        reactive_power_flow_primary=0.0,
+        active_power_flow_secondary=0.0,
+        reactive_power_flow_secondary=0.0,
+        active_power_flow_tertiary=0.0,
+        reactive_power_flow_tertiary=0.0,
+        r_primary=0.0,
+        x_primary=0.0,
+        r_secondary=0.0,
+        x_secondary=0.0,
+        r_tertiary=0.0,
+        x_tertiary=0.0,
+        rating=nothing,
+        r_12=0.0,
+        x_12=0.0,
+        r_23=0.0,
+        x_23=0.0,
+        r_13=0.0,
+        x_13=0.0,
+        g=0.0,
+        b=0.0,
+        primary_turns_ratio=0.0,
+        secondary_turns_ratio=0.0,
+        tertiary_turns_ratio=0.0,
+        services=Device[],
+        ext=Dict{String, Any}(),
+    )
+end
+
+"""Get [`Transformer3W`](@ref) `name`."""
+get_name(value::Transformer3W) = value.name
+"""Get [`Transformer3W`](@ref) `available`."""
+get_available(value::Transformer3W) = value.available
+"""Get [`Transformer3W`](@ref) `primary_secondary_arc`."""
+get_primary_secondary_arc(value::Transformer3W) = value.primary_secondary_arc
+"""Get [`Transformer3W`](@ref) `secondary_tertiary_arc`."""
+get_secondary_tertiary_arc(value::Transformer3W) = value.secondary_tertiary_arc
+"""Get [`Transformer3W`](@ref) `primary_tertiary_arc`."""
+get_primary_tertiary_arc(value::Transformer3W) = value.primary_tertiary_arc
+"""Get [`Transformer3W`](@ref) `star_bus`."""
+get_star_bus(value::Transformer3W) = value.star_bus
+"""Get [`Transformer3W`](@ref) `active_power_flow_primary`."""
+get_active_power_flow_primary(value::Transformer3W) = get_value(value, value.active_power_flow_primary)
+"""Get [`Transformer3W`](@ref) `reactive_power_flow_primary`."""
+get_reactive_power_flow_primary(value::Transformer3W) = get_value(value, value.reactive_power_flow_primary)
+"""Get [`Transformer3W`](@ref) `active_power_flow_secondary`."""
+get_active_power_flow_secondary(value::Transformer3W) = get_value(value, value.active_power_flow_secondary)
+"""Get [`Transformer3W`](@ref) `reactive_power_flow_secondary`."""
+get_reactive_power_flow_secondary(value::Transformer3W) = get_value(value, value.reactive_power_flow_secondary)
+"""Get [`Transformer3W`](@ref) `active_power_flow_tertiary`."""
+get_active_power_flow_tertiary(value::Transformer3W) = get_value(value, value.active_power_flow_tertiary)
+"""Get [`Transformer3W`](@ref) `reactive_power_flow_tertiary`."""
+get_reactive_power_flow_tertiary(value::Transformer3W) = get_value(value, value.reactive_power_flow_tertiary)
+"""Get [`Transformer3W`](@ref) `r_primary`."""
+get_r_primary(value::Transformer3W) = value.r_primary
+"""Get [`Transformer3W`](@ref) `x_primary`."""
+get_x_primary(value::Transformer3W) = value.x_primary
+"""Get [`Transformer3W`](@ref) `r_secondary`."""
+get_r_secondary(value::Transformer3W) = value.r_secondary
+"""Get [`Transformer3W`](@ref) `x_secondary`."""
+get_x_secondary(value::Transformer3W) = value.x_secondary
+"""Get [`Transformer3W`](@ref) `r_tertiary`."""
+get_r_tertiary(value::Transformer3W) = value.r_tertiary
+"""Get [`Transformer3W`](@ref) `x_tertiary`."""
+get_x_tertiary(value::Transformer3W) = value.x_tertiary
+"""Get [`Transformer3W`](@ref) `rating`."""
+get_rating(value::Transformer3W) = get_value(value, value.rating)
+"""Get [`Transformer3W`](@ref) `r_12`."""
+get_r_12(value::Transformer3W) = value.r_12
+"""Get [`Transformer3W`](@ref) `x_12`."""
+get_x_12(value::Transformer3W) = value.x_12
+"""Get [`Transformer3W`](@ref) `r_23`."""
+get_r_23(value::Transformer3W) = value.r_23
+"""Get [`Transformer3W`](@ref) `x_23`."""
+get_x_23(value::Transformer3W) = value.x_23
+"""Get [`Transformer3W`](@ref) `r_13`."""
+get_r_13(value::Transformer3W) = value.r_13
+"""Get [`Transformer3W`](@ref) `x_13`."""
+get_x_13(value::Transformer3W) = value.x_13
+"""Get [`Transformer3W`](@ref) `g`."""
+get_g(value::Transformer3W) = value.g
+"""Get [`Transformer3W`](@ref) `b`."""
+get_b(value::Transformer3W) = value.b
+"""Get [`Transformer3W`](@ref) `primary_turns_ratio`."""
+get_primary_turns_ratio(value::Transformer3W) = value.primary_turns_ratio
+"""Get [`Transformer3W`](@ref) `secondary_turns_ratio`."""
+get_secondary_turns_ratio(value::Transformer3W) = value.secondary_turns_ratio
+"""Get [`Transformer3W`](@ref) `tertiary_turns_ratio`."""
+get_tertiary_turns_ratio(value::Transformer3W) = value.tertiary_turns_ratio
+"""Get [`Transformer3W`](@ref) `services`."""
+get_services(value::Transformer3W) = value.services
+"""Get [`Transformer3W`](@ref) `ext`."""
+get_ext(value::Transformer3W) = value.ext
+"""Get [`Transformer3W`](@ref) `internal`."""
+get_internal(value::Transformer3W) = value.internal
+
+"""Set [`Transformer3W`](@ref) `available`."""
+set_available!(value::Transformer3W, val) = value.available = val
+"""Set [`Transformer3W`](@ref) `primary_secondary_arc`."""
+set_primary_secondary_arc!(value::Transformer3W, val) = value.primary_secondary_arc = val
+"""Set [`Transformer3W`](@ref) `secondary_tertiary_arc`."""
+set_secondary_tertiary_arc!(value::Transformer3W, val) = value.secondary_tertiary_arc = val
+"""Set [`Transformer3W`](@ref) `primary_tertiary_arc`."""
+set_primary_tertiary_arc!(value::Transformer3W, val) = value.primary_tertiary_arc = val
+"""Set [`Transformer3W`](@ref) `star_bus`."""
+set_star_bus!(value::Transformer3W, val) = value.star_bus = val
+"""Set [`Transformer3W`](@ref) `active_power_flow_primary`."""
+set_active_power_flow_primary!(value::Transformer3W, val) = value.active_power_flow_primary = set_value(value, val)
+"""Set [`Transformer3W`](@ref) `reactive_power_flow_primary`."""
+set_reactive_power_flow_primary!(value::Transformer3W, val) = value.reactive_power_flow_primary = set_value(value, val)
+"""Set [`Transformer3W`](@ref) `active_power_flow_secondary`."""
+set_active_power_flow_secondary!(value::Transformer3W, val) = value.active_power_flow_secondary = set_value(value, val)
+"""Set [`Transformer3W`](@ref) `reactive_power_flow_secondary`."""
+set_reactive_power_flow_secondary!(value::Transformer3W, val) = value.reactive_power_flow_secondary = set_value(value, val)
+"""Set [`Transformer3W`](@ref) `active_power_flow_tertiary`."""
+set_active_power_flow_tertiary!(value::Transformer3W, val) = value.active_power_flow_tertiary = set_value(value, val)
+"""Set [`Transformer3W`](@ref) `reactive_power_flow_tertiary`."""
+set_reactive_power_flow_tertiary!(value::Transformer3W, val) = value.reactive_power_flow_tertiary = set_value(value, val)
+"""Set [`Transformer3W`](@ref) `r_primary`."""
+set_r_primary!(value::Transformer3W, val) = value.r_primary = val
+"""Set [`Transformer3W`](@ref) `x_primary`."""
+set_x_primary!(value::Transformer3W, val) = value.x_primary = val
+"""Set [`Transformer3W`](@ref) `r_secondary`."""
+set_r_secondary!(value::Transformer3W, val) = value.r_secondary = val
+"""Set [`Transformer3W`](@ref) `x_secondary`."""
+set_x_secondary!(value::Transformer3W, val) = value.x_secondary = val
+"""Set [`Transformer3W`](@ref) `r_tertiary`."""
+set_r_tertiary!(value::Transformer3W, val) = value.r_tertiary = val
+"""Set [`Transformer3W`](@ref) `x_tertiary`."""
+set_x_tertiary!(value::Transformer3W, val) = value.x_tertiary = val
+"""Set [`Transformer3W`](@ref) `rating`."""
+set_rating!(value::Transformer3W, val) = value.rating = set_value(value, val)
+"""Set [`Transformer3W`](@ref) `r_12`."""
+set_r_12!(value::Transformer3W, val) = value.r_12 = val
+"""Set [`Transformer3W`](@ref) `x_12`."""
+set_x_12!(value::Transformer3W, val) = value.x_12 = val
+"""Set [`Transformer3W`](@ref) `r_23`."""
+set_r_23!(value::Transformer3W, val) = value.r_23 = val
+"""Set [`Transformer3W`](@ref) `x_23`."""
+set_x_23!(value::Transformer3W, val) = value.x_23 = val
+"""Set [`Transformer3W`](@ref) `r_13`."""
+set_r_13!(value::Transformer3W, val) = value.r_13 = val
+"""Set [`Transformer3W`](@ref) `x_13`."""
+set_x_13!(value::Transformer3W, val) = value.x_13 = val
+"""Set [`Transformer3W`](@ref) `g`."""
+set_g!(value::Transformer3W, val) = value.g = val
+"""Set [`Transformer3W`](@ref) `b`."""
+set_b!(value::Transformer3W, val) = value.b = val
+"""Set [`Transformer3W`](@ref) `primary_turns_ratio`."""
+set_primary_turns_ratio!(value::Transformer3W, val) = value.primary_turns_ratio = val
+"""Set [`Transformer3W`](@ref) `secondary_turns_ratio`."""
+set_secondary_turns_ratio!(value::Transformer3W, val) = value.secondary_turns_ratio = val
+"""Set [`Transformer3W`](@ref) `tertiary_turns_ratio`."""
+set_tertiary_turns_ratio!(value::Transformer3W, val) = value.tertiary_turns_ratio = val
+"""Set [`Transformer3W`](@ref) `services`."""
+set_services!(value::Transformer3W, val) = value.services = val
+"""Set [`Transformer3W`](@ref) `ext`."""
+set_ext!(value::Transformer3W, val) = value.ext = val

--- a/src/models/generated/includes.jl
+++ b/src/models/generated/includes.jl
@@ -10,6 +10,7 @@ include("MonitoredLine.jl")
 include("PhaseShiftingTransformer.jl")
 include("TapTransformer.jl")
 include("Transformer2W.jl")
+include("Transformer3W.jl")
 include("TwoTerminalHVDCLine.jl")
 include("TwoTerminalVSCDCLine.jl")
 include("TModelHVDCLine.jl")
@@ -471,6 +472,9 @@ export get_a
 export get_active_power
 export get_active_power_flow
 export get_active_power_flow_limits
+export get_active_power_flow_primary
+export get_active_power_flow_secondary
+export get_active_power_flow_tertiary
 export get_active_power_limits
 export get_active_power_limits_from
 export get_active_power_limits_pump
@@ -612,12 +616,21 @@ export get_phase_angle_limits
 export get_power_factor
 export get_power_gate_openings
 export get_power_trajectory
+export get_primary_secondary_arc
 export get_primary_shunt
+export get_primary_tertiary_arc
+export get_primary_turns_ratio
 export get_prime_mover_type
 export get_pump_efficiency
 export get_q_nl
 export get_r
+export get_r_12
+export get_r_13
+export get_r_23
 export get_r_load
+export get_r_primary
+export get_r_secondary
+export get_r_tertiary
 export get_ramp_limits
 export get_ramp_limits_pump
 export get_rated_current
@@ -627,6 +640,9 @@ export get_rating_pump
 export get_rc_rfd
 export get_reactive_power
 export get_reactive_power_flow
+export get_reactive_power_flow_primary
+export get_reactive_power_flow_secondary
+export get_reactive_power_flow_tertiary
 export get_reactive_power_limits
 export get_reactive_power_limits_from
 export get_reactive_power_limits_pump
@@ -644,8 +660,11 @@ export get_rg
 export get_rrpwr
 export get_rv
 export get_saturation_coeffs
+export get_secondary_tertiary_arc
+export get_secondary_turns_ratio
 export get_services
 export get_speed_error_signal
+export get_star_bus
 export get_start_time_limits
 export get_start_types
 export get_states
@@ -660,6 +679,7 @@ export get_switch
 export get_tF_delay
 export get_tV_delay
 export get_tap
+export get_tertiary_turns_ratio
 export get_tfh
 export get_tfl
 export get_time_at_status
@@ -677,6 +697,12 @@ export get_vl_pnts
 export get_voltage
 export get_voltage_limits
 export get_x
+export get_x_12
+export get_x_13
+export get_x_23
+export get_x_primary
+export get_x_secondary
+export get_x_tertiary
 export get_α
 export get_β
 export get_γ_d1
@@ -1041,6 +1067,9 @@ export set_a!
 export set_active_power!
 export set_active_power_flow!
 export set_active_power_flow_limits!
+export set_active_power_flow_primary!
+export set_active_power_flow_secondary!
+export set_active_power_flow_tertiary!
 export set_active_power_limits!
 export set_active_power_limits_from!
 export set_active_power_limits_pump!
@@ -1182,12 +1211,21 @@ export set_phase_angle_limits!
 export set_power_factor!
 export set_power_gate_openings!
 export set_power_trajectory!
+export set_primary_secondary_arc!
 export set_primary_shunt!
+export set_primary_tertiary_arc!
+export set_primary_turns_ratio!
 export set_prime_mover_type!
 export set_pump_efficiency!
 export set_q_nl!
 export set_r!
+export set_r_12!
+export set_r_13!
+export set_r_23!
 export set_r_load!
+export set_r_primary!
+export set_r_secondary!
+export set_r_tertiary!
 export set_ramp_limits!
 export set_ramp_limits_pump!
 export set_rated_current!
@@ -1197,6 +1235,9 @@ export set_rating_pump!
 export set_rc_rfd!
 export set_reactive_power!
 export set_reactive_power_flow!
+export set_reactive_power_flow_primary!
+export set_reactive_power_flow_secondary!
+export set_reactive_power_flow_tertiary!
 export set_reactive_power_limits!
 export set_reactive_power_limits_from!
 export set_reactive_power_limits_pump!
@@ -1214,8 +1255,11 @@ export set_rg!
 export set_rrpwr!
 export set_rv!
 export set_saturation_coeffs!
+export set_secondary_tertiary_arc!
+export set_secondary_turns_ratio!
 export set_services!
 export set_speed_error_signal!
+export set_star_bus!
 export set_start_time_limits!
 export set_start_types!
 export set_states!
@@ -1230,6 +1274,7 @@ export set_switch!
 export set_tF_delay!
 export set_tV_delay!
 export set_tap!
+export set_tertiary_turns_ratio!
 export set_tfh!
 export set_tfl!
 export set_time_at_status!
@@ -1247,6 +1292,12 @@ export set_vl_pnts!
 export set_voltage!
 export set_voltage_limits!
 export set_x!
+export set_x_12!
+export set_x_13!
+export set_x_23!
+export set_x_primary!
+export set_x_secondary!
+export set_x_tertiary!
 export set_α!
 export set_β!
 export set_γ_d1!

--- a/src/models/generated/includes.jl
+++ b/src/models/generated/includes.jl
@@ -484,6 +484,9 @@ export get_angle_limits
 export get_arc
 export get_area
 export get_available
+export get_available_primary
+export get_available_secondary
+export get_available_tertiary
 export get_b
 export get_base_power
 export get_base_voltage
@@ -636,7 +639,10 @@ export get_ramp_limits_pump
 export get_rated_current
 export get_rated_voltage
 export get_rating
+export get_rating_primary
 export get_rating_pump
+export get_rating_secondary
+export get_rating_tertiary
 export get_rc_rfd
 export get_reactive_power
 export get_reactive_power_flow
@@ -1079,6 +1085,9 @@ export set_angle_limits!
 export set_arc!
 export set_area!
 export set_available!
+export set_available_primary!
+export set_available_secondary!
+export set_available_tertiary!
 export set_b!
 export set_base_power!
 export set_base_voltage!
@@ -1231,7 +1240,10 @@ export set_ramp_limits_pump!
 export set_rated_current!
 export set_rated_voltage!
 export set_rating!
+export set_rating_primary!
 export set_rating_pump!
+export set_rating_secondary!
+export set_rating_tertiary!
 export set_rc_rfd!
 export set_reactive_power!
 export set_reactive_power_flow!

--- a/src/parsers/power_system_table_data.jl
+++ b/src/parsers/power_system_table_data.jl
@@ -833,11 +833,14 @@ function make_cost(
         cost_pairs = get_cost_pairs(gen, cost_colnames)
         var_cost, fixed = create_pwinc_cost(cost_pairs)
     end
+    parse_maybe_nothing(x) = isnothing(x) ? 0.0 : tryparse(Float64, x)
+    vom_cost = parse_maybe_nothing(getfield(gen, Symbol("variable_cost")))
+    vom_data = LinearCurve(vom_cost)
 
     startup_cost, shutdown_cost = calculate_uc_cost(data, gen, fuel_price)
 
     op_cost = ThermalGenerationCost(
-        FuelCurve(var_cost, UnitSystem.NATURAL_UNITS, fuel_price),
+        FuelCurve(var_cost, UnitSystem.NATURAL_UNITS, fuel_price, vom_data),
         fixed * fuel_price,
         startup_cost,
         shutdown_cost,
@@ -855,9 +858,12 @@ function make_cost(
     cost_pairs = get_cost_pairs(gen, cost_colnames)
     var_cost = create_pwl_cost(cost_pairs)
     startup_cost, shutdown_cost = calculate_uc_cost(data, gen, fuel_price)
+    parse_maybe_nothing(x) = isnothing(x) ? 0.0 : tryparse(Float64, x)
+    vom_cost = parse_maybe_nothing(getfield(gen, Symbol("variable_cost")))
+    vom_data = LinearCurve(vom_cost)
 
     op_cost = ThermalGenerationCost(
-        CostCurve(var_cost, UnitSystem.NATURAL_UNITS),
+        CostCurve(var_cost, UnitSystem.NATURAL_UNITS, vom_data),
         gen.fixed_cost,
         startup_cost,
         shutdown_cost,
@@ -901,14 +907,13 @@ function make_cost(
     cost_colnames::_HeatRateColumns,
 ) where {T <: RenewableGen}
     @warn "Heat rate parsing not valid for RenewableGen replacing with zero cost"
+    parse_maybe_nothing(x) = isnothing(x) ? 0.0 : tryparse(Float64, x)
+    vom_cost = parse_maybe_nothing(getfield(gen, Symbol("variable_cost")))
+    vom_data = LinearCurve(vom_cost)
     var_cost = CostCurve(;
         value_curve = LinearCurve(0.0),
         power_units = UnitSystem.NATURAL_UNITS,
-        vom_cost = if isnothing(gen.variable_cost)
-            LinearCurve(0.0)
-        else
-            LinearCurve(gen.variable_cost)
-        end,
+        vom_cost = vom_data,
     )
     op_cost = RenewableGenerationCost(var_cost)
     return op_cost
@@ -921,10 +926,13 @@ function make_cost(
     cost_colnames::_CostPointColumns,
 ) where {T <: RenewableGen}
     cost_pairs = get_cost_pairs(gen, cost_colnames)
+    parse_maybe_nothing(x) = isnothing(x) ? 0.0 : tryparse(Float64, x)
+    vom_cost = parse_maybe_nothing(getfield(gen, Symbol("variable_cost")))
+    vom_data = LinearCurve(vom_cost)
     var_cost = CostCurve(;
         value_curve = cost_pairs,
         power_units = UnitSystem.NATURAL_UNITS,
-        vom_cost = isnothing(gen.variable_cost) ? 0.0 : gen.variable_cost,
+        vom_cost = vom_data,
     )
     op_cost = RenewableGenerationCost(var_cost)
     return op_cost

--- a/test/test_system.jl
+++ b/test/test_system.jl
@@ -215,6 +215,14 @@ end
     @test get_units_base(sys) == "DEVICE_BASE"
     set_units_base_system!(sys, "SYSTEM_BASE")
     @test get_units_base(sys) == "SYSTEM_BASE"
+
+    gen = get_component(ThermalStandard, sys, "322_CT_6")
+    active_power_mw = with_units_base(sys, UnitSystem.NATURAL_UNITS) do
+        get_active_power(gen)
+    end
+    @test get_units_base(sys) == "SYSTEM_BASE"
+    set_units_base_system!(sys, UnitSystem.NATURAL_UNITS)
+    @test active_power_mw == get_active_power(gen)
 end
 
 @testset "Test add_time_series multiple components" begin


### PR DESCRIPTION
Initial idea for 3W transformer based on PSSE.

We are not giving support to any tap voltage control (i.e. `COD1 = COD2 = COD3 = 0`), and we are assuming that all the data must come in system per unit. These requires the flags `CW = CZ = CM = 1`.