### PR TITLE
adding per_unit conversion for zip load

### DIFF
--- a/src/parsers/pm_io/data.jl
+++ b/src/parsers/pm_io/data.jl
@@ -314,6 +314,10 @@ function _make_per_unit!(data::Dict{String, <:Any}, mva_base::Real)
         for (i, load) in data["load"]
             _apply_func!(load, "pd", rescale)
             _apply_func!(load, "qd", rescale)
+            _apply_func!(load, "pi", rescale)
+            _apply_func!(load, "qi", rescale)
+            _apply_func!(load, "py", rescale)
+            _apply_func!(load, "qy", rescale)
         end
     end
 

--- a/test/test_parse_psse.jl
+++ b/test/test_parse_psse.jl
@@ -24,9 +24,9 @@ end
 @testset "PSSE Component Parsing" begin
     @info "Testing Load Parsing"
     sys = build_system(PSYTestSystems, "psse_240_parsing_sys") # current/imedance_power read in natural units during parsing
-    @test get_current_active_power(get_component(StandardLoad, sys, "load10021")) == 223.71
+    @test get_current_active_power(get_component(StandardLoad, sys, "load10021")) == 2.2371
     @test get_impedance_reactive_power(get_component(StandardLoad, sys, "load10021")) ==
-          583.546
+          5.83546
     sys2 = build_system(PSYTestSystems, "psse_Benchmark_4ger_33_2015_sys")  # Constant_active/reactive_power read in pu during parsing
     @test get_constant_active_power(get_component(StandardLoad, sys2, "load71")) == 9.67
     @test get_constant_reactive_power(get_component(StandardLoad, sys2, "load71")) == 1.0


### PR DESCRIPTION
Adding rescaling for ZIP StandardLoad parameters that were missing (current_active_power, current_reactive_power, impedance_active_power, impedance_reactive_power)
