### PR TITLE
Mb/parse psse transformer name

### DIFF
--- a/src/parsers/pm_io/psse.jl
+++ b/src/parsers/pm_io/psse.jl
@@ -671,6 +671,7 @@ function _psse2pm_transformer!(pm_data::Dict, pti_data::Dict, import_all::Bool)
                     0,
                 ]
                 sub_data["ext"] = Dict{String, Any}(
+                    "psse_name" => transformer["NAME"],
                     "CW" => transformer["CW"],
                     "CZ" => transformer["CZ"],
                     "CM" => transformer["CM"],
@@ -885,6 +886,7 @@ function _psse2pm_transformer!(pm_data::Dict, pti_data::Dict, import_all::Bool)
                 sub_data["circuit"] = strip(transformer["CKT"])
 
                 sub_data["ext"] = Dict{String, Any}(
+                    "psse_name" => transformer["NAME"],
                     "CW" => transformer["CW"],
                     "CZ" => transformer["CZ"],
                     "CM" => transformer["CM"],

--- a/test/test_parse_psse.jl
+++ b/test/test_parse_psse.jl
@@ -58,7 +58,10 @@ end
     @info "Testing Three-Winding Transformer Parsing"
 
     @test isnothing(get_component(Transformer3W, sys3, "1"))
-
+    @test haskey(
+        get_ext(get_component(Transformer2W, sys3, "DALLAS 1 3-DALLAS 1 0-i_1")),
+        "psse_name",
+    )
     @test get_available(
         get_component(Transformer3W, sys4, "FAV PLACE 07-FAV SPOT 06-FAV SPOT 03-i_1"),
     ) == true
@@ -76,6 +79,13 @@ end
     @test get_r_primary(
         get_component(Transformer3W, sys5, "FAV SPOT 01-FAV SPOT 02-FAV SPOT 03-i_C"),
     ) == 0.00225
+    @test haskey(
+        get_ext(
+            get_component(Transformer3W, sys5, "FAV SPOT 01-FAV SPOT 02-FAV SPOT 03-i_C"),
+        ),
+        "psse_name",
+    )
+
     @test length(get_components(Transformer3W, sys5)) == 5
 
     @info "Testing Switched Shunt Parsing"


### PR DESCRIPTION
parse the (non-unique) PSSE transformer name to the ext of `Transformer2W` and `Transformer3W`. PSSE generates the star bus based on the sorted transformer names. Having this information is needed to map PSSE star buses to the ones generated by PowerSystems.jl.