### PR TITLE
Remove bus modifications during parsing 

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -1901,7 +1901,7 @@ Check system consistency and validity.
 function check(sys::System)
     buses = get_components(ACBus, sys)
     slack_bus_check(buses)
-    buscheck(buses)
+    buscheck(sys)
     critical_components_check(sys)
     adequacy_check(sys)
     check_subsystems(sys)

--- a/src/parsers/pm_io/common.jl
+++ b/src/parsers/pm_io/common.jl
@@ -65,7 +65,6 @@ Runs various data quality checks on a PowerModels data dictionary.
 Applies modifications in some cases.  Reports modified component ids.
 """
 function correct_network_data!(data::Dict{String, <:Any}; correct_branch_rating = true)
-    mod_bus = Dict{Symbol, Set{Int}}()
     mod_gen = Dict{Symbol, Set{Int}}()
     mod_branch = Dict{Symbol, Set{Int}}()
     mod_dcline = Dict{Symbol, Set{Int}}()
@@ -107,7 +106,6 @@ function correct_network_data!(data::Dict{String, <:Any}; correct_branch_rating 
 
     mod_dcline[:losses] = correct_dcline_limits!(data)
 
-    mod_bus[:type] = correct_bus_types!(data)
     check_voltage_setpoints(data)
 
     check_storage_parameters(data)
@@ -120,7 +118,6 @@ function correct_network_data!(data::Dict{String, <:Any}; correct_branch_rating 
     simplify_cost_terms!(data)
 
     return Dict(
-        "bus" => mod_bus,
         "gen" => mod_gen,
         "branch" => mod_branch,
         "dcline" => mod_dcline,

--- a/src/parsers/pm_io/data.jl
+++ b/src/parsers/pm_io/data.jl
@@ -1678,43 +1678,6 @@ function check_switch_parameters(data::Dict{String, <:Any})
     end
 end
 
-"checks bus types are consistent with generator connections, if not, fixes them"
-function correct_bus_types!(data::Dict{String, <:Any})
-    if ismultinetwork(data)
-        error("check_bus_types does not yet support multinetwork data")
-    end
-
-    modified = Set{Int}()
-
-    bus_gens = Dict((i, []) for (i, bus) in data["bus"])
-
-    for (i, gen) in data["gen"]
-        #println(gen)
-        if gen["gen_status"] == 1
-            push!(bus_gens[gen["gen_bus"]], i)
-        end
-    end
-
-    for (i, bus) in data["bus"]
-        if bus["bus_type"] != 4 && bus["bus_type"] != 3
-            bus_gens_count = length(bus_gens[i])
-
-            if bus_gens_count == 0 && bus["bus_type"] != 1
-                @info "no active generators found at bus $(bus["bus_i"]), updating to bus type from $(bus["bus_type"]) to 1" maxlog =
-                    PS_MAX_LOG
-                bus["bus_type"] = 1
-                push!(modified, bus["index"])
-            end
-
-            if bus_gens_count != 0 && bus["bus_type"] != 2
-                @warn "active generators found at bus $(bus["bus_i"]) on bus type $(bus["bus_type"]), i.e. different than 2 (PV). Consider checking your data inputs."
-            end
-        end
-    end
-
-    return modified
-end
-
 "checks that parameters for dc lines are reasonable"
 function correct_dcline_limits!(data::Dict{String, Any})
     if ismultinetwork(data)
@@ -1854,7 +1817,6 @@ end
 
 ""
 function _correct_cost_function!(id, comp, type_name)
-    #println(comp)
     modified = false
 
     if "model" in keys(comp) && "cost" in keys(comp)

--- a/src/utils/IO/system_checks.jl
+++ b/src/utils/IO/system_checks.jl
@@ -3,10 +3,13 @@
 
 ## Check that all the buses have a type defintion and that bus types are consistent with generator connections ##
 
-function buscheck(sys)
+function buscheck(sys::System)
     buses = get_components(ACBus, sys)
     bus_to_active_gens_map = Dict((i, Set{String}()) for i in get_number.(buses))
-    for gen in get_components(x -> get_available(x), Generator, sys)
+    for gen in get_components(Generator, sys)
+        if !get_available(gen)
+            continue
+        end
         bus_number = get_number(get_bus(gen))
         gen_name = get_name(gen)
         push!(get!(bus_to_active_gens_map, bus_number, Set{String}()), gen_name)
@@ -20,11 +23,11 @@ function buscheck(sys)
         elseif b_type != ACBusTypes.ISOLATED && b_type != ACBusTypes.REF
             bus_gens_count = length(bus_to_active_gens_map[b_number])
             if bus_gens_count == 0 && b_type != ACBusTypes.PQ
-                @error "no active generators found at bus $(b_number) with type $(b_type), consider checking your data inputs." maxlog =
+                @error "no active generators found at bus $(summary(b)) with type $(b_type), consider checking your data inputs." maxlog =
                     PS_MAX_LOG
             end
             if bus_gens_count != 0 && b_type != ACBusTypes.PV
-                @error "active generators found at bus $(b_number) with type $(b_type), consider checking your data inputs." maxlog =
+                @error "active generators found at bus $(summary(b)) with type $(b_type), consider checking your data inputs." maxlog =
                     PS_MAX_LOG
             end
         end

--- a/src/utils/IO/system_checks.jl
+++ b/src/utils/IO/system_checks.jl
@@ -1,13 +1,32 @@
 
 ### Utility Functions needed for the construction of the Power System, mostly used for consistency checking ####
 
-## Check that all the buses have a type defintion ##
+## Check that all the buses have a type defintion and that bus types are consistent with generator connections ##
 
-function buscheck(buses)
+function buscheck(sys)
+    buses = get_components(ACBus, sys)
+    bus_to_active_gens_map = Dict((i, Set{String}()) for i in get_number.(buses))
+    for gen in get_components(x -> get_available(x), Generator, sys)
+        bus_number = get_number(get_bus(gen))
+        gen_name = get_name(gen)
+        push!(get!(bus_to_active_gens_map, bus_number, Set{String}()), gen_name)
+    end
     for b in buses
-        if isnothing(b.bustype)
+        b_type = get_bustype(b)
+        b_number = get_number(b)
+        if isnothing(b_type)
             @warn "Bus/Nodes data does not contain information to build an a network" maxlog =
                 10
+        elseif b_type != ACBusTypes.ISOLATED && b_type != ACBusTypes.REF
+            bus_gens_count = length(bus_to_active_gens_map[b_number])
+            if bus_gens_count == 0 && b_type != ACBusTypes.PQ
+                @error "no active generators found at bus $(b_number) with type $(b_type), consider checking your data inputs." maxlog =
+                    PS_MAX_LOG
+            end
+            if bus_gens_count != 0 && b_type != ACBusTypes.PV
+                @error "active generators found at bus $(b_number) with type $(b_type), consider checking your data inputs." maxlog =
+                    PS_MAX_LOG
+            end
         end
     end
     return


### PR DESCRIPTION
Removes the modifications of bus types depending on the connected generators during parsing.
Instead, logs errors during the system checks.

@jd-lara Should this definitely be an error and not a warning? This causes errors to be logged in various systems used in the tests:
<img width="647" alt="image" src="https://github.com/user-attachments/assets/23c21e0e-9310-4d81-8b09-a71d648d5503" />