### PR TITLE
Fix parse psse test

### DIFF
--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -800,14 +800,18 @@ function make_thermal_gen(
         start_up = startup,
         shut_down = shutdn,
     )
-
-    ext = Dict{String, Float64}(
-        "r" => d["r_source"],
-        "x" => d["x_source"],
-        "rt" => d["rt_source"],
-        "xt" => d["xt_source"],
-    )
  
+    ext = Dict{String, Float64}()
+    if haskey(d, "r_source") && haskey(d, "x_source")
+        ext["r"] = d["r_source"]
+        ext["x"] = d["x_source"]
+    end
+
+    if haskey(d, "rt_source") && haskey(d, "xt_source")
+        ext["rt"] = d["rt_source"]
+        ext["xt"] = d["xt_source"]
+    end
+
     if d["mbase"] != 0.0
         mbase = d["mbase"]
     else

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -801,15 +801,13 @@ function make_thermal_gen(
         shut_down = shutdn,
     )
 
-    ext = Dict{String, Any}()
-    if haskey(d, "r_source")
-        ext["z_source"] = (r = d["r_source"], x = d["x_source"])
-    end
-
-    if haskey(d, "rt_source")
-        ext["zt_source"] = (rt = d["rt_source"], xt = d["xt_source"])
-    end
-
+    ext = Dict{String, Float64}(
+        "r" => d["r_source"],
+        "x" => d["x_source"],
+        "rt" => d["rt_source"],
+        "xt" => d["xt_source"],
+    )
+ 
     if d["mbase"] != 0.0
         mbase = d["mbase"]
     else

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -800,7 +800,7 @@ function make_thermal_gen(
         start_up = startup,
         shut_down = shutdn,
     )
- 
+
     ext = Dict{String, Float64}()
     if haskey(d, "r_source") && haskey(d, "x_source")
         ext["r"] = d["r_source"]

--- a/src/parsers/psse_dynamic_data.jl
+++ b/src/parsers/psse_dynamic_data.jl
@@ -503,7 +503,7 @@ function add_dyn_injectors!(sys::System, bus_dict_gen::Dict)
         temp_dict = get(bus_dict_gen, _num, nothing)
         if temp_dict === nothing
             @warn "Generator at bus $(_num), id $(_id), not found in Dynamic Data.\nVoltage Source will be used to model it."
-            r, x = get_ext(g)["z_source"]
+            r, x = get_ext(g)["r"], get_ext(g)["x"]
             if x == 0.0
                 @warn "No series reactance found. Setting it to 1e-6"
                 x = 1e-6
@@ -516,7 +516,7 @@ function add_dyn_injectors!(sys::System, bus_dict_gen::Dict)
                 # Obtain Machine from Dictionary
                 machine = temp_dict[_id][1]
                 # Update R,X from RSORCE and XSORCE from RAW file
-                r, x = get_ext(g)["z_source"]
+                r, x = get_ext(g)["r"], get_ext(g)["x"]
                 set_R!(machine, r)
                 # Obtain Shaft from dictionary
                 shaft = temp_dict[_id][2]

--- a/test/test_parse_psse.jl
+++ b/test/test_parse_psse.jl
@@ -321,7 +321,8 @@ end
 end
 
 @testset "PSSE System Serialization/Desearialization" begin
-    original_sys = build_system(PSSEParsingTestSystems, "pti_case30_sys"; force_build = true)
+    original_sys =
+        build_system(PSSEParsingTestSystems, "pti_case30_sys"; force_build = true)
     serialize_sys_path = joinpath(tempdir(), "test_system.json")
     to_json(original_sys, serialize_sys_path; force = true)
     deserialized_sys = System(serialize_sys_path)

--- a/test/test_parse_psse.jl
+++ b/test/test_parse_psse.jl
@@ -10,7 +10,9 @@
         @info "Successfully parsed $f to PowerModelsData"
         sys = System(pm_data)
         for g in get_components(Generator, sys)
-            @test haskey(get_ext(g), "z_source")
+            # @test haskey(get_ext(g), "z_source")
+            @test haskey(get_ext(g), "r")
+            @test haskey(get_ext(g), "x")
         end
         @info "Successfully parsed $f to System struct"
     end
@@ -319,7 +321,7 @@ end
 end
 
 @testset "PSSE System Serialization/Desearialization" begin
-    original_sys = build_system(PSSEParsingTestSystems, "pti_case30_sys")
+    original_sys = build_system(PSSEParsingTestSystems, "pti_case30_sys"; force_build = true)
     serialize_sys_path = joinpath(tempdir(), "test_system.json")
     to_json(original_sys, serialize_sys_path; force = true)
     deserialized_sys = System(serialize_sys_path)


### PR DESCRIPTION
We were getting problems with serializing named tuples.

Do you think this approach is okay @jd-lara ? We could also add in the ext, `r_source` and `x_source` rather than `r` and `x`?
