### PR TITLE
Read export metadata file for round trip with PowerFlows.jl's PSS/E exporter

### DIFF
--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -777,6 +777,7 @@ include("parsers/power_models_data.jl")
 include("parsers/powerflowdata_data.jl")
 include("parsers/psse_dynamic_data.jl")
 include("parsers/TAMU_data.jl")
+include("parsers/psse_metadata_reimport.jl")
 
 # Better printing
 include("utils/print.jl")

--- a/src/base.jl
+++ b/src/base.jl
@@ -2,6 +2,7 @@
 const SKIP_PM_VALIDATION = false
 
 const SYSTEM_KWARGS = Set((
+    :area_name_formatter,
     :branch_name_formatter,
     :bus_name_formatter,
     :config_path,

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -211,13 +211,18 @@ function read_bus!(sys::System, data::Dict; kwargs...)
     default_bus_naming = x -> _get_pm_bus_name(x, unique_bus_names)
 
     _get_name = get(kwargs, :bus_name_formatter, default_bus_naming)
+
+    default_area_naming = string
+    # The formatter for area_name should be a function that transform the Area Int to a String
+    _get_name_area = get(kwargs, :area_name_formatter, default_area_naming)
+
     for (i, (d_key, d)) in enumerate(bus_data)
         # d id the data dict for each bus
         # d_key is bus key
         bus_name = strip(_get_name(d))
         bus_number = Int(d["bus_i"])
 
-        area_name = string(d["area"])
+        area_name = _get_name_area(d["area"])
         area = get_component(Area, sys, area_name)
         if isnothing(area)
             area = Area(area_name)

--- a/src/parsers/psse_metadata_reimport.jl
+++ b/src/parsers/psse_metadata_reimport.jl
@@ -115,8 +115,10 @@ function parse_export_metadata_dict(md::Dict)
         Int64,
     )
     loadzone_name_map = reverse_dict(md["zone_mapping"])
+    get!(loadzone_name_map, 1, "1")
     loadzone_name_formatter = name -> loadzone_name_map[name]
     area_name_map = reverse_dict(md["area_mapping"])
+    get!(area_name_map, 1, "1")
     area_name_formatter = name -> area_name_map[name]
 
     sys_kwargs = Dict(

--- a/src/parsers/psse_metadata_reimport.jl
+++ b/src/parsers/psse_metadata_reimport.jl
@@ -2,7 +2,7 @@
 
 # Currently the following mappings are used here:
 #   area_mapping: maps Sienna name to PSS/E number for all areas
-#   zone_mapping: maps Sienna name to PSS/E number for all zones
+#   zone_mapping: maps Sienna name to PSS/E number for all load zones
 #   bus_number_mapping: maps Sienna number to PSS/E number for all buses
 #   load_name_mapping: maps (Sienna bus, Sienna name) to PSS/E name for all loads
 #   shunt_name_mapping: maps (Sienna bus, Sienna name) to PSS/E name for all shunts
@@ -117,6 +117,8 @@ function System(raw_path::AbstractString, md::Dict)
     )
     loadzone_name_map = reverse_dict(md["zone_mapping"])
     loadzone_name_formatter = name -> loadzone_name_map[name]
+    area_name_map = reverse_dict(md["area_mapping"])
+    area_name_formatter = name -> area_name_map[name]
 
     sys =
         System(raw_path;
@@ -125,7 +127,8 @@ function System(raw_path::AbstractString, md::Dict)
             load_name_formatter = load_name_formatter,
             branch_name_formatter = branch_name_formatter,
             shunt_name_formatter = shunt_name_formatter,
-            loadzone_name_formatter = loadzone_name_formatter)
+            loadzone_name_formatter = loadzone_name_formatter,
+            area_name_formatter = area_name_formatter)
     fix_nans!(sys)
     # TODO remap bus numbers
     # TODO remap areas

--- a/src/parsers/psse_metadata_reimport.jl
+++ b/src/parsers/psse_metadata_reimport.jl
@@ -1,4 +1,20 @@
-# Parse the `*_metadata.json` file written alongside PowerFlows.jl PSS/E files
+# Parse the `*_export_metadata.json` file written alongside PSS/E files by PowerFlows.jl
+
+# Currently the following mappings are used here:
+#   area_mapping: maps Sienna name to PSS/E number for all areas
+#   zone_mapping: maps Sienna name to PSS/E number for all zones
+#   bus_number_mapping: maps Sienna number to PSS/E number for all buses
+#   load_name_mapping: maps (Sienna bus, Sienna name) to PSS/E name for all loads
+#   shunt_name_mapping: maps (Sienna bus, Sienna name) to PSS/E name for all shunts
+#   generator_name_mapping: maps (Sienna bus 1, Sienna bus 2, Sienna name) to PSS/E name for all generators
+#   branch_name_mapping: maps (Sienna bus 1, Sienna bus 2, Sienna name) to PSS/E name for all non-transformer branches
+#   transformer_ckt_mapping: maps (Sienna bus1, Sienna bus2, Sienna name) to PSS/E CKT field for all transformers
+
+# Mappings are stored in the file in the Sienna -> PSS/E direction, so they need to be
+# reversed for use here. Wherever a tuple is indicated above, the presentation in the file
+# is of the elements joined with underscores to form a single string.
+
+const PSSE_EXPORT_METADATA_EXTENSION = "_export_metadata.json"
 
 reverse_dict(d::Dict) = Dict(map(reverse, collect(d)))
 
@@ -52,8 +68,8 @@ end
 # See https://github.com/NREL-Sienna/PowerSystems.jl/issues/1160
 "Rename all the `LoadZone`s in the system according to the `Load_Zone_Name_Mapping` in the metadata"
 function fix_load_zone_names!(sys::System, md::Dict)
-    lz_map = reverse_dict(md["zone_number_mapping"])
-    # `collect` is necessary due to https://github.com/NREL-Sienna/PowerSystems.jl/issues/1161
+    lz_map = reverse_dict(md["zone_mapping"])
+    # `collect` is necessary because we're mutating the dictionary storing the components
     for load_zone in collect(get_components(LoadZone, sys))
         old_name = get_name(load_zone)
         new_name = get(lz_map, parse(Int64, old_name), old_name)

--- a/src/parsers/psse_metadata_reimport.jl
+++ b/src/parsers/psse_metadata_reimport.jl
@@ -50,20 +50,6 @@ deserialize_reverse_component_ids(
         end
         for (s_buses_s_name, p_name) in mapping)
 
-# TODO figure out where these are coming from and fix at the source
-# I think it has to do with per-unit conversions creating a division by zero, because `set_[re]active_power!(..., 0.0)` doesn't fix it
-"Iterate over all the `Generator`s in the system and, if any `active_power` or `reactive_power` fields are `NaN`, make them `0.0`"
-function fix_nans!(sys::System)
-    for gen in get_components(Generator, sys)
-        isnan(get_active_power(gen)) && (gen.active_power = 0.0)
-        isnan(get_reactive_power(gen)) && (gen.reactive_power = 0.0)
-        all(isnan.(values(get_reactive_power_limits(gen)))) &&
-            (gen.reactive_power_limits = (min = 0.0, max = 0.0))
-        all(isnan.(values(get_active_power_limits(gen)))) &&
-            (gen.active_power_limits = (min = 0.0, max = 0.0))
-    end
-end
-
 """
 Use PSS/E exporter metadata to build a function that maps component names back to their
 original Sienna values.
@@ -137,6 +123,5 @@ function System(raw_path::AbstractString, md::Dict)
             area_name_formatter = area_name_formatter)
     # Remap bus numbers last because everything has been added to the system using PSS/E bus numbers
     remap_bus_numbers!(sys, md["bus_number_mapping"])
-    fix_nans!(sys)
     return sys
 end

--- a/src/parsers/psse_metadata_reimport.jl
+++ b/src/parsers/psse_metadata_reimport.jl
@@ -1,0 +1,129 @@
+# Parse the `*_metadata.json` file written alongside PowerFlows.jl PSS/E files
+
+reverse_dict(d::Dict) = Dict(map(reverse, collect(d)))
+
+function split_first_rest(s::AbstractString; delim = "_")
+    splitted = split(s, delim)
+    return first(splitted), join(splitted[2:end], delim)
+end
+
+"Convert a s_bus_n_s_name => p_name dictionary to a (p_bus_n, p_name) => s_name dictionary"
+deserialize_reverse_component_ids(
+    mapping,
+    bus_number_mapping,
+    ::T,
+) where {T <: Type{Int64}} =
+    Dict(
+        let
+            (s_bus_n, s_name) = split_first_rest(s_bus_n_s_name)
+            p_bus_n = bus_number_mapping[s_bus_n]
+            (p_bus_n, p_name) => s_name
+        end
+        for (s_bus_n_s_name, p_name) in mapping)
+deserialize_reverse_component_ids(
+    mapping,
+    bus_number_mapping,
+    ::T,
+) where {T <: Type{Tuple{Int64, Int64}}} =
+    Dict(
+        let
+            (s_buses, s_name) = split_first_rest(s_buses_s_name)
+            (s_bus_1, s_bus_2) = split(s_buses, "-")
+            (p_bus_1, p_bus_2) = bus_number_mapping[s_bus_1], bus_number_mapping[s_bus_2]
+            ((p_bus_1, p_bus_2), p_name) => s_name
+        end
+        for (s_buses_s_name, p_name) in mapping)
+
+# TODO figure out where these are coming from and fix at the source
+# I think it has to do with per-unit conversions creating a division by zero, because `set_[re]active_power!(..., 0.0)` doesn't fix it
+"Iterate over all the `Generator`s in the system and, if any `active_power` or `reactive_power` fields are `NaN`, make them `0.0`"
+function fix_nans!(sys::System)
+    for gen in get_components(Generator, sys)
+        isnan(get_active_power(gen)) && (gen.active_power = 0.0)
+        isnan(get_reactive_power(gen)) && (gen.reactive_power = 0.0)
+        all(isnan.(values(get_reactive_power_limits(gen)))) &&
+            (gen.reactive_power_limits = (min = 0.0, max = 0.0))
+        all(isnan.(values(get_active_power_limits(gen)))) &&
+            (gen.active_power_limits = (min = 0.0, max = 0.0))
+    end
+end
+
+# TODO this should be a System constructor kwarg, like bus_name_formatter
+# See https://github.com/NREL-Sienna/PowerSystems.jl/issues/1160
+"Rename all the `LoadZone`s in the system according to the `Load_Zone_Name_Mapping` in the metadata"
+function fix_load_zone_names!(sys::System, md::Dict)
+    lz_map = reverse_dict(md["zone_number_mapping"])
+    # `collect` is necessary due to https://github.com/NREL-Sienna/PowerSystems.jl/issues/1161
+    for load_zone in collect(get_components(LoadZone, sys))
+        old_name = get_name(load_zone)
+        new_name = get(lz_map, parse(Int64, old_name), old_name)
+        (old_name != new_name) && set_name!(sys, load_zone, new_name)
+    end
+end
+
+"""
+Use PSS/E exporter metadata to build a function that maps component names back to their
+original Sienna values.
+"""
+function name_formatter_from_component_ids(raw_name_mapping, bus_number_mapping, sig)
+    reversed_name_mapping =
+        deserialize_reverse_component_ids(raw_name_mapping, bus_number_mapping, sig)
+    function component_id_formatter(device_dict)
+        (p_bus_n, p_name) = device_dict["source_id"][2:3]
+        (p_bus_n isa Integer) || (p_bus_n = parse(Int64, p_bus_n))
+        new_name = reversed_name_mapping[(p_bus_n, p_name)]
+        return new_name
+    end
+    return component_id_formatter
+end
+
+function System(raw_path::AbstractString, md::Dict)
+    bus_name_map = reverse_dict(md["bus_name_mapping"])  # PSS/E bus name -> Sienna bus name
+    bus_number_map = reverse_dict(md["bus_number_mapping"])  # PSS/E bus number -> Sienna bus number
+    all_branch_name_map = deserialize_reverse_component_ids(
+        merge(md["branch_name_mapping"], md["transformer_ckt_mapping"]),
+        md["bus_number_mapping"],
+        Tuple{Int64, Int64},
+    )
+
+    bus_name_formatter = device_dict -> bus_name_map[device_dict["name"]]
+    gen_name_formatter = name_formatter_from_component_ids(
+        md["generator_name_mapping"],
+        md["bus_number_mapping"],
+        Int64,
+    )
+    load_name_formatter = name_formatter_from_component_ids(
+        md["load_name_mapping"],
+        md["bus_number_mapping"],
+        Int64,
+    )
+    function branch_name_formatter(
+        device_dict::Dict,
+        bus_f::ACBus,
+        bus_t::ACBus,
+    )::String
+        sid = device_dict["source_id"]
+        (p_bus_1, p_bus_2, p_name) =
+            (length(sid) == 6) ? [sid[2], sid[3], sid[5]] : last(sid, 3)
+        return all_branch_name_map[((p_bus_1, p_bus_2), p_name)]
+    end
+    shunt_name_formatter = name_formatter_from_component_ids(
+        md["shunt_name_mapping"],
+        md["bus_number_mapping"],
+        Int64,
+    )
+
+    sys =
+        System(raw_path;
+            bus_name_formatter = bus_name_formatter,
+            gen_name_formatter = gen_name_formatter,
+            load_name_formatter = load_name_formatter,
+            branch_name_formatter = branch_name_formatter,
+            shunt_name_formatter = shunt_name_formatter)
+    fix_nans!(sys)
+    fix_load_zone_names!(sys, md)
+    # TODO remap bus numbers
+    # TODO remap areas
+    # TODO remap everything else! Should be reading all the keys in `md`
+    return sys
+end


### PR DESCRIPTION
Here, I implement logic such that when `System("my_filename.raw")` is called, PowerSystems will check for a `my_filename_export_metadata.json` file written by the PowerFlows.jl PSS/E exporter in the same directory and, if it is found, use its contents to undo the system alterations PowerFlows had to make to write to the PSS/E format. The goal is for systems loaded this way to look as similar to the original system that was serialized as possible. The user can opt out of this feature by passing `try_reimport = false`. There is also interface to manually pass a metadata dictionary to perform this same remapping.

In the process of implementation, I also added a `area_name_formatter` System constructor kwarg along the same lines as https://github.com/NREL-Sienna/PowerSystems.jl/issues/1160.

No unit tests are currently included. Up until now, this functionality was implemented in PowerFlows.jl, and there are fairly detailed but not perfectly comprehensive tests of this functionality due to the testing of the round trip fidelity over there. Looking for reviewer input on whether that is sufficient to merge this now or whether dedicated unit tests in PowerSystems are required first.

Exporter is implemented in https://github.com/NREL-Sienna/PowerFlows.jl/pull/53 and that PR now depends on this one.

@daniel-thom don't feel obligated to fully review, just tagging you in case you have opinions on how I'm messing with the System constructor.