### PR TITLE
Export IS.get_time_series_summary_table

### DIFF
--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -581,8 +581,6 @@ import InfrastructureSystems:
     get_time_series_values,
     get_time_series_keys,
     show_time_series,
-    get_static_time_series_summary_table, # StaticTimeSeries Summary Export for SPI
-    get_forecast_summary_table, # Forecast Summary Export for SPI
     get_scenario_count, # Scenario Forecast Exports
     get_percentiles, # Probabilistic Forecast Exports
     get_next_time_series_array!,

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -293,7 +293,7 @@ export ForecastKey
 export TimeSeriesCounts
 export ForecastCache
 export StaticTimeSeriesCache
-# from IS time_series_metadata_store.jl
+# from IS time_series_metadata_store.jl and defined for System in base.jl
 export get_static_time_series_summary_table
 export get_forecast_summary_table
 # from IS time_series_parser.jl

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -294,7 +294,8 @@ export TimeSeriesCounts
 export ForecastCache
 export StaticTimeSeriesCache
 # from IS time_series_metadata_store.jl
-export get_time_series_summary_table
+export get_static_time_series_summary_table
+export get_forecast_summary_table
 # from IS time_series_parser.jl
 export NormalizationFactor
 export NormalizationTypes
@@ -580,7 +581,8 @@ import InfrastructureSystems:
     get_time_series_values,
     get_time_series_keys,
     show_time_series,
-    get_time_series_summary_table, # Time Series Summary Export for SPI
+    get_static_time_series_summary_table, # StaticTimeSeries Summary Export for SPI
+    get_forecast_summary_table, # Forecast Summary Export for SPI
     get_scenario_count, # Scenario Forecast Exports
     get_percentiles, # Probabilistic Forecast Exports
     get_next_time_series_array!,

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -293,6 +293,8 @@ export ForecastKey
 export TimeSeriesCounts
 export ForecastCache
 export StaticTimeSeriesCache
+# from IS time_series_metadata_store.jl
+export get_time_series_summary_table
 # from IS time_series_parser.jl
 export NormalizationFactor
 export NormalizationTypes
@@ -578,6 +580,7 @@ import InfrastructureSystems:
     get_time_series_values,
     get_time_series_keys,
     show_time_series,
+    get_time_series_summary_table, # Time Series Summary Export for SPI
     get_scenario_count, # Scenario Forecast Exports
     get_percentiles, # Probabilistic Forecast Exports
     get_next_time_series_array!,

--- a/src/base.jl
+++ b/src/base.jl
@@ -2750,7 +2750,7 @@ Return a DataFrame with the number of static time series for components and supp
 attributes.
 """
 function get_static_time_series_summary_table(sys::System)
-    return get_static_time_series_summary_table(sys.data)
+    return IS.get_static_time_series_summary_table(sys.data)
 end
 
 """
@@ -2758,5 +2758,5 @@ Return a DataFrame with the number of forecasts for components and supplemental
 attributes.
 """
 function get_forecast_summary_table(sys::System)
-    return get_forecast_summary_table(sys.data)
+    return IS.get_forecast_summary_table(sys.data)
 end

--- a/src/base.jl
+++ b/src/base.jl
@@ -2744,3 +2744,19 @@ function fast_deepcopy_system(
     end
     return new_sys
 end
+
+"""
+Return a DataFrame with the number of static time series for components and supplemental
+attributes.
+"""
+function get_static_time_series_summary_table(sys::System)
+    return get_static_time_series_summary_table(sys.data)
+end
+
+"""
+Return a DataFrame with the number of forecasts for components and supplemental
+attributes.
+"""
+function get_forecast_summary_table(sys::System)
+    return get_forecast_summary_table(sys.data)
+end


### PR DESCRIPTION
* Export IS.get_time_series_summary_table to be used by SiennaPRASInterface and also prints length when system time series summary is pretty printed.
