### PR TITLE
`MarketBidCost`: let `shut_down` be a time series, clean up startup cost interface

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -1615,7 +1615,7 @@ function transform_single_time_series!(
         sys.data,
         IS.DeterministicSingleTimeSeries,
         horizon,
-        interval,
+        interval;
         resolution = resolution,
     )
     return

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -6,6 +6,12 @@ const FromTo = NamedTuple{(:from, :to), Tuple{Float64, Float64}}
 const FromTo_ToFrom = NamedTuple{(:from_to, :to_from), Tuple{Float64, Float64}}
 const StartUpStages = NamedTuple{(:hot, :warm, :cold), NTuple{3, Float64}}
 
+# Intended for use with generators that are not multi-start (e.g. ThermalStandard).
+# Operators use `hot` when they don’t have multiple stages.
+"Convert a single start-up cost value to a `StartUpStages`"
+single_start_up_to_stages(start_up::Real) =
+    (hot = Float64(start_up), warm = 0.0, cold = 0.0)
+
 "From http://www.pserc.cornell.edu/matpower/MATPOWER-manual.pdf Table B-4"
 
 IS.@scoped_enum(GeneratorCostModels, PIECEWISE_LINEAR = 1, POLYNOMIAL = 2,)

--- a/src/models/cost_function_timeseries.jl
+++ b/src/models/cost_function_timeseries.jl
@@ -379,8 +379,8 @@ get_decremental_initial_input(
 """
 Retrieve the startup cost data for a `StaticInjection` device with a `MarketBidCost`. If
 this field is a time series, the user may specify `start_time` and `len` and the function
-returns a `TimeArray` of `Float64`s; if the field is not a time series, the function
-returns a single `Float64`.
+returns a `TimeArray` of `StartUpStages`s; if the field is not a time series, the function
+returns a single `StartUpStages`.
 """
 get_start_up(
     device::StaticInjection,
@@ -389,6 +389,20 @@ get_start_up(
     len::Union{Nothing, Int} = nothing,
 ) = _process_get_cost(StartUpStages, device,
     get_start_up(cost), StartUpStages, start_time, len)
+
+"""
+Retrieve the shutdown cost data for a `StaticInjection` device with a `MarketBidCost`. If
+this field is a time series, the user may specify `start_time` and `len` and the function
+returns a `TimeArray` of `Float64`s; if the field is not a time series, the function
+returns a single `Float64`.
+"""
+get_shut_down(
+    device::StaticInjection,
+    cost::MarketBidCost;
+    start_time::Union{Nothing, Dates.DateTime} = nothing,
+    len::Union{Nothing, Int} = nothing,
+) = _process_get_cost(Float64, device,
+    get_shut_down(cost), Float64, start_time, len)
 
 # SETTER HELPER FUNCTIONS
 """
@@ -657,9 +671,9 @@ single number, a single `StartUpStages`, or a time series.
 # Arguments
 - `sys::System`: PowerSystem System
 - `component::StaticInjection`: Static injection device
-- `time_series_data::Union{Float64, StartUpStages, IS.TimeSeriesData},`: the data. If a time
-  series, must be of eltype `NTuple{3, Float64}` -- to represent a single value in a time
-  series, use `(value, 0.0, 0.0)`.
+- `data::Union{Float64, StartUpStages, IS.TimeSeriesData},`: the data. If a time series,
+  must be of eltype `NTuple{3, Float64}` -- to represent a single value in a time series,
+  use `(value, 0.0, 0.0)`.
 """
 function set_start_up!(
     sys::System,
@@ -676,6 +690,33 @@ function set_start_up!(
         data,
     )
     set_start_up!(market_bid_cost, to_set)
+end
+
+"""
+Set the shutdown cost for a `StaticInjection` device with a `MarketBidCost` to either a
+single number or a time series.
+
+# Arguments
+- `sys::System`: PowerSystem System
+- `component::StaticInjection`: Static injection device
+- `data::Union{Float64, IS.TimeSeriesData},`: the data. If a time series, must be of eltype
+  `Float64`.
+"""
+function set_shut_down!(
+    sys::System,
+    component::StaticInjection,
+    data::Union{Float64, IS.TimeSeriesData},
+)
+    market_bid_cost = get_operation_cost(component)
+    _validate_market_bid_cost(market_bid_cost, "get_operation_cost(component)")
+    to_set = _process_set_cost(
+        Float64,
+        Float64,
+        sys,
+        component,
+        data,
+    )
+    set_shut_down!(market_bid_cost, to_set)
 end
 
 """

--- a/src/models/cost_function_timeseries.jl
+++ b/src/models/cost_function_timeseries.jl
@@ -651,21 +651,30 @@ function set_decremental_initial_input!(
 end
 
 """
-Set the startup cost for a `StaticInjection` device with a `MarketBidCost` to either a single `StartUpStages` or a time series.
+Set the startup cost for a `StaticInjection` device with a `MarketBidCost` to either a
+single number, a single `StartUpStages`, or a time series.
 
 # Arguments
 - `sys::System`: PowerSystem System
 - `component::StaticInjection`: Static injection device
-- `time_series_data::Union{StartUpStages, IS.TimeSeriesData},`: the data. If a time series, must be of eltype `NTuple{3, Float64}`.
+- `time_series_data::Union{Float64, StartUpStages, IS.TimeSeriesData},`: the data. If a time
+  series, must be of eltype `NTuple{3, Float64}` -- to represent a single value in a time
+  series, use `(value, 0.0, 0.0)`.
 """
 function set_start_up!(
     sys::System,
     component::StaticInjection,
-    data::Union{StartUpStages, IS.TimeSeriesData},
+    data::Union{Float64, StartUpStages, IS.TimeSeriesData},
 )
     market_bid_cost = get_operation_cost(component)
     _validate_market_bid_cost(market_bid_cost, "get_operation_cost(component)")
-    to_set = _process_set_cost(StartUpStages, NTuple{3, Float64}, sys, component, data)
+    to_set = _process_set_cost(
+        Union{Float64, StartUpStages},
+        NTuple{3, Float64},
+        sys,
+        component,
+        data,
+    )
     set_start_up!(market_bid_cost, to_set)
 end
 

--- a/src/models/cost_functions/MarketBidCost.jl
+++ b/src/models/cost_functions/MarketBidCost.jl
@@ -9,9 +9,9 @@ $(TYPEDFIELDS)
 An operating cost for market bids of energy and ancilliary services for any asset.
 Compatible with most US Market bidding mechanisms that support demand and generation side.
 """
-@kwdef mutable struct MarketBidCost <: OperationalCost
+mutable struct MarketBidCost <: OperationalCost
     "No load cost"
-    no_load_cost::Union{TimeSeriesKey, Nothing, Float64} = nothing
+    no_load_cost::Union{TimeSeriesKey, Nothing, Float64}
     "Start-up cost at different stages of the thermal cycle as the unit cools after a 
     shutdown (e.g., *hot*, *warm*, or *cold* starts). Warm is also referred to as
     intermediate in some markets. Can also accept a single value if there is only one
@@ -25,25 +25,25 @@ Compatible with most US Market bidding mechanisms that support demand and genera
         Nothing,
         TimeSeriesKey,  # piecewise step data
         CostCurve{PiecewiseIncrementalCurve},
-    } = nothing
+    }
     "Buy Offer Curves data, which can be a time series of `PiecewiseStepData` or a
     [`CostCurve`](@ref) of [`PiecewiseIncrementalCurve`](@ref)"
     decremental_offer_curves::Union{
         Nothing,
         TimeSeriesKey,
         CostCurve{PiecewiseIncrementalCurve},
-    } = nothing
+    }
     "If using a time series for incremental_offer_curves, this is a time series of `Float64` representing the `initial_input`"
-    incremental_initial_input::Union{Nothing, TimeSeriesKey} = nothing
+    incremental_initial_input::Union{Nothing, TimeSeriesKey}
     "If using a time series for decremental_offer_curves, this is a time series of `Float64` representing the `initial_input`"
-    decremental_initial_input::Union{Nothing, TimeSeriesKey} = nothing
+    decremental_initial_input::Union{Nothing, TimeSeriesKey}
     "Bids for the ancillary services"
-    ancillary_service_offers::Vector{Service} = Vector{Service}()
+    ancillary_service_offers::Vector{Service}
 end
 
 "Auxiliary constructor for shut_down::Integer"
 MarketBidCost(
-    no_load_cost::Float64,
+    no_load_cost::Union{TimeSeriesKey, Nothing, Float64},
     start_up::Union{TimeSeriesKey, StartUpStages},
     shut_down::Integer,
     incremental_offer_curves,
@@ -112,6 +112,21 @@ function MarketBidCost(::Nothing)
         shut_down = 0.0,
     )
 end
+
+MarketBidCost(;
+    no_load_cost = nothing,
+    start_up,
+    shut_down,
+    incremental_offer_curves = nothing,
+    decremental_offer_curves = nothing,
+    incremental_initial_input = nothing,
+    decremental_initial_input = nothing,
+    ancillary_service_offers = Vector{Service}(),
+) = MarketBidCost(
+    no_load_cost, start_up, shut_down, incremental_offer_curves,
+    decremental_offer_curves, incremental_initial_input, decremental_initial_input,
+    ancillary_service_offers,
+)
 
 """
 Accepts a single `start_up` value to use as the `hot` value, with `warm` and `cold` set to

--- a/src/models/cost_functions/MarketBidCost.jl
+++ b/src/models/cost_functions/MarketBidCost.jl
@@ -108,7 +108,7 @@ function MarketBidCost(
 )
     # Intended for use with generators that are not multi-start (e.g. ThermalStandard).
     # Operators use `hot` when they don’t have multiple stages.
-    start_up_multi = (hot = Float64(start_up), warm = 0.0, cold = 0.0)
+    start_up_multi = single_start_up_to_stages(start_up)
     return MarketBidCost(;
         no_load_cost = no_load_cost,
         start_up = start_up_multi,
@@ -162,7 +162,7 @@ set_ancillary_service_offers!(value::MarketBidCost, val) =
 
 """Auxiliary Method for setting up start up that are not multi-start"""
 function set_start_up!(value::MarketBidCost, val::Real)
-    start_up_multi = (hot = Float64(val), warm = 0.0, cold = 0.0)
+    start_up_multi = single_start_up_to_stages(val)
     set_start_up!(value, start_up_multi)
 end
 

--- a/src/models/cost_functions/MarketBidCost.jl
+++ b/src/models/cost_functions/MarketBidCost.jl
@@ -18,7 +18,7 @@ Compatible with most US Market bidding mechanisms that support demand and genera
     start-up cost"
     start_up::Union{TimeSeriesKey, StartUpStages}
     "Shut-down cost"
-    shut_down::Float64
+    shut_down::Union{TimeSeriesKey, Float64}
     "Sell Offer Curves data, which can be a time series of `PiecewiseStepData` or a
     [`CostCurve`](@ref) of [`PiecewiseIncrementalCurve`](@ref)"
     incremental_offer_curves::Union{
@@ -41,11 +41,32 @@ Compatible with most US Market bidding mechanisms that support demand and genera
     ancillary_service_offers::Vector{Service} = Vector{Service}()
 end
 
-"Auxiliary Constructor for Deserialization with Integer at no load cost"
+"Auxiliary constructor for shut_down::Integer"
+MarketBidCost(
+    no_load_cost::Float64,
+    start_up::Union{TimeSeriesKey, StartUpStages},
+    shut_down::Integer,
+    incremental_offer_curves,
+    decremental_offer_curves,
+    incremental_initial_input,
+    decremental_initial_input,
+    ancillary_service_offers,
+) = MarketBidCost(
+    no_load_cost,
+    start_up,
+    Float64(shut_down),
+    incremental_offer_curves,
+    decremental_offer_curves,
+    incremental_initial_input,
+    decremental_initial_input,
+    ancillary_service_offers,
+)
+
+"Auxiliary constructor for no_load_cost::Integer"
 MarketBidCost(
     no_load_cost::Integer,
     start_up::Union{TimeSeriesKey, StartUpStages},
-    shut_down,
+    shut_down::Union{TimeSeriesKey, Float64},
     incremental_offer_curves,
     decremental_offer_curves,
     incremental_initial_input,
@@ -67,7 +88,7 @@ MarketBidCost(
 MarketBidCost(
     no_load_cost::Float64,
     start_up::Union{TimeSeriesKey, StartUpStages},
-    shut_down,
+    shut_down::Union{TimeSeriesKey, Float64},
     incremental_offer_curves,
     decremental_offer_curves,
     ancillary_service_offers,

--- a/test/test_cost_functions.jl
+++ b/test/test_cost_functions.jl
@@ -374,22 +374,22 @@ end
     generator = get_component(ThermalStandard, sys, "322_CT_6")
     market_bid = MarketBidCost(nothing)
     set_operation_cost!(generator, market_bid)
-    
+
     op_cost = get_operation_cost(generator)
     @test get_shut_down(op_cost) == 0.0
     @test get_shut_down(generator, op_cost) == 0.0
-    
+
     set_shut_down!(sys, generator, 3.14)
     @test get_shut_down(op_cost) == 3.14
     @test get_shut_down(generator, op_cost) == 3.14
-    
+
     initial_time = Dates.DateTime("2020-01-01")
     resolution = Dates.Hour(1)
     horizon = 24
     data_float = SortedDict(initial_time => test_costs[Float64])
     forecast_fd = IS.Deterministic("fuel_cost", data_float, resolution)
-    
+
     set_shut_down!(sys, generator, forecast_fd)
     @test first(TimeSeries.values(get_shut_down(generator, op_cost))) ==
-            first(data_float[initial_time])
+          first(data_float[initial_time])
 end

--- a/test/test_cost_functions.jl
+++ b/test/test_cost_functions.jl
@@ -308,7 +308,7 @@ end
     fuel_forecast = get_fuel_cost(generator)  # missing start_time filled in with initial time
     @test first(TimeSeries.values(fuel_forecast)) == first(data_float[initial_time])
 end
-@testset "Test no-load cost (scalar and time series)" begin
+@testset "Test MarketBidCost no-load cost (single number and time series)" begin
     sys = PSB.build_system(PSITestSystems, "test_RTS_GMLC_sys")
     generators = collect(get_components(ThermalStandard, sys))
     generator = get_component(ThermalStandard, sys, "322_CT_6")
@@ -332,7 +332,7 @@ end
           first(data_float[initial_time])
 end
 
-@testset "Test startup cost (single number, tuple, and time series)" begin
+@testset "Test MarketBidCost startup cost (single number, tuple, and time series)" begin
     sys = PSB.build_system(PSITestSystems, "test_RTS_GMLC_sys")
     generators = collect(get_components(ThermalStandard, sys))
     generator = get_component(ThermalStandard, sys, "322_CT_6")
@@ -366,4 +366,30 @@ end
     set_start_up!(sys, generator, forecast_fd)
     @test first(TimeSeries.values(get_start_up(generator, op_cost))) ==
           first(data_sus[initial_time])
+end
+
+@testset "Test MarketBidCost shutdown cost (single number and time series)" begin
+    sys = PSB.build_system(PSITestSystems, "test_RTS_GMLC_sys")
+    generators = collect(get_components(ThermalStandard, sys))
+    generator = get_component(ThermalStandard, sys, "322_CT_6")
+    market_bid = MarketBidCost(nothing)
+    set_operation_cost!(generator, market_bid)
+    
+    op_cost = get_operation_cost(generator)
+    @test get_shut_down(op_cost) == 0.0
+    @test get_shut_down(generator, op_cost) == 0.0
+    
+    set_shut_down!(sys, generator, 3.14)
+    @test get_shut_down(op_cost) == 3.14
+    @test get_shut_down(generator, op_cost) == 3.14
+    
+    initial_time = Dates.DateTime("2020-01-01")
+    resolution = Dates.Hour(1)
+    horizon = 24
+    data_float = SortedDict(initial_time => test_costs[Float64])
+    forecast_fd = IS.Deterministic("fuel_cost", data_float, resolution)
+    
+    set_shut_down!(sys, generator, forecast_fd)
+    @test first(TimeSeries.values(get_shut_down(generator, op_cost))) ==
+            first(data_float[initial_time])
 end


### PR DESCRIPTION
`MarketBidCost.start_up` could already be set to a time series; here I add that feature to `MarketBidCost.shut_down`. I also clean up the startup cost interface a little: allow the user to call `set_start_up!(::System, ::StaticInjection, data)` with `Float64` data (they could already call `set_start_up!(::StaticInjection, data)` with `Float64` data), etc.

I think this could be added to PSY4 as a minor update, it doesn't seem like it needs to wait until PSY5, unless that would make things too chaotic.