### PR TITLE
Revert shunt (fixed and switched) naming

### DIFF
--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -1538,8 +1538,7 @@ function read_switched_shunt!(
         d["name"] = get(d, "name", d_key)
         name = _get_name(d)
         bus = bus_number_to_bus[d["shunt_bus"]]
-        full_name = "$(get_name(bus))_$(name)"
-        shunt = make_switched_shunt(full_name, d, bus)
+        shunt = make_switched_shunt(name, d, bus)
 
         add_component!(sys, shunt; skip_validation = SKIP_PM_VALIDATION)
     end
@@ -1621,8 +1620,7 @@ function read_shunt!(
         d["name"] = get(d, "name", d_key)
         name = _get_name(d)
         bus = bus_number_to_bus[d["shunt_bus"]]
-        full_name = "$(get_name(bus))_$(name)"
-        shunt = make_shunt(full_name, d, bus)
+        shunt = make_shunt(name, d, bus)
 
         add_component!(sys, shunt; skip_validation = SKIP_PM_VALIDATION)
     end


### PR DESCRIPTION
This is a small change to avoid conflicts with the tests in PowerFlows psse exporter.