### PR TITLE
Bug fixes for reading MMWG files

### DIFF
--- a/src/parsers/pm_io/psse.jl
+++ b/src/parsers/pm_io/psse.jl
@@ -1290,6 +1290,8 @@ function _build_switch_breaker_sub_data(
     sub_data["state"] = pop!(branch, "ST")
     sub_data["active_power_flow"] = 0.0
     sub_data["reactive_power_flow"] = 0.0
+    sub_data["psw"] = sub_data["active_power_flow"]
+    sub_data["qsw"] = sub_data["reactive_power_flow"]
     sub_data["rating"] = pop!(branch, "RATEA")
     sub_data["discrete_branch_type"] = discrete_branch_type
     sub_data["source_id"] =

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -709,6 +709,7 @@ function make_branch(name::String, d::Dict, bus_f::ACBus, bus_t::ACBus, source_t
     primary_shunt = d["b_fr"]
     alpha = d["shift"]
     branch_type = get_branch_type(d["tap"], alpha, d["transformer"])
+
     if d["transformer"]
         if branch_type == Line
             throw(DataFormatError("Data is mismatched; this cannot be a line. $d"))
@@ -827,9 +828,8 @@ function make_transformer_2w(
        get_bustype(bus_t) == ACBusTypes.ISOLATED
         available_value = false
     end
-    # println(name)
+
     ext = source_type == "pti" ? d["ext"] : Dict{String, Any}()
-    # println(d["ext"])
 
     return Transformer2W(;
         name = name,

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -1,3 +1,4 @@
+const VOLT_THRESHOLD = 1.0
 
 """Container for data parsed by PowerModels"""
 struct PowerModelsData
@@ -85,7 +86,8 @@ function correct_pm_transformer_status!(pm_data::PowerModelsData)
     for (k, branch) in pm_data.data["branch"]
         f_bus_bvolt = pm_data.data["bus"][branch["f_bus"]]["base_kv"]
         t_bus_bvolt = pm_data.data["bus"][branch["t_bus"]]["base_kv"]
-        if !branch["transformer"] && !isapprox(f_bus_bvolt, t_bus_bvolt; atol = 1.0)
+        if !branch["transformer"] &&
+           !isapprox(f_bus_bvolt, t_bus_bvolt; atol = VOLT_THRESHOLD)
             branch["transformer"] = true
             branch["ext"] = Dict{String, Any}()
             @warn "Branch $(branch["f_bus"]) - $(branch["t_bus"]) have different voltage levels endpoints: from: $(f_bus_bvolt)kV, to: $(t_bus_bvolt)kV, converting to transformer."


### PR DESCRIPTION
- The new keys "psw" and "qsw" where added in the parser as the active and reactive power flow respectively, since these in particular are necessary for parsing the file.
-  There were some problems creating the key "ext" when converting a branch to a 2W transformer for bus voltage differences.
     - A small logic was added to keep considering the elements as branches if the threshold of 1kV is not exceeded, otherwise it will be considered as a 2W transformer and an empty "ext" dict is added.
     - Improve of the warning statement to see the voltage difference and in which buses this is happening.
