### PR TITLE
Adding load conforming field

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -2705,6 +2705,7 @@ function convert_component!(
         constant_reactive_power = get_reactive_power(old_load),
         max_constant_active_power = get_max_active_power(old_load),
         max_constant_reactive_power = get_max_active_power(old_load),
+        is_conforming = get_is_conforming(old_load),
         dynamic_injector = get_dynamic_injector(old_load),
         internal = _copy_internal_for_conversion(old_load),
         services = Device[],

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -2704,6 +2704,11 @@
                     "data_type": "Bool"
                 },
                 {
+                    "name": "is_conforming",
+                    "comment": "Indicates whether the specified load is conforming or non-conforming.",
+                    "data_type": "Bool"
+                },
+                {
                     "name": "bus",
                     "comment": "Bus that this component is connected to",
                     "null_value": "ACBus(nothing)",
@@ -2747,12 +2752,6 @@
                     "null_value": "0.0",
                     "data_type": "Float64",
                     "needs_conversion": true
-                },
-                {
-                    "name": "is_conforming",
-                    "comment": "Indicates whether the specified load is conforming or non-conforming.",
-                    "data_type": "Int64",
-                    "default": "1.0"
                 },
                 {
                     "name": "services",
@@ -2801,6 +2800,11 @@
                     "null_value": "false",
                     "name": "available",
                     "comment": "Indicator of whether the component is connected and online (`true`) or disconnected, offline, or down (`false`). Unavailable components are excluded during simulations",
+                    "data_type": "Bool"
+                },
+                {
+                    "name": "is_conforming",
+                    "comment": "Indicates whether the specified load is conforming or non-conforming.",
                     "data_type": "Bool"
                 },
                 {
@@ -2917,12 +2921,6 @@
                     "needs_conversion": true
                 },
                 {
-                    "name": "is_conforming",
-                    "comment": "Indicates whether the specified load is conforming or non-conforming.",
-                    "data_type": "Int64",
-                    "default": "1.0"
-                },
-                {
                     "name": "services",
                     "data_type": "Vector{Service}",
                     "comment": "Services that this device contributes to",
@@ -2969,6 +2967,11 @@
                     "null_value": "false",
                     "name": "available",
                     "comment": "Indicator of whether the component is connected and online (`true`) or disconnected, offline, or down (`false`). Unavailable components are excluded during simulations",
+                    "data_type": "Bool"
+                },
+                {
+                    "name": "is_conforming",
+                    "comment": "Indicates whether the specified load is conforming or non-conforming.",
                     "data_type": "Bool"
                 },
                 {
@@ -3037,12 +3040,6 @@
                     "null_value": "0.0",
                     "data_type": "Float64",
                     "needs_conversion": true
-                },
-                {
-                    "name": "is_conforming",
-                    "comment": "Indicates whether the specified load is conforming or non-conforming.",
-                    "data_type": "Int64",
-                    "default": "1.0"
                 },
                 {
                     "name": "services",

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -2749,6 +2749,12 @@
                     "needs_conversion": true
                 },
                 {
+                    "name": "is_conforming",
+                    "comment": "Indicates whether the specified load is conforming or non-conforming.",
+                    "data_type": "Int64",
+                    "default": "1.0"
+                },
+                {
                     "name": "services",
                     "data_type": "Vector{Service}",
                     "comment": "Services that this device contributes to",
@@ -2911,6 +2917,12 @@
                     "needs_conversion": true
                 },
                 {
+                    "name": "is_conforming",
+                    "comment": "Indicates whether the specified load is conforming or non-conforming.",
+                    "data_type": "Int64",
+                    "default": "1.0"
+                },
+                {
                     "name": "services",
                     "data_type": "Vector{Service}",
                     "comment": "Services that this device contributes to",
@@ -3025,6 +3037,12 @@
                     "null_value": "0.0",
                     "data_type": "Float64",
                     "needs_conversion": true
+                },
+                {
+                    "name": "is_conforming",
+                    "comment": "Indicates whether the specified load is conforming or non-conforming.",
+                    "data_type": "Int64",
+                    "default": "1.0"
                 },
                 {
                     "name": "services",

--- a/src/models/generated/ExponentialLoad.jl
+++ b/src/models/generated/ExponentialLoad.jl
@@ -8,6 +8,7 @@ This file is auto-generated. Do not edit.
     mutable struct ExponentialLoad <: StaticLoad
         name::String
         available::Bool
+        is_conforming::Bool
         bus::ACBus
         active_power::Float64
         reactive_power::Float64
@@ -16,7 +17,6 @@ This file is auto-generated. Do not edit.
         base_power::Float64
         max_active_power::Float64
         max_reactive_power::Float64
-        is_conforming::Int64
         services::Vector{Service}
         dynamic_injector::Union{Nothing, DynamicInjection}
         ext::Dict{String, Any}
@@ -30,6 +30,7 @@ An `ExponentialLoad` models active power as P = P0 * V^α and reactive power as 
 # Arguments
 - `name::String`: Name of the component. Components of the same type (e.g., `PowerLoad`) must have unique names, but components of different types (e.g., `PowerLoad` and `ACBus`) can have the same name
 - `available::Bool`: Indicator of whether the component is connected and online (`true`) or disconnected, offline, or down (`false`). Unavailable components are excluded during simulations
+- `is_conforming::Bool`: Indicates whether the specified load is conforming or non-conforming.
 - `bus::ACBus`: Bus that this component is connected to
 - `active_power::Float64`: Active power coefficient, P0 (MW)
 - `reactive_power::Float64`: Reactive power coefficient, Q0 (MVAR)
@@ -38,7 +39,6 @@ An `ExponentialLoad` models active power as P = P0 * V^α and reactive power as 
 - `base_power::Float64`: Base power (MVA) for [per unitization](@ref per_unit), validation range: `(0, nothing)`
 - `max_active_power::Float64`: Maximum active power (MW) that this load can demand
 - `max_reactive_power::Float64`: Maximum reactive power (MVAR) that this load can demand
-- `is_conforming::Int64`: (default: `1.0`) Indicates whether the specified load is conforming or non-conforming.
 - `services::Vector{Service}`: (default: `Device[]`) Services that this device contributes to
 - `dynamic_injector::Union{Nothing, DynamicInjection}`: (default: `nothing`) corresponding dynamic injection device
 - `ext::Dict{String, Any}`: (default: `Dict{String, Any}()`) An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation, such as latitude and longitude.
@@ -49,6 +49,8 @@ mutable struct ExponentialLoad <: StaticLoad
     name::String
     "Indicator of whether the component is connected and online (`true`) or disconnected, offline, or down (`false`). Unavailable components are excluded during simulations"
     available::Bool
+    "Indicates whether the specified load is conforming or non-conforming."
+    is_conforming::Bool
     "Bus that this component is connected to"
     bus::ACBus
     "Active power coefficient, P0 (MW)"
@@ -65,8 +67,6 @@ mutable struct ExponentialLoad <: StaticLoad
     max_active_power::Float64
     "Maximum reactive power (MVAR) that this load can demand"
     max_reactive_power::Float64
-    "Indicates whether the specified load is conforming or non-conforming."
-    is_conforming::Int64
     "Services that this device contributes to"
     services::Vector{Service}
     "corresponding dynamic injection device"
@@ -77,38 +77,20 @@ mutable struct ExponentialLoad <: StaticLoad
     internal::InfrastructureSystemsInternal
 end
 
-function ExponentialLoad(name, available, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, is_conforming=1.0, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), )
-    ExponentialLoad(name, available, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, is_conforming, services, dynamic_injector, ext, InfrastructureSystemsInternal(), )
+function ExponentialLoad(name, available, is_conforming, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), )
+    ExponentialLoad(name, available, is_conforming, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, services, dynamic_injector, ext, InfrastructureSystemsInternal(), )
 end
 
-function ExponentialLoad(; name, available, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, is_conforming=1.0, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
-    ExponentialLoad(name, available, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, is_conforming, services, dynamic_injector, ext, internal, )
-end
-
-# Constructor for demo purposes; non-functional.
-function ExponentialLoad(::Nothing)
-    ExponentialLoad(;
-        name="init",
-        available=false,
-        bus=ACBus(nothing),
-        active_power=0.0,
-        reactive_power=0.0,
-        α=0.0,
-        β=0.0,
-        base_power=0.0,
-        max_active_power=0.0,
-        max_reactive_power=0.0,
-        is_conforming=1.0,
-        services=Device[],
-        dynamic_injector=nothing,
-        ext=Dict{String, Any}(),
-    )
+function ExponentialLoad(; name, available, is_conforming, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+    ExponentialLoad(name, available, is_conforming, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, services, dynamic_injector, ext, internal, )
 end
 
 """Get [`ExponentialLoad`](@ref) `name`."""
 get_name(value::ExponentialLoad) = value.name
 """Get [`ExponentialLoad`](@ref) `available`."""
 get_available(value::ExponentialLoad) = value.available
+"""Get [`ExponentialLoad`](@ref) `is_conforming`."""
+get_is_conforming(value::ExponentialLoad) = value.is_conforming
 """Get [`ExponentialLoad`](@ref) `bus`."""
 get_bus(value::ExponentialLoad) = value.bus
 """Get [`ExponentialLoad`](@ref) `active_power`."""
@@ -125,8 +107,6 @@ get_base_power(value::ExponentialLoad) = value.base_power
 get_max_active_power(value::ExponentialLoad) = get_value(value, value.max_active_power)
 """Get [`ExponentialLoad`](@ref) `max_reactive_power`."""
 get_max_reactive_power(value::ExponentialLoad) = get_value(value, value.max_reactive_power)
-"""Get [`ExponentialLoad`](@ref) `is_conforming`."""
-get_is_conforming(value::ExponentialLoad) = value.is_conforming
 """Get [`ExponentialLoad`](@ref) `services`."""
 get_services(value::ExponentialLoad) = value.services
 """Get [`ExponentialLoad`](@ref) `dynamic_injector`."""
@@ -138,6 +118,8 @@ get_internal(value::ExponentialLoad) = value.internal
 
 """Set [`ExponentialLoad`](@ref) `available`."""
 set_available!(value::ExponentialLoad, val) = value.available = val
+"""Set [`ExponentialLoad`](@ref) `is_conforming`."""
+set_is_conforming!(value::ExponentialLoad, val) = value.is_conforming = val
 """Set [`ExponentialLoad`](@ref) `bus`."""
 set_bus!(value::ExponentialLoad, val) = value.bus = val
 """Set [`ExponentialLoad`](@ref) `active_power`."""
@@ -154,8 +136,6 @@ set_base_power!(value::ExponentialLoad, val) = value.base_power = val
 set_max_active_power!(value::ExponentialLoad, val) = value.max_active_power = set_value(value, val)
 """Set [`ExponentialLoad`](@ref) `max_reactive_power`."""
 set_max_reactive_power!(value::ExponentialLoad, val) = value.max_reactive_power = set_value(value, val)
-"""Set [`ExponentialLoad`](@ref) `is_conforming`."""
-set_is_conforming!(value::ExponentialLoad, val) = value.is_conforming = val
 """Set [`ExponentialLoad`](@ref) `services`."""
 set_services!(value::ExponentialLoad, val) = value.services = val
 """Set [`ExponentialLoad`](@ref) `ext`."""

--- a/src/models/generated/ExponentialLoad.jl
+++ b/src/models/generated/ExponentialLoad.jl
@@ -16,6 +16,7 @@ This file is auto-generated. Do not edit.
         base_power::Float64
         max_active_power::Float64
         max_reactive_power::Float64
+        is_conforming::Int64
         services::Vector{Service}
         dynamic_injector::Union{Nothing, DynamicInjection}
         ext::Dict{String, Any}
@@ -37,6 +38,7 @@ An `ExponentialLoad` models active power as P = P0 * V^α and reactive power as 
 - `base_power::Float64`: Base power (MVA) for [per unitization](@ref per_unit), validation range: `(0, nothing)`
 - `max_active_power::Float64`: Maximum active power (MW) that this load can demand
 - `max_reactive_power::Float64`: Maximum reactive power (MVAR) that this load can demand
+- `is_conforming::Int64`: (default: `1.0`) Indicates whether the specified load is conforming or non-conforming.
 - `services::Vector{Service}`: (default: `Device[]`) Services that this device contributes to
 - `dynamic_injector::Union{Nothing, DynamicInjection}`: (default: `nothing`) corresponding dynamic injection device
 - `ext::Dict{String, Any}`: (default: `Dict{String, Any}()`) An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation, such as latitude and longitude.
@@ -63,6 +65,8 @@ mutable struct ExponentialLoad <: StaticLoad
     max_active_power::Float64
     "Maximum reactive power (MVAR) that this load can demand"
     max_reactive_power::Float64
+    "Indicates whether the specified load is conforming or non-conforming."
+    is_conforming::Int64
     "Services that this device contributes to"
     services::Vector{Service}
     "corresponding dynamic injection device"
@@ -73,12 +77,12 @@ mutable struct ExponentialLoad <: StaticLoad
     internal::InfrastructureSystemsInternal
 end
 
-function ExponentialLoad(name, available, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), )
-    ExponentialLoad(name, available, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, services, dynamic_injector, ext, InfrastructureSystemsInternal(), )
+function ExponentialLoad(name, available, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, is_conforming=1.0, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), )
+    ExponentialLoad(name, available, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, is_conforming, services, dynamic_injector, ext, InfrastructureSystemsInternal(), )
 end
 
-function ExponentialLoad(; name, available, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
-    ExponentialLoad(name, available, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, services, dynamic_injector, ext, internal, )
+function ExponentialLoad(; name, available, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, is_conforming=1.0, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+    ExponentialLoad(name, available, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, is_conforming, services, dynamic_injector, ext, internal, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -94,6 +98,7 @@ function ExponentialLoad(::Nothing)
         base_power=0.0,
         max_active_power=0.0,
         max_reactive_power=0.0,
+        is_conforming=1.0,
         services=Device[],
         dynamic_injector=nothing,
         ext=Dict{String, Any}(),
@@ -120,6 +125,8 @@ get_base_power(value::ExponentialLoad) = value.base_power
 get_max_active_power(value::ExponentialLoad) = get_value(value, value.max_active_power)
 """Get [`ExponentialLoad`](@ref) `max_reactive_power`."""
 get_max_reactive_power(value::ExponentialLoad) = get_value(value, value.max_reactive_power)
+"""Get [`ExponentialLoad`](@ref) `is_conforming`."""
+get_is_conforming(value::ExponentialLoad) = value.is_conforming
 """Get [`ExponentialLoad`](@ref) `services`."""
 get_services(value::ExponentialLoad) = value.services
 """Get [`ExponentialLoad`](@ref) `dynamic_injector`."""
@@ -147,6 +154,8 @@ set_base_power!(value::ExponentialLoad, val) = value.base_power = val
 set_max_active_power!(value::ExponentialLoad, val) = value.max_active_power = set_value(value, val)
 """Set [`ExponentialLoad`](@ref) `max_reactive_power`."""
 set_max_reactive_power!(value::ExponentialLoad, val) = value.max_reactive_power = set_value(value, val)
+"""Set [`ExponentialLoad`](@ref) `is_conforming`."""
+set_is_conforming!(value::ExponentialLoad, val) = value.is_conforming = val
 """Set [`ExponentialLoad`](@ref) `services`."""
 set_services!(value::ExponentialLoad, val) = value.services = val
 """Set [`ExponentialLoad`](@ref) `ext`."""

--- a/src/models/generated/PowerLoad.jl
+++ b/src/models/generated/PowerLoad.jl
@@ -8,13 +8,13 @@ This file is auto-generated. Do not edit.
     mutable struct PowerLoad <: StaticLoad
         name::String
         available::Bool
+        is_conforming::Bool
         bus::ACBus
         active_power::Float64
         reactive_power::Float64
         base_power::Float64
         max_active_power::Float64
         max_reactive_power::Float64
-        is_conforming::Int64
         services::Vector{Service}
         dynamic_injector::Union{Nothing, DynamicInjection}
         ext::Dict{String, Any}
@@ -28,13 +28,13 @@ This load consumes a set amount of power (set by `active_power` for a power flow
 # Arguments
 - `name::String`: Name of the component. Components of the same type (e.g., `PowerLoad`) must have unique names, but components of different types (e.g., `PowerLoad` and `ACBus`) can have the same name
 - `available::Bool`: Indicator of whether the component is connected and online (`true`) or disconnected, offline, or down (`false`). Unavailable components are excluded during simulations
+- `is_conforming::Bool`: Indicates whether the specified load is conforming or non-conforming.
 - `bus::ACBus`: Bus that this component is connected to
 - `active_power::Float64`: Initial steady-state active power demand (MW)
 - `reactive_power::Float64`: Initial steady-state reactive power demand (MVAR)
 - `base_power::Float64`: Base power (MVA) for [per unitization](@ref per_unit), validation range: `(0, nothing)`
 - `max_active_power::Float64`: Maximum active power (MW) that this load can demand
 - `max_reactive_power::Float64`: Maximum reactive power (MVAR) that this load can demand
-- `is_conforming::Int64`: (default: `1.0`) Indicates whether the specified load is conforming or non-conforming.
 - `services::Vector{Service}`: (default: `Device[]`) Services that this device contributes to
 - `dynamic_injector::Union{Nothing, DynamicInjection}`: (default: `nothing`) corresponding dynamic injection device
 - `ext::Dict{String, Any}`: (default: `Dict{String, Any}()`) An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation, such as latitude and longitude.
@@ -45,6 +45,8 @@ mutable struct PowerLoad <: StaticLoad
     name::String
     "Indicator of whether the component is connected and online (`true`) or disconnected, offline, or down (`false`). Unavailable components are excluded during simulations"
     available::Bool
+    "Indicates whether the specified load is conforming or non-conforming."
+    is_conforming::Bool
     "Bus that this component is connected to"
     bus::ACBus
     "Initial steady-state active power demand (MW)"
@@ -57,8 +59,6 @@ mutable struct PowerLoad <: StaticLoad
     max_active_power::Float64
     "Maximum reactive power (MVAR) that this load can demand"
     max_reactive_power::Float64
-    "Indicates whether the specified load is conforming or non-conforming."
-    is_conforming::Int64
     "Services that this device contributes to"
     services::Vector{Service}
     "corresponding dynamic injection device"
@@ -69,36 +69,20 @@ mutable struct PowerLoad <: StaticLoad
     internal::InfrastructureSystemsInternal
 end
 
-function PowerLoad(name, available, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, is_conforming=1.0, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), )
-    PowerLoad(name, available, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, is_conforming, services, dynamic_injector, ext, InfrastructureSystemsInternal(), )
+function PowerLoad(name, available, is_conforming, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), )
+    PowerLoad(name, available, is_conforming, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, services, dynamic_injector, ext, InfrastructureSystemsInternal(), )
 end
 
-function PowerLoad(; name, available, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, is_conforming=1.0, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
-    PowerLoad(name, available, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, is_conforming, services, dynamic_injector, ext, internal, )
-end
-
-# Constructor for demo purposes; non-functional.
-function PowerLoad(::Nothing)
-    PowerLoad(;
-        name="init",
-        available=false,
-        bus=ACBus(nothing),
-        active_power=0.0,
-        reactive_power=0.0,
-        base_power=0.0,
-        max_active_power=0.0,
-        max_reactive_power=0.0,
-        is_conforming=1.0,
-        services=Device[],
-        dynamic_injector=nothing,
-        ext=Dict{String, Any}(),
-    )
+function PowerLoad(; name, available, is_conforming, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+    PowerLoad(name, available, is_conforming, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, services, dynamic_injector, ext, internal, )
 end
 
 """Get [`PowerLoad`](@ref) `name`."""
 get_name(value::PowerLoad) = value.name
 """Get [`PowerLoad`](@ref) `available`."""
 get_available(value::PowerLoad) = value.available
+"""Get [`PowerLoad`](@ref) `is_conforming`."""
+get_is_conforming(value::PowerLoad) = value.is_conforming
 """Get [`PowerLoad`](@ref) `bus`."""
 get_bus(value::PowerLoad) = value.bus
 """Get [`PowerLoad`](@ref) `active_power`."""
@@ -111,8 +95,6 @@ get_base_power(value::PowerLoad) = value.base_power
 get_max_active_power(value::PowerLoad) = get_value(value, value.max_active_power)
 """Get [`PowerLoad`](@ref) `max_reactive_power`."""
 get_max_reactive_power(value::PowerLoad) = get_value(value, value.max_reactive_power)
-"""Get [`PowerLoad`](@ref) `is_conforming`."""
-get_is_conforming(value::PowerLoad) = value.is_conforming
 """Get [`PowerLoad`](@ref) `services`."""
 get_services(value::PowerLoad) = value.services
 """Get [`PowerLoad`](@ref) `dynamic_injector`."""
@@ -124,6 +106,8 @@ get_internal(value::PowerLoad) = value.internal
 
 """Set [`PowerLoad`](@ref) `available`."""
 set_available!(value::PowerLoad, val) = value.available = val
+"""Set [`PowerLoad`](@ref) `is_conforming`."""
+set_is_conforming!(value::PowerLoad, val) = value.is_conforming = val
 """Set [`PowerLoad`](@ref) `bus`."""
 set_bus!(value::PowerLoad, val) = value.bus = val
 """Set [`PowerLoad`](@ref) `active_power`."""
@@ -136,8 +120,6 @@ set_base_power!(value::PowerLoad, val) = value.base_power = val
 set_max_active_power!(value::PowerLoad, val) = value.max_active_power = set_value(value, val)
 """Set [`PowerLoad`](@ref) `max_reactive_power`."""
 set_max_reactive_power!(value::PowerLoad, val) = value.max_reactive_power = set_value(value, val)
-"""Set [`PowerLoad`](@ref) `is_conforming`."""
-set_is_conforming!(value::PowerLoad, val) = value.is_conforming = val
 """Set [`PowerLoad`](@ref) `services`."""
 set_services!(value::PowerLoad, val) = value.services = val
 """Set [`PowerLoad`](@ref) `ext`."""

--- a/src/models/generated/PowerLoad.jl
+++ b/src/models/generated/PowerLoad.jl
@@ -14,6 +14,7 @@ This file is auto-generated. Do not edit.
         base_power::Float64
         max_active_power::Float64
         max_reactive_power::Float64
+        is_conforming::Int64
         services::Vector{Service}
         dynamic_injector::Union{Nothing, DynamicInjection}
         ext::Dict{String, Any}
@@ -33,6 +34,7 @@ This load consumes a set amount of power (set by `active_power` for a power flow
 - `base_power::Float64`: Base power (MVA) for [per unitization](@ref per_unit), validation range: `(0, nothing)`
 - `max_active_power::Float64`: Maximum active power (MW) that this load can demand
 - `max_reactive_power::Float64`: Maximum reactive power (MVAR) that this load can demand
+- `is_conforming::Int64`: (default: `1.0`) Indicates whether the specified load is conforming or non-conforming.
 - `services::Vector{Service}`: (default: `Device[]`) Services that this device contributes to
 - `dynamic_injector::Union{Nothing, DynamicInjection}`: (default: `nothing`) corresponding dynamic injection device
 - `ext::Dict{String, Any}`: (default: `Dict{String, Any}()`) An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation, such as latitude and longitude.
@@ -55,6 +57,8 @@ mutable struct PowerLoad <: StaticLoad
     max_active_power::Float64
     "Maximum reactive power (MVAR) that this load can demand"
     max_reactive_power::Float64
+    "Indicates whether the specified load is conforming or non-conforming."
+    is_conforming::Int64
     "Services that this device contributes to"
     services::Vector{Service}
     "corresponding dynamic injection device"
@@ -65,12 +69,12 @@ mutable struct PowerLoad <: StaticLoad
     internal::InfrastructureSystemsInternal
 end
 
-function PowerLoad(name, available, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), )
-    PowerLoad(name, available, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, services, dynamic_injector, ext, InfrastructureSystemsInternal(), )
+function PowerLoad(name, available, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, is_conforming=1.0, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), )
+    PowerLoad(name, available, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, is_conforming, services, dynamic_injector, ext, InfrastructureSystemsInternal(), )
 end
 
-function PowerLoad(; name, available, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
-    PowerLoad(name, available, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, services, dynamic_injector, ext, internal, )
+function PowerLoad(; name, available, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, is_conforming=1.0, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+    PowerLoad(name, available, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, is_conforming, services, dynamic_injector, ext, internal, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -84,6 +88,7 @@ function PowerLoad(::Nothing)
         base_power=0.0,
         max_active_power=0.0,
         max_reactive_power=0.0,
+        is_conforming=1.0,
         services=Device[],
         dynamic_injector=nothing,
         ext=Dict{String, Any}(),
@@ -106,6 +111,8 @@ get_base_power(value::PowerLoad) = value.base_power
 get_max_active_power(value::PowerLoad) = get_value(value, value.max_active_power)
 """Get [`PowerLoad`](@ref) `max_reactive_power`."""
 get_max_reactive_power(value::PowerLoad) = get_value(value, value.max_reactive_power)
+"""Get [`PowerLoad`](@ref) `is_conforming`."""
+get_is_conforming(value::PowerLoad) = value.is_conforming
 """Get [`PowerLoad`](@ref) `services`."""
 get_services(value::PowerLoad) = value.services
 """Get [`PowerLoad`](@ref) `dynamic_injector`."""
@@ -129,6 +136,8 @@ set_base_power!(value::PowerLoad, val) = value.base_power = val
 set_max_active_power!(value::PowerLoad, val) = value.max_active_power = set_value(value, val)
 """Set [`PowerLoad`](@ref) `max_reactive_power`."""
 set_max_reactive_power!(value::PowerLoad, val) = value.max_reactive_power = set_value(value, val)
+"""Set [`PowerLoad`](@ref) `is_conforming`."""
+set_is_conforming!(value::PowerLoad, val) = value.is_conforming = val
 """Set [`PowerLoad`](@ref) `services`."""
 set_services!(value::PowerLoad, val) = value.services = val
 """Set [`PowerLoad`](@ref) `ext`."""

--- a/src/models/generated/StandardLoad.jl
+++ b/src/models/generated/StandardLoad.jl
@@ -8,6 +8,7 @@ This file is auto-generated. Do not edit.
     mutable struct StandardLoad <: StaticLoad
         name::String
         available::Bool
+        is_conforming::Bool
         bus::ACBus
         base_power::Float64
         constant_active_power::Float64
@@ -22,7 +23,6 @@ This file is auto-generated. Do not edit.
         max_impedance_reactive_power::Float64
         max_current_active_power::Float64
         max_current_reactive_power::Float64
-        is_conforming::Int64
         services::Vector{Service}
         dynamic_injector::Union{Nothing, DynamicInjection}
         ext::Dict{String, Any}
@@ -38,6 +38,7 @@ For an alternative exponential formulation of the ZIP model, see [`ExponentialLo
 # Arguments
 - `name::String`: Name of the component. Components of the same type (e.g., `PowerLoad`) must have unique names, but components of different types (e.g., `PowerLoad` and `ACBus`) can have the same name
 - `available::Bool`: Indicator of whether the component is connected and online (`true`) or disconnected, offline, or down (`false`). Unavailable components are excluded during simulations
+- `is_conforming::Bool`: Indicates whether the specified load is conforming or non-conforming.
 - `bus::ACBus`: Bus that this component is connected to
 - `base_power::Float64`: Base power of the load (MVA) for [per unitization](@ref per_unit), validation range: `(0, nothing)`
 - `constant_active_power::Float64`: (default: `0.0`) Constant active power demand in MW (P_P)
@@ -52,7 +53,6 @@ For an alternative exponential formulation of the ZIP model, see [`ExponentialLo
 - `max_impedance_reactive_power::Float64`: (default: `0.0`) Maximum reactive power (MVAR) drawn by constant impedance load
 - `max_current_active_power::Float64`: (default: `0.0`) Maximum active power (MW) drawn by constant current load
 - `max_current_reactive_power::Float64`: (default: `0.0`) Maximum reactive power (MVAR) drawn by constant current load
-- `is_conforming::Int64`: (default: `1.0`) Indicates whether the specified load is conforming or non-conforming.
 - `services::Vector{Service}`: (default: `Device[]`) Services that this device contributes to
 - `dynamic_injector::Union{Nothing, DynamicInjection}`: (default: `nothing`) corresponding dynamic injection device
 - `ext::Dict{String, Any}`: (default: `Dict{String, Any}()`) An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation, such as latitude and longitude.
@@ -63,6 +63,8 @@ mutable struct StandardLoad <: StaticLoad
     name::String
     "Indicator of whether the component is connected and online (`true`) or disconnected, offline, or down (`false`). Unavailable components are excluded during simulations"
     available::Bool
+    "Indicates whether the specified load is conforming or non-conforming."
+    is_conforming::Bool
     "Bus that this component is connected to"
     bus::ACBus
     "Base power of the load (MVA) for [per unitization](@ref per_unit)"
@@ -91,8 +93,6 @@ mutable struct StandardLoad <: StaticLoad
     max_current_active_power::Float64
     "Maximum reactive power (MVAR) drawn by constant current load"
     max_current_reactive_power::Float64
-    "Indicates whether the specified load is conforming or non-conforming."
-    is_conforming::Int64
     "Services that this device contributes to"
     services::Vector{Service}
     "corresponding dynamic injection device"
@@ -103,44 +103,20 @@ mutable struct StandardLoad <: StaticLoad
     internal::InfrastructureSystemsInternal
 end
 
-function StandardLoad(name, available, bus, base_power, constant_active_power=0.0, constant_reactive_power=0.0, impedance_active_power=0.0, impedance_reactive_power=0.0, current_active_power=0.0, current_reactive_power=0.0, max_constant_active_power=0.0, max_constant_reactive_power=0.0, max_impedance_active_power=0.0, max_impedance_reactive_power=0.0, max_current_active_power=0.0, max_current_reactive_power=0.0, is_conforming=1.0, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), )
-    StandardLoad(name, available, bus, base_power, constant_active_power, constant_reactive_power, impedance_active_power, impedance_reactive_power, current_active_power, current_reactive_power, max_constant_active_power, max_constant_reactive_power, max_impedance_active_power, max_impedance_reactive_power, max_current_active_power, max_current_reactive_power, is_conforming, services, dynamic_injector, ext, InfrastructureSystemsInternal(), )
+function StandardLoad(name, available, is_conforming, bus, base_power, constant_active_power=0.0, constant_reactive_power=0.0, impedance_active_power=0.0, impedance_reactive_power=0.0, current_active_power=0.0, current_reactive_power=0.0, max_constant_active_power=0.0, max_constant_reactive_power=0.0, max_impedance_active_power=0.0, max_impedance_reactive_power=0.0, max_current_active_power=0.0, max_current_reactive_power=0.0, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), )
+    StandardLoad(name, available, is_conforming, bus, base_power, constant_active_power, constant_reactive_power, impedance_active_power, impedance_reactive_power, current_active_power, current_reactive_power, max_constant_active_power, max_constant_reactive_power, max_impedance_active_power, max_impedance_reactive_power, max_current_active_power, max_current_reactive_power, services, dynamic_injector, ext, InfrastructureSystemsInternal(), )
 end
 
-function StandardLoad(; name, available, bus, base_power, constant_active_power=0.0, constant_reactive_power=0.0, impedance_active_power=0.0, impedance_reactive_power=0.0, current_active_power=0.0, current_reactive_power=0.0, max_constant_active_power=0.0, max_constant_reactive_power=0.0, max_impedance_active_power=0.0, max_impedance_reactive_power=0.0, max_current_active_power=0.0, max_current_reactive_power=0.0, is_conforming=1.0, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
-    StandardLoad(name, available, bus, base_power, constant_active_power, constant_reactive_power, impedance_active_power, impedance_reactive_power, current_active_power, current_reactive_power, max_constant_active_power, max_constant_reactive_power, max_impedance_active_power, max_impedance_reactive_power, max_current_active_power, max_current_reactive_power, is_conforming, services, dynamic_injector, ext, internal, )
-end
-
-# Constructor for demo purposes; non-functional.
-function StandardLoad(::Nothing)
-    StandardLoad(;
-        name="init",
-        available=false,
-        bus=ACBus(nothing),
-        base_power=0.0,
-        constant_active_power=0.0,
-        constant_reactive_power=0.0,
-        impedance_active_power=0.0,
-        impedance_reactive_power=0.0,
-        current_active_power=0.0,
-        current_reactive_power=0.0,
-        max_constant_active_power=0.0,
-        max_constant_reactive_power=0.0,
-        max_impedance_active_power=0.0,
-        max_impedance_reactive_power=0.0,
-        max_current_active_power=0.0,
-        max_current_reactive_power=0.0,
-        is_conforming=1.0,
-        services=Device[],
-        dynamic_injector=nothing,
-        ext=Dict{String, Any}(),
-    )
+function StandardLoad(; name, available, is_conforming, bus, base_power, constant_active_power=0.0, constant_reactive_power=0.0, impedance_active_power=0.0, impedance_reactive_power=0.0, current_active_power=0.0, current_reactive_power=0.0, max_constant_active_power=0.0, max_constant_reactive_power=0.0, max_impedance_active_power=0.0, max_impedance_reactive_power=0.0, max_current_active_power=0.0, max_current_reactive_power=0.0, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+    StandardLoad(name, available, is_conforming, bus, base_power, constant_active_power, constant_reactive_power, impedance_active_power, impedance_reactive_power, current_active_power, current_reactive_power, max_constant_active_power, max_constant_reactive_power, max_impedance_active_power, max_impedance_reactive_power, max_current_active_power, max_current_reactive_power, services, dynamic_injector, ext, internal, )
 end
 
 """Get [`StandardLoad`](@ref) `name`."""
 get_name(value::StandardLoad) = value.name
 """Get [`StandardLoad`](@ref) `available`."""
 get_available(value::StandardLoad) = value.available
+"""Get [`StandardLoad`](@ref) `is_conforming`."""
+get_is_conforming(value::StandardLoad) = value.is_conforming
 """Get [`StandardLoad`](@ref) `bus`."""
 get_bus(value::StandardLoad) = value.bus
 """Get [`StandardLoad`](@ref) `base_power`."""
@@ -169,8 +145,6 @@ get_max_impedance_reactive_power(value::StandardLoad) = get_value(value, value.m
 get_max_current_active_power(value::StandardLoad) = get_value(value, value.max_current_active_power)
 """Get [`StandardLoad`](@ref) `max_current_reactive_power`."""
 get_max_current_reactive_power(value::StandardLoad) = get_value(value, value.max_current_reactive_power)
-"""Get [`StandardLoad`](@ref) `is_conforming`."""
-get_is_conforming(value::StandardLoad) = value.is_conforming
 """Get [`StandardLoad`](@ref) `services`."""
 get_services(value::StandardLoad) = value.services
 """Get [`StandardLoad`](@ref) `dynamic_injector`."""
@@ -182,6 +156,8 @@ get_internal(value::StandardLoad) = value.internal
 
 """Set [`StandardLoad`](@ref) `available`."""
 set_available!(value::StandardLoad, val) = value.available = val
+"""Set [`StandardLoad`](@ref) `is_conforming`."""
+set_is_conforming!(value::StandardLoad, val) = value.is_conforming = val
 """Set [`StandardLoad`](@ref) `bus`."""
 set_bus!(value::StandardLoad, val) = value.bus = val
 """Set [`StandardLoad`](@ref) `base_power`."""
@@ -210,8 +186,6 @@ set_max_impedance_reactive_power!(value::StandardLoad, val) = value.max_impedanc
 set_max_current_active_power!(value::StandardLoad, val) = value.max_current_active_power = set_value(value, val)
 """Set [`StandardLoad`](@ref) `max_current_reactive_power`."""
 set_max_current_reactive_power!(value::StandardLoad, val) = value.max_current_reactive_power = set_value(value, val)
-"""Set [`StandardLoad`](@ref) `is_conforming`."""
-set_is_conforming!(value::StandardLoad, val) = value.is_conforming = val
 """Set [`StandardLoad`](@ref) `services`."""
 set_services!(value::StandardLoad, val) = value.services = val
 """Set [`StandardLoad`](@ref) `ext`."""

--- a/src/models/generated/StandardLoad.jl
+++ b/src/models/generated/StandardLoad.jl
@@ -22,6 +22,7 @@ This file is auto-generated. Do not edit.
         max_impedance_reactive_power::Float64
         max_current_active_power::Float64
         max_current_reactive_power::Float64
+        is_conforming::Int64
         services::Vector{Service}
         dynamic_injector::Union{Nothing, DynamicInjection}
         ext::Dict{String, Any}
@@ -51,6 +52,7 @@ For an alternative exponential formulation of the ZIP model, see [`ExponentialLo
 - `max_impedance_reactive_power::Float64`: (default: `0.0`) Maximum reactive power (MVAR) drawn by constant impedance load
 - `max_current_active_power::Float64`: (default: `0.0`) Maximum active power (MW) drawn by constant current load
 - `max_current_reactive_power::Float64`: (default: `0.0`) Maximum reactive power (MVAR) drawn by constant current load
+- `is_conforming::Int64`: (default: `1.0`) Indicates whether the specified load is conforming or non-conforming.
 - `services::Vector{Service}`: (default: `Device[]`) Services that this device contributes to
 - `dynamic_injector::Union{Nothing, DynamicInjection}`: (default: `nothing`) corresponding dynamic injection device
 - `ext::Dict{String, Any}`: (default: `Dict{String, Any}()`) An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation, such as latitude and longitude.
@@ -89,6 +91,8 @@ mutable struct StandardLoad <: StaticLoad
     max_current_active_power::Float64
     "Maximum reactive power (MVAR) drawn by constant current load"
     max_current_reactive_power::Float64
+    "Indicates whether the specified load is conforming or non-conforming."
+    is_conforming::Int64
     "Services that this device contributes to"
     services::Vector{Service}
     "corresponding dynamic injection device"
@@ -99,12 +103,12 @@ mutable struct StandardLoad <: StaticLoad
     internal::InfrastructureSystemsInternal
 end
 
-function StandardLoad(name, available, bus, base_power, constant_active_power=0.0, constant_reactive_power=0.0, impedance_active_power=0.0, impedance_reactive_power=0.0, current_active_power=0.0, current_reactive_power=0.0, max_constant_active_power=0.0, max_constant_reactive_power=0.0, max_impedance_active_power=0.0, max_impedance_reactive_power=0.0, max_current_active_power=0.0, max_current_reactive_power=0.0, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), )
-    StandardLoad(name, available, bus, base_power, constant_active_power, constant_reactive_power, impedance_active_power, impedance_reactive_power, current_active_power, current_reactive_power, max_constant_active_power, max_constant_reactive_power, max_impedance_active_power, max_impedance_reactive_power, max_current_active_power, max_current_reactive_power, services, dynamic_injector, ext, InfrastructureSystemsInternal(), )
+function StandardLoad(name, available, bus, base_power, constant_active_power=0.0, constant_reactive_power=0.0, impedance_active_power=0.0, impedance_reactive_power=0.0, current_active_power=0.0, current_reactive_power=0.0, max_constant_active_power=0.0, max_constant_reactive_power=0.0, max_impedance_active_power=0.0, max_impedance_reactive_power=0.0, max_current_active_power=0.0, max_current_reactive_power=0.0, is_conforming=1.0, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), )
+    StandardLoad(name, available, bus, base_power, constant_active_power, constant_reactive_power, impedance_active_power, impedance_reactive_power, current_active_power, current_reactive_power, max_constant_active_power, max_constant_reactive_power, max_impedance_active_power, max_impedance_reactive_power, max_current_active_power, max_current_reactive_power, is_conforming, services, dynamic_injector, ext, InfrastructureSystemsInternal(), )
 end
 
-function StandardLoad(; name, available, bus, base_power, constant_active_power=0.0, constant_reactive_power=0.0, impedance_active_power=0.0, impedance_reactive_power=0.0, current_active_power=0.0, current_reactive_power=0.0, max_constant_active_power=0.0, max_constant_reactive_power=0.0, max_impedance_active_power=0.0, max_impedance_reactive_power=0.0, max_current_active_power=0.0, max_current_reactive_power=0.0, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
-    StandardLoad(name, available, bus, base_power, constant_active_power, constant_reactive_power, impedance_active_power, impedance_reactive_power, current_active_power, current_reactive_power, max_constant_active_power, max_constant_reactive_power, max_impedance_active_power, max_impedance_reactive_power, max_current_active_power, max_current_reactive_power, services, dynamic_injector, ext, internal, )
+function StandardLoad(; name, available, bus, base_power, constant_active_power=0.0, constant_reactive_power=0.0, impedance_active_power=0.0, impedance_reactive_power=0.0, current_active_power=0.0, current_reactive_power=0.0, max_constant_active_power=0.0, max_constant_reactive_power=0.0, max_impedance_active_power=0.0, max_impedance_reactive_power=0.0, max_current_active_power=0.0, max_current_reactive_power=0.0, is_conforming=1.0, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+    StandardLoad(name, available, bus, base_power, constant_active_power, constant_reactive_power, impedance_active_power, impedance_reactive_power, current_active_power, current_reactive_power, max_constant_active_power, max_constant_reactive_power, max_impedance_active_power, max_impedance_reactive_power, max_current_active_power, max_current_reactive_power, is_conforming, services, dynamic_injector, ext, internal, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -126,6 +130,7 @@ function StandardLoad(::Nothing)
         max_impedance_reactive_power=0.0,
         max_current_active_power=0.0,
         max_current_reactive_power=0.0,
+        is_conforming=1.0,
         services=Device[],
         dynamic_injector=nothing,
         ext=Dict{String, Any}(),
@@ -164,6 +169,8 @@ get_max_impedance_reactive_power(value::StandardLoad) = get_value(value, value.m
 get_max_current_active_power(value::StandardLoad) = get_value(value, value.max_current_active_power)
 """Get [`StandardLoad`](@ref) `max_current_reactive_power`."""
 get_max_current_reactive_power(value::StandardLoad) = get_value(value, value.max_current_reactive_power)
+"""Get [`StandardLoad`](@ref) `is_conforming`."""
+get_is_conforming(value::StandardLoad) = value.is_conforming
 """Get [`StandardLoad`](@ref) `services`."""
 get_services(value::StandardLoad) = value.services
 """Get [`StandardLoad`](@ref) `dynamic_injector`."""
@@ -203,6 +210,8 @@ set_max_impedance_reactive_power!(value::StandardLoad, val) = value.max_impedanc
 set_max_current_active_power!(value::StandardLoad, val) = value.max_current_active_power = set_value(value, val)
 """Set [`StandardLoad`](@ref) `max_current_reactive_power`."""
 set_max_current_reactive_power!(value::StandardLoad, val) = value.max_current_reactive_power = set_value(value, val)
+"""Set [`StandardLoad`](@ref) `is_conforming`."""
+set_is_conforming!(value::StandardLoad, val) = value.is_conforming = val
 """Set [`StandardLoad`](@ref) `services`."""
 set_services!(value::StandardLoad, val) = value.services = val
 """Set [`StandardLoad`](@ref) `ext`."""

--- a/src/models/generated/includes.jl
+++ b/src/models/generated/includes.jl
@@ -594,6 +594,7 @@ export get_inverter_tap_setting
 export get_inverter_tap_step
 export get_inverter_transformer_ratio
 export get_inverter_xc
+export get_is_conforming
 export get_is_filter_differential
 export get_k1
 export get_k2
@@ -1252,6 +1253,7 @@ export set_inverter_tap_setting!
 export set_inverter_tap_step!
 export set_inverter_transformer_ratio!
 export set_inverter_xc!
+export set_is_conforming!
 export set_is_filter_differential!
 export set_k1!
 export set_k2!

--- a/src/parsers/pm_io/matpower.jl
+++ b/src/parsers/pm_io/matpower.jl
@@ -216,6 +216,7 @@ function _parse_matpower_string(data_string::String)
             bus_data = row_to_typed_dict(bus_row, _mp_bus_columns)
             bus_data["index"] = check_type(Int, bus_row[1])
             bus_data["source_id"] = ["bus", bus_data["index"]]
+            bus_data["is_conforming"] = true
             push!(buses, bus_data)
             if bus_data["bus_type"] ∈ MP_FIX_VOLTAGE_BUSES
                 pv_bus_lookup[bus_data["index"]] = bus_data
@@ -509,6 +510,7 @@ function _split_loads_shunts!(data::Dict{String, Any})
                     Dict{String, Any}(
                         "pd" => bus["pd"],
                         "qd" => bus["qd"],
+                        "is_conforming" => true,
                         "load_bus" => bus["bus_i"],
                         "status" => convert(Int8, bus["bus_type"] != 4),
                         "index" => load_num,

--- a/src/parsers/pm_io/psse.jl
+++ b/src/parsers/pm_io/psse.jl
@@ -395,7 +395,7 @@ function _psse2pm_load!(pm_data::Dict, pti_data::Dict, import_all::Bool)
             sub_data["py"] = pop!(load, "YP")
             sub_data["qy"] = pop!(load, "YQ")
             sub_data["source_id"] = ["load", sub_data["load_bus"], pop!(load, "ID")]
-            sub_data["is_conforming"] = pop!(load, "SCALE") 
+            sub_data["is_conforming"] = pop!(load, "SCALE")
             sub_data["status"] = pop!(load, "STATUS")
             sub_data["index"] = length(pm_data["load"]) + 1
             if import_all

--- a/src/parsers/pm_io/psse.jl
+++ b/src/parsers/pm_io/psse.jl
@@ -395,6 +395,7 @@ function _psse2pm_load!(pm_data::Dict, pti_data::Dict, import_all::Bool)
             sub_data["py"] = pop!(load, "YP")
             sub_data["qy"] = pop!(load, "YQ")
             sub_data["source_id"] = ["load", sub_data["load_bus"], pop!(load, "ID")]
+            sub_data["is_conforming"] = pop!(load, "SCALE") 
             sub_data["status"] = pop!(load, "STATUS")
             sub_data["index"] = length(pm_data["load"]) + 1
             if import_all

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -344,6 +344,7 @@ function make_power_load(d::Dict, bus::ACBus, sys_mbase::Float64; kwargs...)
         max_active_power = d["pd"],
         max_reactive_power = d["qd"],
         base_power = sys_mbase,
+        is_conforming = d["is_conforming"]
     )
 end
 
@@ -366,6 +367,7 @@ function make_standard_load(d::Dict, bus::ACBus, sys_mbase::Float64; kwargs...)
         max_impedance_active_power = d["py"],
         max_impedance_reactive_power = d["qy"],
         base_power = sys_mbase,
+        is_conforming = d["is_conforming"]
     )
 end
 

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -344,7 +344,7 @@ function make_power_load(d::Dict, bus::ACBus, sys_mbase::Float64; kwargs...)
         max_active_power = d["pd"],
         max_reactive_power = d["qd"],
         base_power = sys_mbase,
-        is_conforming = Bool(d["is_conforming"])
+        is_conforming = Bool(d["is_conforming"]),
     )
 end
 
@@ -367,7 +367,7 @@ function make_standard_load(d::Dict, bus::ACBus, sys_mbase::Float64; kwargs...)
         max_impedance_active_power = d["py"],
         max_impedance_reactive_power = d["qy"],
         base_power = sys_mbase,
-        is_conforming = Bool(d["is_conforming"])
+        is_conforming = Bool(d["is_conforming"]),
     )
 end
 

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -344,7 +344,7 @@ function make_power_load(d::Dict, bus::ACBus, sys_mbase::Float64; kwargs...)
         max_active_power = d["pd"],
         max_reactive_power = d["qd"],
         base_power = sys_mbase,
-        is_conforming = d["is_conforming"]
+        is_conforming = Bool(d["is_conforming"])
     )
 end
 
@@ -367,7 +367,7 @@ function make_standard_load(d::Dict, bus::ACBus, sys_mbase::Float64; kwargs...)
         max_impedance_active_power = d["py"],
         max_impedance_reactive_power = d["qy"],
         base_power = sys_mbase,
-        is_conforming = d["is_conforming"]
+        is_conforming = Bool(d["is_conforming"])
     )
 end
 

--- a/test/test_parse_psse.jl
+++ b/test/test_parse_psse.jl
@@ -27,9 +27,11 @@ end
     @test get_current_active_power(get_component(StandardLoad, sys, "load10021")) == 2.2371
     @test get_impedance_reactive_power(get_component(StandardLoad, sys, "load10021")) ==
           5.83546
+    @test get_is_conforming(get_component(StandardLoad, sys, "load10021")) == 1
     sys2 = build_system(PSYTestSystems, "psse_Benchmark_4ger_33_2015_sys")  # Constant_active/reactive_power read in pu during parsing
     @test get_constant_active_power(get_component(StandardLoad, sys2, "load71")) == 9.67
     @test get_constant_reactive_power(get_component(StandardLoad, sys2, "load71")) == 1.0
+    @test get_is_conforming(get_component(StandardLoad, sys2, "load71")) == 1
 
     @info "Testing Generator Parsing"
     @test get_status(get_component(ThermalStandard, sys, "generator-2438-ND")) == 0


### PR DESCRIPTION
An is_conforming Bool field was added to the structs of StaticLoad subtypes. All tests are passing in psy5
