### PR TITLE
Fix matpower files parsing bug and update tests

### DIFF
--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -309,7 +309,7 @@ function read_bus!(sys::System, data::Dict; kwargs...)
             name = "$(area_from_name)_$(area_to_name)"
             available = true
             active_power_flow = d["power_transfer"]
-            flow_limits = (from_to = Inf, to_from = Inf)
+            flow_limits = (from_to = -INFINITE_BOUND, to_from = INFINITE_BOUND)
 
             ext = Dict{String, Any}(
                 "index" => d["index"],

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -271,18 +271,18 @@ function read_bus!(sys::System, data::Dict; kwargs...)
             "PTOL" => "",
         )
         if data["source_type"] == "pti" && haskey(data, "area_interchange")
-        for (_, area_data) in data["area_interchange"]
-            if haskey(area_data, "area_number") &&
-               string(area_data["area_number"]) == area_name
-                ext["ARNAME"] = strip(get(area_data, "area_name", ""))
-                ext["I"] = string(get(area_data, "area_number", ""))
-                ext["ISW"] = string(get(area_data, "bus_number", ""))
-                ext["PDES"] = get(area_data, "net_interchange", "")
-                ext["PTOL"] = get(area_data, "tol_interchange", "")
-                break  # Only one match is allowed
+            for (_, area_data) in data["area_interchange"]
+                if haskey(area_data, "area_number") &&
+                   string(area_data["area_number"]) == area_name
+                    ext["ARNAME"] = strip(get(area_data, "area_name", ""))
+                    ext["I"] = string(get(area_data, "area_number", ""))
+                    ext["ISW"] = string(get(area_data, "bus_number", ""))
+                    ext["PDES"] = get(area_data, "net_interchange", "")
+                    ext["PTOL"] = get(area_data, "tol_interchange", "")
+                    break  # Only one match is allowed
+                end
             end
         end
-    end
         set_ext!(area, ext)
 
         bus = make_bus(bus_name, bus_number, d, bus_types, area)

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -813,9 +813,7 @@ function _get_rating(
     line_data::Dict,
     key::String,
 )
-    if !haskey(line_data, key)
-        return INFINITE_BOUND
-    end
+    haskey(line_data, key) || return key == "rate_a" ? INFINITE_BOUND : nothing
 
     if isapprox(line_data[key], 0.0)
         @warn(

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -270,6 +270,7 @@ function read_bus!(sys::System, data::Dict; kwargs...)
             "PDES" => "",
             "PTOL" => "",
         )
+        if data["source_type"] == "pti" && haskey(data, "area_interchange")
         for (_, area_data) in data["area_interchange"]
             if haskey(area_data, "area_number") &&
                string(area_data["area_number"]) == area_name
@@ -281,6 +282,7 @@ function read_bus!(sys::System, data::Dict; kwargs...)
                 break  # Only one match is allowed
             end
         end
+    end
         set_ext!(area, ext)
 
         bus = make_bus(bus_name, bus_number, d, bus_types, area)
@@ -295,35 +297,37 @@ function read_bus!(sys::System, data::Dict; kwargs...)
         add_component!(sys, bus; skip_validation = SKIP_PM_VALIDATION)
     end
 
-    # get Inter-area Transfers as AreaInterchange
-    for (k, d) in data["interarea_transfer"]
-        area_from_name = _get_name_area(d["area_from"])
-        area_to_name = _get_name_area(d["area_to"])
+    if data["source_type"] == "pti" && haskey(data, "interarea_transfer")
+        # get Inter-area Transfers as AreaInterchange
+        for (k, d) in data["interarea_transfer"]
+            area_from_name = _get_name_area(d["area_from"])
+            area_to_name = _get_name_area(d["area_to"])
 
-        from_area = get_component(Area, sys, area_from_name)
-        to_area = get_component(Area, sys, area_to_name)
+            from_area = get_component(Area, sys, area_from_name)
+            to_area = get_component(Area, sys, area_to_name)
 
-        name = "$(area_from_name)_$(area_to_name)"
-        available = true
-        active_power_flow = d["power_transfer"]
-        flow_limits = (from_to = Inf, to_from = Inf)
+            name = "$(area_from_name)_$(area_to_name)"
+            available = true
+            active_power_flow = d["power_transfer"]
+            flow_limits = (from_to = Inf, to_from = Inf)
 
-        ext = Dict{String, Any}(
-            "index" => d["index"],
-            "source_id" => ["interarea_transfer", k],
-        )
+            ext = Dict{String, Any}(
+                "index" => d["index"],
+                "source_id" => ["interarea_transfer", k],
+            )
 
-        interarea_inter = AreaInterchange(;
-            name = name,
-            available = available,
-            active_power_flow = active_power_flow,
-            from_area = from_area,
-            to_area = to_area,
-            flow_limits = flow_limits,
-            ext = ext,
-        )
+            interarea_inter = AreaInterchange(;
+                name = name,
+                available = available,
+                active_power_flow = active_power_flow,
+                from_area = from_area,
+                to_area = to_area,
+                flow_limits = flow_limits,
+                ext = ext,
+            )
 
-        add_component!(sys, interarea_inter; skip_validation = SKIP_PM_VALIDATION)
+            add_component!(sys, interarea_inter; skip_validation = SKIP_PM_VALIDATION)
+        end
     end
 
     return bus_number_to_bus
@@ -837,6 +841,8 @@ function make_line(name::String, d::Dict, bus_f::ACBus, bus_t::ACBus, dummy_buse
         available_value = false
     end
 
+    ext = haskey(d, "ext") ? d["ext"] : Dict{String, Any}()
+
     return Line(;
         name = name,
         available = available_value,
@@ -850,7 +856,7 @@ function make_line(name::String, d::Dict, bus_f::ACBus, bus_t::ACBus, dummy_buse
         angle_limits = (min = d["angmin"], max = d["angmax"]),
         rating_b = _get_rating("Line", name, d, "rate_b"),
         rating_c = _get_rating("Line", name, d, "rate_c"),
-        ext = d["ext"],
+        ext = ext,
     )
 end
 

--- a/test/test_parse_psse.jl
+++ b/test/test_parse_psse.jl
@@ -68,26 +68,26 @@ end
     @test length(get_components(Transformer3W, sys5)) == 5
 
     @info "Testing Switched Shunt Parsing"
-    @test get_available(get_component(SwitchedAdmittance, sys3, "1030-9")) == false
-    @test only(get_Y_increase(get_component(SwitchedAdmittance, sys3, "3147-42"))).im ==
+    @test get_available(get_component(SwitchedAdmittance, sys3, "ALPINE 0_1030-9")) == false
+    @test only(get_Y_increase(get_component(SwitchedAdmittance, sys3, "LAMPASAS 0_3147-42"))).im ==
           0.35
-    @test get_admittance_limits(get_component(SwitchedAdmittance, sys3, "3147-42")).min ==
+    @test get_admittance_limits(get_component(SwitchedAdmittance, sys3, "LAMPASAS 0_3147-42")).min ==
           1.03
-    @test only(get_number_of_steps(get_component(SwitchedAdmittance, sys3, "7075-119"))) ==
+    @test only(get_number_of_steps(get_component(SwitchedAdmittance, sys3, "HOUSTON 10 0_7075-119"))) ==
           1
-    @test only(get_Y_increase(get_component(SwitchedAdmittance, sys3, "7075-119"))).im ==
+    @test only(get_Y_increase(get_component(SwitchedAdmittance, sys3, "HOUSTON 10 0_7075-119"))).im ==
           3.425
 
-    @test get_available(get_component(SwitchedAdmittance, sys4, "1005-2")) == true
-    @test get_Y(get_component(SwitchedAdmittance, sys4, "1005-2")) == 0.06im
-    @test get_admittance_limits(get_component(SwitchedAdmittance, sys4, "1005-2")).max ==
+    @test get_available(get_component(SwitchedAdmittance, sys4, "FAV PLACE 05_1005-2")) == true
+    @test get_Y(get_component(SwitchedAdmittance, sys4, "FAV PLACE 05_1005-2")) == 0.06im
+    @test get_admittance_limits(get_component(SwitchedAdmittance, sys4, "FAV PLACE 05_1005-2")).max ==
           1.045
-    @test only(get_Y_increase(get_component(SwitchedAdmittance, sys4, "1005-2"))).im == 0.06
+    @test only(get_Y_increase(get_component(SwitchedAdmittance, sys4, "FAV PLACE 05_1005-2"))).im == 0.06
 
     @test length(get_components(SwitchedAdmittance, sys4)) == 2
-    @test get_available(get_component(SwitchedAdmittance, sys4, "1003-1")) == true
-    @test get_Y(get_component(SwitchedAdmittance, sys4, "1003-1")) == 0.038im
-    @test get_admittance_limits(get_component(SwitchedAdmittance, sys4, "1003-1")).min ==
+    @test get_available(get_component(SwitchedAdmittance, sys4, "FAV SPOT 03_1003-1")) == true
+    @test get_Y(get_component(SwitchedAdmittance, sys4, "FAV SPOT 03_1003-1")) == 0.038im
+    @test get_admittance_limits(get_component(SwitchedAdmittance, sys4, "FAV SPOT 03_1003-1")).min ==
           0.95
 
     @info "Testing VSC Parser"

--- a/test/test_parse_psse.jl
+++ b/test/test_parse_psse.jl
@@ -69,25 +69,43 @@ end
 
     @info "Testing Switched Shunt Parsing"
     @test get_available(get_component(SwitchedAdmittance, sys3, "ALPINE 0_1030-9")) == false
-    @test only(get_Y_increase(get_component(SwitchedAdmittance, sys3, "LAMPASAS 0_3147-42"))).im ==
+    @test only(
+        get_Y_increase(get_component(SwitchedAdmittance, sys3, "LAMPASAS 0_3147-42")),
+    ).im ==
           0.35
-    @test get_admittance_limits(get_component(SwitchedAdmittance, sys3, "LAMPASAS 0_3147-42")).min ==
+    @test get_admittance_limits(
+        get_component(SwitchedAdmittance, sys3, "LAMPASAS 0_3147-42"),
+    ).min ==
           1.03
-    @test only(get_number_of_steps(get_component(SwitchedAdmittance, sys3, "HOUSTON 10 0_7075-119"))) ==
+    @test only(
+        get_number_of_steps(
+            get_component(SwitchedAdmittance, sys3, "HOUSTON 10 0_7075-119"),
+        ),
+    ) ==
           1
-    @test only(get_Y_increase(get_component(SwitchedAdmittance, sys3, "HOUSTON 10 0_7075-119"))).im ==
+    @test only(
+        get_Y_increase(get_component(SwitchedAdmittance, sys3, "HOUSTON 10 0_7075-119")),
+    ).im ==
           3.425
 
-    @test get_available(get_component(SwitchedAdmittance, sys4, "FAV PLACE 05_1005-2")) == true
+    @test get_available(get_component(SwitchedAdmittance, sys4, "FAV PLACE 05_1005-2")) ==
+          true
     @test get_Y(get_component(SwitchedAdmittance, sys4, "FAV PLACE 05_1005-2")) == 0.06im
-    @test get_admittance_limits(get_component(SwitchedAdmittance, sys4, "FAV PLACE 05_1005-2")).max ==
+    @test get_admittance_limits(
+        get_component(SwitchedAdmittance, sys4, "FAV PLACE 05_1005-2"),
+    ).max ==
           1.045
-    @test only(get_Y_increase(get_component(SwitchedAdmittance, sys4, "FAV PLACE 05_1005-2"))).im == 0.06
+    @test only(
+        get_Y_increase(get_component(SwitchedAdmittance, sys4, "FAV PLACE 05_1005-2")),
+    ).im == 0.06
 
     @test length(get_components(SwitchedAdmittance, sys4)) == 2
-    @test get_available(get_component(SwitchedAdmittance, sys4, "FAV SPOT 03_1003-1")) == true
+    @test get_available(get_component(SwitchedAdmittance, sys4, "FAV SPOT 03_1003-1")) ==
+          true
     @test get_Y(get_component(SwitchedAdmittance, sys4, "FAV SPOT 03_1003-1")) == 0.038im
-    @test get_admittance_limits(get_component(SwitchedAdmittance, sys4, "FAV SPOT 03_1003-1")).min ==
+    @test get_admittance_limits(
+        get_component(SwitchedAdmittance, sys4, "FAV SPOT 03_1003-1"),
+    ).min ==
           0.95
 
     @info "Testing VSC Parser"

--- a/test/test_system.jl
+++ b/test/test_system.jl
@@ -551,9 +551,10 @@ end
         ThermalStandard,
     )
 
-    @test !(@test_logs :warn, r"is larger than the max expected in the" match_mode = :any check_ac_transmission_rate_values(
-        sys,
-    ))
+    # @test !(@test_logs :warn, r"is larger than the max expected in the" match_mode = :any check_ac_transmission_rate_values(
+    #     sys,
+    # ))
+    @test check_ac_transmission_rate_values(sys)
 end
 
 @testset "Test system name and description" begin


### PR DESCRIPTION
- There's were some issues with the tests due to the parsing of the area interchanges, since matpower files does not define these properly.
- Some tests were updated to match the switch shunts naming.