### PR TITLE
Update current pti parser to handle V35 PSSE files

### DIFF
--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -2584,6 +2584,12 @@
                     "comment": "[`OperationalCost`](@ref) of interrupting load"
                 },
                 {
+                    "name": "interruptible",
+                    "comment": "Interruptible load flag, one for an interruptible load for zero for a non interruptible load.",
+                    "data_type": "Int64",
+                    "default": "0"
+                },
+                {
                     "name": "services",
                     "data_type": "Vector{Service}",
                     "comment": "Services that this device contributes to",
@@ -2900,6 +2906,13 @@
                     "data_type": "Complex{Float64}"
                 },
                 {
+                    "name": "initial_status",
+                    "comment": "Vector of initial switched shunt status, one for in-service and zero for out-of-service for block i (1 through 8)",
+                    "null_value": "Int[]",
+                    "data_type": "Vector{Int}",
+                    "default": "Int[]"
+                },
+                {
                     "name": "number_of_steps",
                     "comment": "Vector with number of steps for each adjustable shunt block. For example, `number_of_steps[2]` are the number of available steps for admittance increment at block 2.",
                     "null_value": "Int[]",
@@ -3022,6 +3035,12 @@
                     "comment": "Indicator of scalability of the load. Indicates whether the specified load is conforming or non-conforming.",
                     "data_type": "LoadConformity",
                     "default": "LoadConformity.UNDEFINED"
+                },
+                {
+                    "name": "interruptible",
+                    "comment": "Interruptible load flag, one for an interruptible load for zero for a non interruptible load.",
+                    "data_type": "Int64",
+                    "default": "0"
                 },
                 {
                     "name": "services",
@@ -3204,6 +3223,12 @@
                     "default": "LoadConformity.UNDEFINED"
                 },
                 {
+                    "name": "interruptible",
+                    "comment": "Interruptible load flag, one for an interruptible load for zero for a non interruptible load.",
+                    "data_type": "Int64",
+                    "default": "0"
+                },
+                {
                     "name": "services",
                     "data_type": "Vector{Service}",
                     "comment": "Services that this device contributes to",
@@ -3328,6 +3353,12 @@
                     "comment": "Indicator of scalability of the load. Indicates whether the specified load is conforming or non-conforming.",
                     "data_type": "LoadConformity",
                     "default": "LoadConformity.UNDEFINED"
+                },
+                {
+                    "name": "interruptible",
+                    "comment": "Interruptible load flag, one for an interruptible load for zero for a non interruptible load.",
+                    "data_type": "Int64",
+                    "default": "0"
                 },
                 {
                     "name": "services",

--- a/src/models/generated/ExponentialLoad.jl
+++ b/src/models/generated/ExponentialLoad.jl
@@ -17,6 +17,7 @@ This file is auto-generated. Do not edit.
         max_active_power::Float64
         max_reactive_power::Float64
         conformity::LoadConformity
+        interruptible::Int64
         services::Vector{Service}
         dynamic_injector::Union{Nothing, DynamicInjection}
         ext::Dict{String, Any}
@@ -39,6 +40,7 @@ An `ExponentialLoad` models active power as P = P0 * V^α and reactive power as 
 - `max_active_power::Float64`: Maximum active power (MW) that this load can demand
 - `max_reactive_power::Float64`: Maximum reactive power (MVAR) that this load can demand
 - `conformity::LoadConformity`: (default: `LoadConformity.UNDEFINED`) Indicator of scalability of the load. Indicates whether the specified load is conforming or non-conforming.
+- `interruptible::Int64`: (default: `0`) Interruptible load flag, one for an interruptible load for zero for a non interruptible load.
 - `services::Vector{Service}`: (default: `Device[]`) Services that this device contributes to
 - `dynamic_injector::Union{Nothing, DynamicInjection}`: (default: `nothing`) corresponding dynamic injection device
 - `ext::Dict{String, Any}`: (default: `Dict{String, Any}()`) An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation.
@@ -67,6 +69,8 @@ mutable struct ExponentialLoad <: StaticLoad
     max_reactive_power::Float64
     "Indicator of scalability of the load. Indicates whether the specified load is conforming or non-conforming."
     conformity::LoadConformity
+    "Interruptible load flag, one for an interruptible load for zero for a non interruptible load."
+    interruptible::Int64
     "Services that this device contributes to"
     services::Vector{Service}
     "corresponding dynamic injection device"
@@ -77,12 +81,12 @@ mutable struct ExponentialLoad <: StaticLoad
     internal::InfrastructureSystemsInternal
 end
 
-function ExponentialLoad(name, available, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, conformity=LoadConformity.UNDEFINED, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), )
-    ExponentialLoad(name, available, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, conformity, services, dynamic_injector, ext, InfrastructureSystemsInternal(), )
+function ExponentialLoad(name, available, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, conformity=LoadConformity.UNDEFINED, interruptible=0, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), )
+    ExponentialLoad(name, available, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, conformity, interruptible, services, dynamic_injector, ext, InfrastructureSystemsInternal(), )
 end
 
-function ExponentialLoad(; name, available, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, conformity=LoadConformity.UNDEFINED, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
-    ExponentialLoad(name, available, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, conformity, services, dynamic_injector, ext, internal, )
+function ExponentialLoad(; name, available, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, conformity=LoadConformity.UNDEFINED, interruptible=0, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+    ExponentialLoad(name, available, bus, active_power, reactive_power, α, β, base_power, max_active_power, max_reactive_power, conformity, interruptible, services, dynamic_injector, ext, internal, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -99,6 +103,7 @@ function ExponentialLoad(::Nothing)
         max_active_power=0.0,
         max_reactive_power=0.0,
         conformity=LoadConformity.UNDEFINED,
+        interruptible=0,
         services=Device[],
         dynamic_injector=nothing,
         ext=Dict{String, Any}(),
@@ -127,6 +132,8 @@ get_max_active_power(value::ExponentialLoad) = get_value(value, Val(:max_active_
 get_max_reactive_power(value::ExponentialLoad) = get_value(value, Val(:max_reactive_power), Val(:mva))
 """Get [`ExponentialLoad`](@ref) `conformity`."""
 get_conformity(value::ExponentialLoad) = value.conformity
+"""Get [`ExponentialLoad`](@ref) `interruptible`."""
+get_interruptible(value::ExponentialLoad) = value.interruptible
 """Get [`ExponentialLoad`](@ref) `services`."""
 get_services(value::ExponentialLoad) = value.services
 """Get [`ExponentialLoad`](@ref) `dynamic_injector`."""
@@ -156,6 +163,8 @@ set_max_active_power!(value::ExponentialLoad, val) = value.max_active_power = se
 set_max_reactive_power!(value::ExponentialLoad, val) = value.max_reactive_power = set_value(value, Val(:max_reactive_power), val, Val(:mva))
 """Set [`ExponentialLoad`](@ref) `conformity`."""
 set_conformity!(value::ExponentialLoad, val) = value.conformity = val
+"""Set [`ExponentialLoad`](@ref) `interruptible`."""
+set_interruptible!(value::ExponentialLoad, val) = value.interruptible = val
 """Set [`ExponentialLoad`](@ref) `services`."""
 set_services!(value::ExponentialLoad, val) = value.services = val
 """Set [`ExponentialLoad`](@ref) `ext`."""

--- a/src/models/generated/PowerLoad.jl
+++ b/src/models/generated/PowerLoad.jl
@@ -15,6 +15,7 @@ This file is auto-generated. Do not edit.
         max_active_power::Float64
         max_reactive_power::Float64
         conformity::LoadConformity
+        interruptible::Int64
         services::Vector{Service}
         dynamic_injector::Union{Nothing, DynamicInjection}
         ext::Dict{String, Any}
@@ -35,6 +36,7 @@ This load consumes a set amount of power (set by `active_power` for a power flow
 - `max_active_power::Float64`: Maximum active power (MW) that this load can demand
 - `max_reactive_power::Float64`: Maximum reactive power (MVAR) that this load can demand
 - `conformity::LoadConformity`: (default: `LoadConformity.UNDEFINED`) Indicator of scalability of the load. Indicates whether the specified load is conforming or non-conforming.
+- `interruptible::Int64`: (default: `0`) Interruptible load flag, one for an interruptible load for zero for a non interruptible load.
 - `services::Vector{Service}`: (default: `Device[]`) Services that this device contributes to
 - `dynamic_injector::Union{Nothing, DynamicInjection}`: (default: `nothing`) corresponding dynamic injection device
 - `ext::Dict{String, Any}`: (default: `Dict{String, Any}()`) An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation.
@@ -59,6 +61,8 @@ mutable struct PowerLoad <: StaticLoad
     max_reactive_power::Float64
     "Indicator of scalability of the load. Indicates whether the specified load is conforming or non-conforming."
     conformity::LoadConformity
+    "Interruptible load flag, one for an interruptible load for zero for a non interruptible load."
+    interruptible::Int64
     "Services that this device contributes to"
     services::Vector{Service}
     "corresponding dynamic injection device"
@@ -69,12 +73,12 @@ mutable struct PowerLoad <: StaticLoad
     internal::InfrastructureSystemsInternal
 end
 
-function PowerLoad(name, available, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, conformity=LoadConformity.UNDEFINED, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), )
-    PowerLoad(name, available, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, conformity, services, dynamic_injector, ext, InfrastructureSystemsInternal(), )
+function PowerLoad(name, available, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, conformity=LoadConformity.UNDEFINED, interruptible=0, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), )
+    PowerLoad(name, available, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, conformity, interruptible, services, dynamic_injector, ext, InfrastructureSystemsInternal(), )
 end
 
-function PowerLoad(; name, available, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, conformity=LoadConformity.UNDEFINED, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
-    PowerLoad(name, available, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, conformity, services, dynamic_injector, ext, internal, )
+function PowerLoad(; name, available, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, conformity=LoadConformity.UNDEFINED, interruptible=0, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+    PowerLoad(name, available, bus, active_power, reactive_power, base_power, max_active_power, max_reactive_power, conformity, interruptible, services, dynamic_injector, ext, internal, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -89,6 +93,7 @@ function PowerLoad(::Nothing)
         max_active_power=0.0,
         max_reactive_power=0.0,
         conformity=LoadConformity.UNDEFINED,
+        interruptible=0,
         services=Device[],
         dynamic_injector=nothing,
         ext=Dict{String, Any}(),
@@ -113,6 +118,8 @@ get_max_active_power(value::PowerLoad) = get_value(value, Val(:max_active_power)
 get_max_reactive_power(value::PowerLoad) = get_value(value, Val(:max_reactive_power), Val(:mva))
 """Get [`PowerLoad`](@ref) `conformity`."""
 get_conformity(value::PowerLoad) = value.conformity
+"""Get [`PowerLoad`](@ref) `interruptible`."""
+get_interruptible(value::PowerLoad) = value.interruptible
 """Get [`PowerLoad`](@ref) `services`."""
 get_services(value::PowerLoad) = value.services
 """Get [`PowerLoad`](@ref) `dynamic_injector`."""
@@ -138,6 +145,8 @@ set_max_active_power!(value::PowerLoad, val) = value.max_active_power = set_valu
 set_max_reactive_power!(value::PowerLoad, val) = value.max_reactive_power = set_value(value, Val(:max_reactive_power), val, Val(:mva))
 """Set [`PowerLoad`](@ref) `conformity`."""
 set_conformity!(value::PowerLoad, val) = value.conformity = val
+"""Set [`PowerLoad`](@ref) `interruptible`."""
+set_interruptible!(value::PowerLoad, val) = value.interruptible = val
 """Set [`PowerLoad`](@ref) `services`."""
 set_services!(value::PowerLoad, val) = value.services = val
 """Set [`PowerLoad`](@ref) `ext`."""

--- a/src/models/generated/StandardLoad.jl
+++ b/src/models/generated/StandardLoad.jl
@@ -23,6 +23,7 @@ This file is auto-generated. Do not edit.
         max_current_active_power::Float64
         max_current_reactive_power::Float64
         conformity::LoadConformity
+        interruptible::Int64
         services::Vector{Service}
         dynamic_injector::Union{Nothing, DynamicInjection}
         ext::Dict{String, Any}
@@ -53,6 +54,7 @@ For an alternative exponential formulation of the ZIP model, see [`ExponentialLo
 - `max_current_active_power::Float64`: (default: `0.0`) Maximum active power (MW) drawn by constant current load
 - `max_current_reactive_power::Float64`: (default: `0.0`) Maximum reactive power (MVAR) drawn by constant current load
 - `conformity::LoadConformity`: (default: `LoadConformity.UNDEFINED`) Indicator of scalability of the load. Indicates whether the specified load is conforming or non-conforming.
+- `interruptible::Int64`: (default: `0`) Interruptible load flag, one for an interruptible load for zero for a non interruptible load.
 - `services::Vector{Service}`: (default: `Device[]`) Services that this device contributes to
 - `dynamic_injector::Union{Nothing, DynamicInjection}`: (default: `nothing`) corresponding dynamic injection device
 - `ext::Dict{String, Any}`: (default: `Dict{String, Any}()`) An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation.
@@ -93,6 +95,8 @@ mutable struct StandardLoad <: StaticLoad
     max_current_reactive_power::Float64
     "Indicator of scalability of the load. Indicates whether the specified load is conforming or non-conforming."
     conformity::LoadConformity
+    "Interruptible load flag, one for an interruptible load for zero for a non interruptible load."
+    interruptible::Int64
     "Services that this device contributes to"
     services::Vector{Service}
     "corresponding dynamic injection device"
@@ -103,12 +107,12 @@ mutable struct StandardLoad <: StaticLoad
     internal::InfrastructureSystemsInternal
 end
 
-function StandardLoad(name, available, bus, base_power, constant_active_power=0.0, constant_reactive_power=0.0, impedance_active_power=0.0, impedance_reactive_power=0.0, current_active_power=0.0, current_reactive_power=0.0, max_constant_active_power=0.0, max_constant_reactive_power=0.0, max_impedance_active_power=0.0, max_impedance_reactive_power=0.0, max_current_active_power=0.0, max_current_reactive_power=0.0, conformity=LoadConformity.UNDEFINED, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), )
-    StandardLoad(name, available, bus, base_power, constant_active_power, constant_reactive_power, impedance_active_power, impedance_reactive_power, current_active_power, current_reactive_power, max_constant_active_power, max_constant_reactive_power, max_impedance_active_power, max_impedance_reactive_power, max_current_active_power, max_current_reactive_power, conformity, services, dynamic_injector, ext, InfrastructureSystemsInternal(), )
+function StandardLoad(name, available, bus, base_power, constant_active_power=0.0, constant_reactive_power=0.0, impedance_active_power=0.0, impedance_reactive_power=0.0, current_active_power=0.0, current_reactive_power=0.0, max_constant_active_power=0.0, max_constant_reactive_power=0.0, max_impedance_active_power=0.0, max_impedance_reactive_power=0.0, max_current_active_power=0.0, max_current_reactive_power=0.0, conformity=LoadConformity.UNDEFINED, interruptible=0, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), )
+    StandardLoad(name, available, bus, base_power, constant_active_power, constant_reactive_power, impedance_active_power, impedance_reactive_power, current_active_power, current_reactive_power, max_constant_active_power, max_constant_reactive_power, max_impedance_active_power, max_impedance_reactive_power, max_current_active_power, max_current_reactive_power, conformity, interruptible, services, dynamic_injector, ext, InfrastructureSystemsInternal(), )
 end
 
-function StandardLoad(; name, available, bus, base_power, constant_active_power=0.0, constant_reactive_power=0.0, impedance_active_power=0.0, impedance_reactive_power=0.0, current_active_power=0.0, current_reactive_power=0.0, max_constant_active_power=0.0, max_constant_reactive_power=0.0, max_impedance_active_power=0.0, max_impedance_reactive_power=0.0, max_current_active_power=0.0, max_current_reactive_power=0.0, conformity=LoadConformity.UNDEFINED, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
-    StandardLoad(name, available, bus, base_power, constant_active_power, constant_reactive_power, impedance_active_power, impedance_reactive_power, current_active_power, current_reactive_power, max_constant_active_power, max_constant_reactive_power, max_impedance_active_power, max_impedance_reactive_power, max_current_active_power, max_current_reactive_power, conformity, services, dynamic_injector, ext, internal, )
+function StandardLoad(; name, available, bus, base_power, constant_active_power=0.0, constant_reactive_power=0.0, impedance_active_power=0.0, impedance_reactive_power=0.0, current_active_power=0.0, current_reactive_power=0.0, max_constant_active_power=0.0, max_constant_reactive_power=0.0, max_impedance_active_power=0.0, max_impedance_reactive_power=0.0, max_current_active_power=0.0, max_current_reactive_power=0.0, conformity=LoadConformity.UNDEFINED, interruptible=0, services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+    StandardLoad(name, available, bus, base_power, constant_active_power, constant_reactive_power, impedance_active_power, impedance_reactive_power, current_active_power, current_reactive_power, max_constant_active_power, max_constant_reactive_power, max_impedance_active_power, max_impedance_reactive_power, max_current_active_power, max_current_reactive_power, conformity, interruptible, services, dynamic_injector, ext, internal, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -131,6 +135,7 @@ function StandardLoad(::Nothing)
         max_current_active_power=0.0,
         max_current_reactive_power=0.0,
         conformity=LoadConformity.UNDEFINED,
+        interruptible=0,
         services=Device[],
         dynamic_injector=nothing,
         ext=Dict{String, Any}(),
@@ -171,6 +176,8 @@ get_max_current_active_power(value::StandardLoad) = get_value(value, Val(:max_cu
 get_max_current_reactive_power(value::StandardLoad) = get_value(value, Val(:max_current_reactive_power), Val(:mva))
 """Get [`StandardLoad`](@ref) `conformity`."""
 get_conformity(value::StandardLoad) = value.conformity
+"""Get [`StandardLoad`](@ref) `interruptible`."""
+get_interruptible(value::StandardLoad) = value.interruptible
 """Get [`StandardLoad`](@ref) `services`."""
 get_services(value::StandardLoad) = value.services
 """Get [`StandardLoad`](@ref) `dynamic_injector`."""
@@ -212,6 +219,8 @@ set_max_current_active_power!(value::StandardLoad, val) = value.max_current_acti
 set_max_current_reactive_power!(value::StandardLoad, val) = value.max_current_reactive_power = set_value(value, Val(:max_current_reactive_power), val, Val(:mva))
 """Set [`StandardLoad`](@ref) `conformity`."""
 set_conformity!(value::StandardLoad, val) = value.conformity = val
+"""Set [`StandardLoad`](@ref) `interruptible`."""
+set_interruptible!(value::StandardLoad, val) = value.interruptible = val
 """Set [`StandardLoad`](@ref) `services`."""
 set_services!(value::StandardLoad, val) = value.services = val
 """Set [`StandardLoad`](@ref) `ext`."""

--- a/src/models/generated/SwitchedAdmittance.jl
+++ b/src/models/generated/SwitchedAdmittance.jl
@@ -10,6 +10,7 @@ This file is auto-generated. Do not edit.
         available::Bool
         bus::ACBus
         Y::Complex{Float64}
+        initial_status::Vector{Int}
         number_of_steps::Vector{Int}
         Y_increase::Vector{Complex{Float64}}
         admittance_limits::MinMax
@@ -28,6 +29,7 @@ Most often used in power flow studies, iterating over the steps to see impacts o
 - `available::Bool`: Indicator of whether the component is connected and online (`true`) or disconnected, offline, or down (`false`). Unavailable components are excluded during simulations
 - `bus::ACBus`: Bus that this component is connected to
 - `Y::Complex{Float64}`: Initial admittance at N = 0
+- `initial_status::Vector{Int}`: (default: `Int[]`) Vector of initial switched shunt status, one for in-service and zero for out-of-service for block i (1 through 8)
 - `number_of_steps::Vector{Int}`: (default: `Int[]`) Vector with number of steps for each adjustable shunt block. For example, `number_of_steps[2]` are the number of available steps for admittance increment at block 2.
 - `Y_increase::Vector{Complex{Float64}}`: (default: `Complex{Float64}[]`) Vector with admittance increment step for each adjustable shunt block. For example, `Y_increase[2]` is the complex admittance increment for each step at block 2.
 - `admittance_limits::MinMax`: (default: `(min=1.0, max=1.0)`) Shunt admittance limits for switched shunt model
@@ -45,6 +47,8 @@ mutable struct SwitchedAdmittance <: ElectricLoad
     bus::ACBus
     "Initial admittance at N = 0"
     Y::Complex{Float64}
+    "Vector of initial switched shunt status, one for in-service and zero for out-of-service for block i (1 through 8)"
+    initial_status::Vector{Int}
     "Vector with number of steps for each adjustable shunt block. For example, `number_of_steps[2]` are the number of available steps for admittance increment at block 2."
     number_of_steps::Vector{Int}
     "Vector with admittance increment step for each adjustable shunt block. For example, `Y_increase[2]` is the complex admittance increment for each step at block 2."
@@ -61,12 +65,12 @@ mutable struct SwitchedAdmittance <: ElectricLoad
     internal::InfrastructureSystemsInternal
 end
 
-function SwitchedAdmittance(name, available, bus, Y, number_of_steps=Int[], Y_increase=Complex{Float64}[], admittance_limits=(min=1.0, max=1.0), dynamic_injector=nothing, services=Device[], ext=Dict{String, Any}(), )
-    SwitchedAdmittance(name, available, bus, Y, number_of_steps, Y_increase, admittance_limits, dynamic_injector, services, ext, InfrastructureSystemsInternal(), )
+function SwitchedAdmittance(name, available, bus, Y, initial_status=Int[], number_of_steps=Int[], Y_increase=Complex{Float64}[], admittance_limits=(min=1.0, max=1.0), dynamic_injector=nothing, services=Device[], ext=Dict{String, Any}(), )
+    SwitchedAdmittance(name, available, bus, Y, initial_status, number_of_steps, Y_increase, admittance_limits, dynamic_injector, services, ext, InfrastructureSystemsInternal(), )
 end
 
-function SwitchedAdmittance(; name, available, bus, Y, number_of_steps=Int[], Y_increase=Complex{Float64}[], admittance_limits=(min=1.0, max=1.0), dynamic_injector=nothing, services=Device[], ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
-    SwitchedAdmittance(name, available, bus, Y, number_of_steps, Y_increase, admittance_limits, dynamic_injector, services, ext, internal, )
+function SwitchedAdmittance(; name, available, bus, Y, initial_status=Int[], number_of_steps=Int[], Y_increase=Complex{Float64}[], admittance_limits=(min=1.0, max=1.0), dynamic_injector=nothing, services=Device[], ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+    SwitchedAdmittance(name, available, bus, Y, initial_status, number_of_steps, Y_increase, admittance_limits, dynamic_injector, services, ext, internal, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -76,6 +80,7 @@ function SwitchedAdmittance(::Nothing)
         available=false,
         bus=ACBus(nothing),
         Y=0.0 + 0.0im,
+        initial_status=Int[],
         number_of_steps=Int[],
         Y_increase=Complex{Float64}[],
         admittance_limits=(min=0.0, max=0.0),
@@ -93,6 +98,8 @@ get_available(value::SwitchedAdmittance) = value.available
 get_bus(value::SwitchedAdmittance) = value.bus
 """Get [`SwitchedAdmittance`](@ref) `Y`."""
 get_Y(value::SwitchedAdmittance) = value.Y
+"""Get [`SwitchedAdmittance`](@ref) `initial_status`."""
+get_initial_status(value::SwitchedAdmittance) = value.initial_status
 """Get [`SwitchedAdmittance`](@ref) `number_of_steps`."""
 get_number_of_steps(value::SwitchedAdmittance) = value.number_of_steps
 """Get [`SwitchedAdmittance`](@ref) `Y_increase`."""
@@ -114,6 +121,8 @@ set_available!(value::SwitchedAdmittance, val) = value.available = val
 set_bus!(value::SwitchedAdmittance, val) = value.bus = val
 """Set [`SwitchedAdmittance`](@ref) `Y`."""
 set_Y!(value::SwitchedAdmittance, val) = value.Y = val
+"""Set [`SwitchedAdmittance`](@ref) `initial_status`."""
+set_initial_status!(value::SwitchedAdmittance, val) = value.initial_status = val
 """Set [`SwitchedAdmittance`](@ref) `number_of_steps`."""
 set_number_of_steps!(value::SwitchedAdmittance, val) = value.number_of_steps = val
 """Set [`SwitchedAdmittance`](@ref) `Y_increase`."""

--- a/src/parsers/pm_io/common.jl
+++ b/src/parsers/pm_io/common.jl
@@ -39,9 +39,6 @@ function parse_file(
     if filetype == "m"
         pm_data = parse_matpower(io; validate = validate)
     elseif filetype == "raw"
-        @info(
-            "The PSS(R)E parser currently supports buses, loads, shunts, generators, branches, transformers, and dc lines"
-        )
         pm_data = parse_psse(
             io;
             import_all = import_all,

--- a/src/parsers/pm_io/psse.jl
+++ b/src/parsers/pm_io/psse.jl
@@ -1776,7 +1776,7 @@ Parses directly from iostream
 """
 function parse_psse(io::IO; kwargs...)::Dict
     @info(
-        "The PSS(R)E parser currently supports buses, loads, shunts, generators, branches, switches, breakers, transformers, facts, and dc lines",
+        "The PSS(R)E parser currently supports buses, loads, shunts, generators, branches, switches, breakers, IC tables, transformers, facts, and dc lines",
     )
     pti_data = parse_pti(io)
     pm = _pti_to_powermodels!(pti_data; kwargs...)

--- a/src/parsers/pm_io/psse.jl
+++ b/src/parsers/pm_io/psse.jl
@@ -1824,7 +1824,7 @@ function _psse2pm_impedance_correction!(pm_data::Dict, pti_data::Dict, import_al
                 any(k -> contains(k, "Re(F") || contains(k, "Im(F"), keys(imp_correction))
 
             if is_v35
-                sub_data["scaling_factor_real"] =
+                sub_data["scaling_factor"] =
                     sort_values_by_key_prefix_v35(imp_correction, "Re(F")
                 sub_data["scaling_factor_imag"] =
                     sort_values_by_key_prefix_v35(imp_correction, "Im(F")

--- a/src/parsers/pm_io/psse.jl
+++ b/src/parsers/pm_io/psse.jl
@@ -195,18 +195,34 @@ function _psse2pm_branch!(pm_data::Dict, pti_data::Dict, import_all::Bool)
                     else
                         pop!(branch, "BJ")
                     end
-                sub_data["rate_a"] = pop!(branch, "RATEA")
-                sub_data["rate_b"] = pop!(branch, "RATEB")
-                sub_data["rate_c"] = pop!(branch, "RATEC")
+
+                sub_data["ext"] = Dict{String, Any}(
+                    "LEN" => pop!(branch, "LEN"),
+                )
+
+                if pm_data["source_version"] == "33"
+                    sub_data["rate_a"] = pop!(branch, "RATEA")
+                    sub_data["rate_b"] = pop!(branch, "RATEB")
+                    sub_data["rate_c"] = pop!(branch, "RATEC")
+                else
+                    sub_data["rate_a"] = pop!(branch, "RATE1")
+                    sub_data["rate_b"] = pop!(branch, "RATE2")
+                    sub_data["rate_c"] = pop!(branch, "RATE3")
+
+                    for i in 4:12
+                        rate_key = "RATE$i"
+                        if haskey(branch, rate_key)
+                            sub_data["ext"][rate_key] = pop!(branch, rate_key)
+                        end
+                    end
+                end
+
                 sub_data["tap"] = 1.0
                 sub_data["shift"] = 0.0
                 sub_data["br_status"] = pop!(branch, "ST")
                 sub_data["angmin"] = 0.0
                 sub_data["angmax"] = 0.0
                 sub_data["transformer"] = false
-                sub_data["ext"] = Dict{String, Any}(
-                    "LEN" => pop!(branch, "LEN"),
-                )
 
                 sub_data["source_id"] =
                     ["branch", sub_data["f_bus"], sub_data["t_bus"], pop!(branch, "CKT")]
@@ -305,6 +321,15 @@ function _psse2pm_generator!(pm_data::Dict, pti_data::Dict, import_all::Bool)
             sub_data["xt_source"] = pop!(gen, "XT")
             sub_data["r_source"] = pop!(gen, "ZR")
             sub_data["x_source"] = pop!(gen, "ZX")
+
+            if pm_data["source_version"] != "33"
+                sub_data["ext"] = Dict{String, Any}(
+                    "NREG" => pop!(gen, "NREG"),
+                    "BASLOD" => pop!(gen, "BASLOD"),
+                )
+            else
+                sub_data["ext"] = Dict{String, Any}()
+            end
 
             # Default Cost functions
             sub_data["model"] = 2
@@ -469,6 +494,15 @@ function _psse2pm_load!(pm_data::Dict, pti_data::Dict, import_all::Bool)
             sub_data["qy"] = pop!(load, "YQ")
             sub_data["conformity"] = pop!(load, "SCALE")
             sub_data["source_id"] = ["load", sub_data["load_bus"], pop!(load, "ID")]
+
+            if pm_data["source_version"] == "33"
+                sub_data["load_type"] = ""
+                sub_data["interruptible"] = 0
+            else
+                sub_data["load_type"] = pop!(load, "LOADTYPE")
+                sub_data["interruptible"] = pop!(load, "INTRPT")
+            end
+
             sub_data["status"] = pop!(load, "STATUS")
             sub_data["index"] = length(pm_data["load"]) + 1
             if import_all
@@ -481,6 +515,7 @@ function _psse2pm_load!(pm_data::Dict, pti_data::Dict, import_all::Bool)
                 bus["bus_status"] = false
                 sub_data["status"] = false
             end
+
             push!(pm_data["load"], sub_data)
         end
     end
@@ -546,6 +581,8 @@ function _psse2pm_shunt!(pm_data::Dict, pti_data::Dict, import_all::Bool)
             sub_data["step_number"] = [step_numbers[k] for k in step_numbers_sorted]
             sub_data["step_number"] = sub_data["step_number"][sub_data["step_number"] .!= 0]
 
+            sub_data["ext"] = Dict{String, Any}()
+
             y_increment = Dict(
                 k => v for
                 (k, v) in switched_shunt if startswith(k, "B") && isdigit(last(k))
@@ -554,6 +591,23 @@ function _psse2pm_shunt!(pm_data::Dict, pti_data::Dict, import_all::Bool)
                 sort(collect(keys(y_increment)); by = x -> parse(Int, x[2:end]))
             sub_data["y_increment"] = [y_increment[k] for k in y_increment_sorted]im
             sub_data["y_increment"] = sub_data["y_increment"][sub_data["y_increment"] .!= 0]
+
+            if pm_data["source_version"] != "33"
+                sub_data["sw_id"] = pop!(switched_shunt, "ID")
+
+                initial_ss_status = Dict(
+                    k => v for
+                    (k, v) in switched_shunt if startswith(k, "S") && isdigit(last(k))
+                )
+                initial_ss_status_sorted =
+                    sort(collect(keys(initial_ss_status)); by = x -> parse(Int, x[2:end]))
+                sub_data["initial_status"] =
+                    [initial_ss_status[k] for k in initial_ss_status_sorted]
+                sub_data["initial_status"] =
+                    sub_data["initial_status"][1:length(sub_data["step_number"])]
+
+                sub_data["ext"]["NREG"] = pop!(switched_shunt, "NREG")
+            end
 
             sub_data["source_id"] =
                 ["switched shunt", sub_data["shunt_bus"], pop!(switched_shunt, "SWREM")]
@@ -748,9 +802,29 @@ function _psse2pm_transformer!(pm_data::Dict, pti_data::Dict, import_all::Bool)
                 sub_data["g_to"] = 0.0
                 sub_data["b_to"] = 0.0
 
-                sub_data["rate_a"] = pop!(transformer, "RATA1")
-                sub_data["rate_b"] = pop!(transformer, "RATB1")
-                sub_data["rate_c"] = pop!(transformer, "RATC1")
+                sub_data["ext"] = Dict{String, Any}(
+                    "psse_name" => transformer["NAME"],
+                    "CW" => transformer["CW"],
+                    "CZ" => transformer["CZ"],
+                    "CM" => transformer["CM"],
+                )
+
+                if pm_data["source_version"] == "33"
+                    sub_data["rate_a"] = pop!(transformer, "RATA1")
+                    sub_data["rate_b"] = pop!(transformer, "RATB1")
+                    sub_data["rate_c"] = pop!(transformer, "RATC1")
+                else
+                    sub_data["rate_a"] = pop!(transformer, "RATE11")
+                    sub_data["rate_b"] = pop!(transformer, "RATE12")
+                    sub_data["rate_c"] = pop!(transformer, "RATE13")
+
+                    for i in 4:12
+                        rate_key = "RATE1$i"
+                        if haskey(transformer, rate_key)
+                            sub_data["ext"][rate_key] = pop!(transformer, rate_key)
+                        end
+                    end
+                end
 
                 if sub_data["rate_a"] == 0.0
                     delete!(sub_data, "rate_a")
@@ -818,12 +892,6 @@ function _psse2pm_transformer!(pm_data::Dict, pti_data::Dict, import_all::Bool)
                     pop!(transformer, "CKT"),
                     0,
                 ]
-                sub_data["ext"] = Dict{String, Any}(
-                    "psse_name" => transformer["NAME"],
-                    "CW" => transformer["CW"],
-                    "CZ" => transformer["CZ"],
-                    "CM" => transformer["CM"],
-                )
 
                 sub_data["transformer"] = true
                 sub_data["correction_table"] = transformer["TAB1"]
@@ -1033,17 +1101,55 @@ function _psse2pm_transformer!(pm_data::Dict, pti_data::Dict, import_all::Bool)
                 sub_data["r_tertiary"] = Zr_t
                 sub_data["x_tertiary"] = Zx_t
 
-                sub_data["rating_primary"] =
-                    min(transformer["RATA1"], transformer["RATB1"], transformer["RATC1"])
-                sub_data["rating_secondary"] =
-                    min(transformer["RATA2"], transformer["RATB2"], transformer["RATC2"])
-                sub_data["rating_tertiary"] =
-                    min(transformer["RATA3"], transformer["RATB3"], transformer["RATC3"])
-                sub_data["rating"] = min(
-                    sub_data["rating_primary"],
-                    sub_data["rating_secondary"],
-                    sub_data["rating_tertiary"],
-                )
+                if pm_data["source_version"] == "33"
+                    sub_data["rating_primary"] =
+                        min(
+                            transformer["RATA1"],
+                            transformer["RATB1"],
+                            transformer["RATC1"],
+                        )
+                    sub_data["rating_secondary"] =
+                        min(
+                            transformer["RATA2"],
+                            transformer["RATB2"],
+                            transformer["RATC2"],
+                        )
+                    sub_data["rating_tertiary"] =
+                        min(
+                            transformer["RATA3"],
+                            transformer["RATB3"],
+                            transformer["RATC3"],
+                        )
+                    sub_data["rating"] = min(
+                        sub_data["rating_primary"],
+                        sub_data["rating_secondary"],
+                        sub_data["rating_tertiary"],
+                    )
+                else
+                    sub_data["rating_primary"] =
+                        min(
+                            transformer["RATE11"],
+                            transformer["RATE12"],
+                            transformer["RATE13"],
+                        )
+                    sub_data["rating_secondary"] =
+                        min(
+                            transformer["RATE21"],
+                            transformer["RATE22"],
+                            transformer["RATE23"],
+                        )
+                    sub_data["rating_tertiary"] =
+                        min(
+                            transformer["RATE31"],
+                            transformer["RATE32"],
+                            transformer["RATE33"],
+                        )
+                    sub_data["rating"] = min(
+                        sub_data["rating_primary"],
+                        sub_data["rating_secondary"],
+                        sub_data["rating_tertiary"],
+                    )
+                end
 
                 sub_data["r_12"] = br_r12
                 sub_data["x_12"] = br_x12
@@ -1275,6 +1381,15 @@ function _psse2pm_dcline!(pm_data::Dict, pti_data::Dict, import_all::Bool)
             sub_data["inverter_capacitor_reactance"] = dcline["XCAPI"] / ZbaseI
             sub_data["r"] = dcline["RDC"] / ZbaseR
 
+            if pm_data["source_version"] == "33"
+                sub_data["ext"] = Dict{String, Any}()
+            else
+                sub_data["ext"] = Dict{String, Any}(
+                    "NDR" => dcline["NDI"],
+                    "NDI" => dcline["NDI"],
+                )
+            end
+
             sub_data["source_id"] = [
                 "two-terminal dc",
                 sub_data["f_bus"],
@@ -1451,6 +1566,13 @@ function _psse2pm_facts!(pm_data::Dict, pti_data::Dict, import_all::Bool)
 
             sub_data["reactive_power_required"] = facts["RMPCT"]
 
+            sub_data["ext"] = Dict{String, Any}()
+
+            if pm_data["source_version"] != "33"
+                sub_data["ext"]["NREG"] = facts["NREG"]
+                sub_data["ext"]["MNAME"] = facts["MNAME"]
+            end
+
             sub_data["source_id"] =
                 ["facts", sub_data["bus"], sub_data["name"]]
             sub_data["index"] = length(pm_data["facts"]) + 1
@@ -1474,30 +1596,47 @@ end
 
 function _build_switch_breaker_sub_data(
     pm_data::Dict,
-    branch::Dict,
-    branch_type::String,
-    discrete_branch_type::Int,
+    dict_object::Dict,
+    device_type::String,
+    discrete_device_type::Int,
     index::Int,
 )
     sub_data = Dict{String, Any}()
 
-    sub_data["f_bus"] = pop!(branch, "I")
-    sub_data["t_bus"] = pop!(branch, "J")
+    sub_data["f_bus"] = pop!(dict_object, "I")
+    sub_data["t_bus"] = pop!(dict_object, "J")
     if pm_data["has_isolated_buses"]
         push!(pm_data["connected_buses"], sub_data["f_bus"])
         push!(pm_data["connected_buses"], sub_data["t_bus"])
     end
-    sub_data["r"] = pop!(branch, "R")
-    sub_data["x"] = pop!(branch, "X")
-    sub_data["state"] = pop!(branch, "ST")
+
+    sub_data["x"] = pop!(dict_object, "X")
     sub_data["active_power_flow"] = 0.0
     sub_data["reactive_power_flow"] = 0.0
     sub_data["psw"] = sub_data["active_power_flow"]
     sub_data["qsw"] = sub_data["reactive_power_flow"]
-    sub_data["rating"] = pop!(branch, "RATEA")
-    sub_data["discrete_branch_type"] = discrete_branch_type
+    sub_data["discrete_branch_type"] = discrete_device_type
+    ext = Dict{String, Any}()
+
+    if pm_data["source_version"] == "33"
+        sub_data["r"] = pop!(dict_object, "R")
+        sub_data["state"] = pop!(dict_object, "ST")
+        sub_data["rating"] = pop!(dict_object, "RATEA")
+    else
+        sub_data["r"] = 0.0
+        sub_data["state"] = pop!(dict_object, "STAT")
+        sub_data["rating"] = pop!(dict_object, "RATE1")
+
+        for i in 2:12
+            rate_key = "RATE$i"
+            if haskey(dict_object, rate_key)
+                ext[rate_key] = pop!(dict_object, rate_key)
+            end
+        end
+    end
+
     sub_data["source_id"] =
-        [branch_type, sub_data["f_bus"], sub_data["t_bus"], branch["CKT"]]
+        [device_type, sub_data["f_bus"], sub_data["t_bus"], dict_object["CKT"]]
     sub_data["index"] = index
 
     return sub_data
@@ -1508,28 +1647,54 @@ function _psse2pm_switch_breaker!(pm_data::Dict, pti_data::Dict, import_all::Boo
     pm_data["breaker"] = []
     pm_data["switch"] = []
     mapping = Dict('@' => ("breaker", 1), '*' => ("switch", 0))
+    mapping_v35 = Dict(2 => "breaker", 3 => "switch")
 
-    if haskey(pti_data, "BRANCH")
-        for branch in pti_data["BRANCH"]
-            branch_init = first(branch["CKT"])
+    if pm_data["source_version"] == "33"
+        if haskey(pti_data, "BRANCH")
+            for branch in pti_data["BRANCH"]
+                branch_init = first(branch["CKT"])
 
-            # Check if character is in the mapping
-            if haskey(mapping, branch_init)
-                branch_type, discrete_branch_type = mapping[branch_init]
+                # Check if character is in the mapping
+                if haskey(mapping, branch_init)
+                    branch_type, discrete_branch_type = mapping[branch_init]
+
+                    sub_data = _build_switch_breaker_sub_data(
+                        pm_data,
+                        branch,
+                        branch_type,
+                        discrete_branch_type,
+                        length(pm_data[branch_type]) + 1,
+                    )
+
+                    if import_all
+                        _import_remaining_keys!(sub_data, branch)
+                    end
+                    branch_isolated_bus_modifications!(pm_data, sub_data)
+                    push!(pm_data[branch_type], sub_data)
+                end
+            end
+        end
+    else
+        if haskey(pti_data, "SWITCHING DEVICE")
+            for switching_device in pti_data["SWITCHING DEVICE"]
+                device_type = get(mapping_v35, switching_device["STYPE"], "other")
+                discrete_branch_type =
+                    device_type == "breaker" ? 1 : (device_type == "switch" ? 0 : 2)
 
                 sub_data = _build_switch_breaker_sub_data(
                     pm_data,
-                    branch,
-                    branch_type,
+                    switching_device,
+                    device_type,
                     discrete_branch_type,
-                    length(pm_data[branch_type]) + 1,
+                    length(pm_data[device_type]) + 1,
                 )
 
                 if import_all
                     _import_remaining_keys!(sub_data, branch)
                 end
+
                 branch_isolated_bus_modifications!(pm_data, sub_data)
-                push!(pm_data[branch_type], sub_data)
+                push!(pm_data[device_type], sub_data)
             end
         end
     end
@@ -1624,6 +1789,26 @@ function sort_values_by_key_prefix(imp_correction::Dict{String, <:Any}, prefix::
     return sorted_values
 end
 
+function sort_values_by_key_prefix_v35(imp_correction::Dict{String, <:Any}, prefix::String)
+    # For v35, we need to handle "Re(F1)", "Im(F1)" format
+    sorted_values = [
+        last(pair) for pair in sort(
+            [
+                (parse(Int, match(r"\d+", k).match), v) for
+                (k, v) in imp_correction if startswith(k, prefix) && contains(k, r"\d+")
+            ];
+            by = first,
+        )
+    ]
+
+    first_non_zero_index = findfirst(x -> x != 0.0, reverse(sorted_values))
+    if first_non_zero_index !== nothing
+        sorted_values = sorted_values[1:(length(sorted_values) - first_non_zero_index + 1)]
+    end
+
+    return sorted_values
+end
+
 function _psse2pm_impedance_correction!(pm_data::Dict, pti_data::Dict, import_all::Bool)
     @info "Parsing PSS(R)E Transformer Impedance Correction Tables data into a PowerModels Dict..."
 
@@ -1635,8 +1820,19 @@ function _psse2pm_impedance_correction!(pm_data::Dict, pti_data::Dict, import_al
 
             sub_data["table_number"] = imp_correction["I"]
 
-            sub_data["scaling_factor"] = sort_values_by_key_prefix(imp_correction, "F")
-            sub_data["tap_or_angle"] = sort_values_by_key_prefix(imp_correction, "T")
+            is_v35 =
+                any(k -> contains(k, "Re(F") || contains(k, "Im(F"), keys(imp_correction))
+
+            if is_v35
+                sub_data["scaling_factor_real"] =
+                    sort_values_by_key_prefix_v35(imp_correction, "Re(F")
+                sub_data["scaling_factor_imag"] =
+                    sort_values_by_key_prefix_v35(imp_correction, "Im(F")
+                sub_data["tap_or_angle"] = sort_values_by_key_prefix(imp_correction, "T")
+            else
+                sub_data["scaling_factor"] = sort_values_by_key_prefix(imp_correction, "F")
+                sub_data["tap_or_angle"] = sort_values_by_key_prefix(imp_correction, "T")
+            end
 
             sub_data["index"] = length(pm_data["impedance_correction"]) + 1
 
@@ -1648,6 +1844,30 @@ function _psse2pm_impedance_correction!(pm_data::Dict, pti_data::Dict, import_al
         end
     end
     return
+end
+
+function _psse2pm_substation_data!(pm_data::Dict, pti_data::Dict, import_all::Bool)
+    @warn "Parsing PSS(R)E Substation data into a PowerModels Dict..."
+    pm_data["substation_data"] = []
+
+    if haskey(pti_data, "SUBSTATION DATA")
+        for substation_data in pti_data["SUBSTATION DATA"]
+            sub_data = Dict{String, Any}()
+
+            sub_data["name"] = substation_data["NAME"]
+            sub_data["substation_is"] = substation_data["IS"]
+
+            sub_data["latitude"] = substation_data["LATITUDE"]
+            sub_data["longitude"] = substation_data["LONGITUDE"]
+
+            if import_all
+                _import_remaining_keys!(sub_data, substation_data)
+            end
+
+            sub_data["index"] = length(pm_data["substation_data"]) + 1
+            push!(pm_data["substation_data"], sub_data)
+        end
+    end
 end
 
 function _psse2pm_storage!(pm_data::Dict, pti_data::Dict, import_all::Bool)
@@ -1697,6 +1917,7 @@ function _pti_to_powermodels!(
     _psse2pm_transformer!(pm_data, pti_data, import_all)
     _psse2pm_dcline!(pm_data, pti_data, import_all)
     _psse2pm_impedance_correction!(pm_data, pti_data, import_all)
+    _psse2pm_substation_data!(pm_data, pti_data, import_all)
     _psse2pm_storage!(pm_data, pti_data, import_all)
 
     if pm_data["has_isolated_buses"]

--- a/src/parsers/pm_io/psse.jl
+++ b/src/parsers/pm_io/psse.jl
@@ -1616,7 +1616,7 @@ function _build_switch_breaker_sub_data(
     sub_data["psw"] = sub_data["active_power_flow"]
     sub_data["qsw"] = sub_data["reactive_power_flow"]
     sub_data["discrete_branch_type"] = discrete_device_type
-    ext = Dict{String, Any}()
+    sub_data["ext"] = Dict{String, Any}()
 
     if pm_data["source_version"] == "33"
         sub_data["r"] = pop!(dict_object, "R")
@@ -1630,7 +1630,7 @@ function _build_switch_breaker_sub_data(
         for i in 2:12
             rate_key = "RATE$i"
             if haskey(dict_object, rate_key)
-                ext[rate_key] = pop!(dict_object, rate_key)
+                sub_data["ext"][rate_key] = pop!(dict_object, rate_key)
             end
         end
     end

--- a/src/parsers/pm_io/pti.jl
+++ b/src/parsers/pm_io/pti.jl
@@ -5,7 +5,7 @@
 #####################################################################
 
 """
-A list of data file sections in the order that they appear in a PTI v33 file
+A list of data file sections in the order that they appear in a PTI v33/v35 file
 """
 const _pti_sections = [
     "CASE IDENTIFICATION",
@@ -30,6 +30,13 @@ const _pti_sections = [
     "INDUCTION MACHINE",
 ]
 
+const _pti_sections_v35 = vcat(
+    _pti_sections[1:6],
+    ["SWITCHING DEVICE"],
+    _pti_sections[7:end],
+    "SUBSTATION DATA",
+)
+
 const _transaction_dtypes = [
     ("IC", Int64),
     ("SBASE", Float64),
@@ -38,6 +45,60 @@ const _transaction_dtypes = [
     ("NXFRAT", Float64),
     ("BASFRQ", Float64),
 ]
+
+const _transaction_dtypes_v35 = _transaction_dtypes
+
+const _system_wide_dtypes_v35 = [
+    ("THRSHZ", Float64),
+    ("PQBRAK", Float64),
+    ("BLOWUP", Float64),
+    ("MAXISOLLVLS", Int64),
+    ("CAMAXREPTSLN", Int64),
+    ("CHKDUPCNTLBL", Int64),
+    ("ITMX", Int64),
+    ("ACCP", Float64),
+    ("ACCQ", Float64),
+    ("ACCM", Float64),
+    ("TOL", Float64),
+    ("ITMXN", Int64),
+    ("ACCN", Float64),
+    ("TOLN", Float64),
+    ("VCTOLQ", Float64),
+    ("VCTOLV", Float64),
+    ("DVLIM", Float64),
+    ("NDVFCT", Float64),
+    ("ADJTHR", Float64),
+    ("ACCTAP", Float64),
+    ("TAPLIM", Float64),
+    ("SWVBND", Float64),
+    ("MXTPSS", Int64),
+    ("MXSWIM", Int64),
+    ("ITMXTY", Int64),
+    ("ACCTY", Float64),
+    ("TOLTY", Float64),
+    ("METHOD", String),
+    ("ACTAPS", Int64),
+    ("AREAIN", Int64),
+    ("PHSHFT", Int64),
+    ("DCTAPS", Int64),
+    ("SWSHNT", Int64),
+    ("FLATST", Int64),
+    ("VARLIM", Int64),
+    ("NONDIV", Int64),
+    ("IRATE", Int64),
+    ("NAME", String),
+    ("DESC", String),
+]
+
+const _system_wide_data_sections_v35 = Dict{String, Vector{String}}(
+    "GENERAL" => ["THRSHZ", "PQBRAK", "BLOWUP", "MAXISOLLVLS", "CAMAXREPTSLN", "CHKDUPCNTLBL"],
+    "GAUSS" => ["ITMX", "ACCP", "ACCQ", "ACCM", "TOL"],
+    "NEWTON" => ["ITMXN", "ACCN", "TOLN", "VCTOLQ", "VCTOLV", "DVLIM", "NDVFCT"],
+    "ADJUST" => ["ADJTHR", "ACCTAP", "TAPLIM", "SWVBND", "MXTPSS", "MXSWIM"],
+    "TYSL" => ["ITMXTY", "ACCTY", "TOLTY"],
+    "SOLVER" => ["METHOD", "ACTAPS", "AREAIN", "PHSHFT", "DCTAPS", "SWSHNT", "FLATST", "VARLIM", "NONDIV"],
+    "RATING" => ["IRATE", "NAME", "DESC"],
+)
 
 const _bus_dtypes = [
     ("I", Int64),
@@ -54,6 +115,8 @@ const _bus_dtypes = [
     ("EVHI", Float64),
     ("EVLO", Float64),
 ]
+
+const _bus_dtypes_v35 = _bus_dtypes
 
 const _load_dtypes = [
     ("I", Int64),
@@ -72,8 +135,25 @@ const _load_dtypes = [
     ("INTRPT", Int64),
 ]
 
-const _fixed_shunt_dtypes =
-    [("I", Int64), ("ID", String), ("STATUS", Int64), ("GL", Float64), ("BL", Float64)]
+const _load_dtypes_v35 = vcat(
+    _load_dtypes[1:14],
+    [
+        ("DGENP", Float64),
+        ("DGENQ", Float64),
+        ("DGENM", Float64),
+        ("LOADTYPE", String),
+    ],
+)
+
+const _fixed_shunt_dtypes = [
+    ("I", Int64),
+    ("ID", String),
+    ("STATUS", Int64),
+    ("GL", Float64),
+    ("BL", Float64),
+]
+
+const _fixed_shunt_dtypes_v35 = _fixed_shunt_dtypes
 
 const _generator_dtypes = [
     ("I", Int64),
@@ -106,6 +186,14 @@ const _generator_dtypes = [
     ("WPF", Float64),
 ]
 
+const _generator_dtypes_v35 = vcat(
+    _generator_dtypes[1:8],
+    [("NREG", Int64)],
+    _generator_dtypes[9:18],
+    [("BASLOD", Int64)],
+    _generator_dtypes[19:end],
+)
+
 const _branch_dtypes = [
     ("I", Int64),
     ("J", Int64),
@@ -133,6 +221,50 @@ const _branch_dtypes = [
     ("F4", Float64),
 ]
 
+const _branch_dtypes_v35 = vcat(
+    _branch_dtypes[1:6],
+    [
+        ("NAME", String),
+        ("RATE1", Float64),
+        ("RATE2", Float64),
+        ("RATE3", Float64),
+        ("RATE4", Float64),
+        ("RATE5", Float64),
+        ("RATE6", Float64),
+        ("RATE7", Float64),
+        ("RATE8", Float64),
+        ("RATE9", Float64),
+        ("RATE10", Float64),
+        ("RATE11", Float64),
+        ("RATE12", Float64),
+    ],
+    _branch_dtypes[10:end],
+)
+
+const _switching_dtypes_v35 = [
+    ("I", Int64),
+    ("J", Int64),
+    ("CKT", String),
+    ("X", Float64),
+    ("RATE1", Float64),
+    ("RATE2", Float64),
+    ("RATE3", Float64),
+    ("RATE4", Float64),
+    ("RATE5", Float64),
+    ("RATE6", Float64),
+    ("RATE7", Float64),
+    ("RATE8", Float64),
+    ("RATE9", Float64),
+    ("RATE10", Float64),
+    ("RATE11", Float64),
+    ("RATE12", Float64),
+    ("STAT", Int64),
+    ("NSTAT", Int64),
+    ("MET", Int64),
+    ("STYPE", Int64),
+    ("NAME", String),
+]
+
 const _transformer_dtypes = [
     ("I", Int64),
     ("J", Int64),
@@ -157,6 +289,8 @@ const _transformer_dtypes = [
     ("VECGRP", String),
 ]
 
+const _transformer_dtypes_v35 = _transformer_dtypes
+
 const _transformer_3_1_dtypes = [
     ("R1-2", Float64),
     ("X1-2", Float64),
@@ -170,6 +304,8 @@ const _transformer_3_1_dtypes = [
     ("VMSTAR", Float64),
     ("ANSTAR", Float64),
 ]
+
+const _transformer_3_1_dtypes_v35 = _transformer_3_1_dtypes
 
 const _transformer_3_2_dtypes = [
     ("WINDV1", Float64),
@@ -191,6 +327,25 @@ const _transformer_3_2_dtypes = [
     ("CNXA1", Float64),
 ]
 
+const _transformer_3_2_dtypes_v35 = vcat(
+    _transformer_3_2_dtypes[1:3],
+    [
+        ("RATE11", Float64),
+        ("RATE21", Float64),
+        ("RATE31", Float64),
+        ("RATE41", Float64),
+        ("RATE51", Float64),
+        ("RATE61", Float64),
+        ("RATE71", Float64),
+        ("RATE81", Float64),
+        ("RATE91", Float64),
+        ("RATE101", Float64),
+        ("RATE111", Float64),
+        ("RATE121", Float64),
+    ],
+    _transformer_3_2_dtypes[7:end],
+)
+
 const _transformer_3_3_dtypes = [
     ("WINDV2", Float64),
     ("NOMV2", Float64),
@@ -210,6 +365,25 @@ const _transformer_3_3_dtypes = [
     ("CX2", Float64),
     ("CNXA2", Float64),
 ]
+
+const _transformer_3_3_dtypes_v35 = vcat(
+    _transformer_3_3_dtypes[1:3],
+    [
+        ("RATE12", Float64),
+        ("RATE22", Float64),
+        ("RATE32", Float64),
+        ("RATE42", Float64),
+        ("RATE52", Float64),
+        ("RATE62", Float64),
+        ("RATE72", Float64),
+        ("RATE82", Float64),
+        ("RATE92", Float64),
+        ("RATE102", Float64),
+        ("RATE112", Float64),
+        ("RATE122", Float64),
+    ],
+    _transformer_3_2_dtypes[7:end],
+)
 
 const _transformer_3_4_dtypes = [
     ("WINDV3", Float64),
@@ -231,8 +405,29 @@ const _transformer_3_4_dtypes = [
     ("CNXA3", Float64),
 ]
 
+const _transformer_3_4_dtypes_v35 = vcat(
+    _transformer_3_4_dtypes[1:3],
+    [
+        ("RATE13", Float64),
+        ("RATE23", Float64),
+        ("RATE33", Float64),
+        ("RATE43", Float64),
+        ("RATE53", Float64),
+        ("RATE63", Float64),
+        ("RATE73", Float64),
+        ("RATE83", Float64),
+        ("RATE93", Float64),
+        ("RATE103", Float64),
+        ("RATE113", Float64),
+        ("RATE123", Float64),
+    ],
+    _transformer_3_2_dtypes[7:end],
+)
+
 const _transformer_2_1_dtypes =
     [("R1-2", Float64), ("X1-2", Float64), ("SBASE1-2", Float64)]
+
+const _transformer_2_1_dtypes_v35 = _transformer_2_1_dtypes
 
 const _transformer_2_2_dtypes = [
     ("WINDV1", Float64),
@@ -254,10 +449,33 @@ const _transformer_2_2_dtypes = [
     ("CNXA1", Float64),
 ]
 
+const _transformer_2_2_dtypes_v35 = vcat(
+    _transformer_2_2_dtypes[1:3],
+    [
+        ("RATE13", Float64),
+        ("RATE23", Float64),
+        ("RATE33", Float64),
+        ("RATE43", Float64),
+        ("RATE53", Float64),
+        ("RATE63", Float64),
+        ("RATE73", Float64),
+        ("RATE83", Float64),
+        ("RATE93", Float64),
+        ("RATE103", Float64),
+        ("RATE113", Float64),
+        ("RATE123", Float64),
+    ],
+    _transformer_3_2_dtypes[7:end],
+)
+
 const _transformer_2_3_dtypes = [("WINDV2", Float64), ("NOMV2", Float64)]
+
+const _transformer_2_3_dtypes_v35 = _transformer_2_3_dtypes
 
 const _area_interchange_dtypes =
     [("I", Int64), ("ISW", Int64), ("PDES", Float64), ("PTOL", Float64), ("ARNAME", String)]
+
+const _area_interchange_dtypes_v35 = _area_interchange_dtypes
 
 const _two_terminal_line_dtypes = [
     ("NAME", String),
@@ -308,6 +526,14 @@ const _two_terminal_line_dtypes = [
     ("XCAPI", Float64),
 ]
 
+const _two_terminal_line_dtypes_v35 = vcat(
+    _two_terminal_line_dtypes[1:25],
+    [("NDR", Int64)],
+    _two_terminal_line_dtypes[26:42],
+    [("NDI", Int64)],
+    _two_terminal_line_dtypes[43:end],
+)
+
 const _vsc_line_dtypes = [
     ("NAME", String),
     ("MDC", Int64),
@@ -321,6 +547,8 @@ const _vsc_line_dtypes = [
     ("O4", Int64),
     ("F4", Float64),
 ]
+
+const _vsc_line_dtypes_35 = _vsc_line_dtypes
 
 const _vsc_subline_dtypes = [
     ("IBUS", Int64),
@@ -339,6 +567,8 @@ const _vsc_subline_dtypes = [
     ("REMOT", Int64),
     ("RMPCT", Float64),
 ]
+
+const _vsc_subline_dtypes_v35 = _vsc_subline_dtypes
 
 const _impedance_correction_dtypes = [
     ("I", Int64),
@@ -366,6 +596,22 @@ const _impedance_correction_dtypes = [
     ("F11", Float64),
 ]
 
+const _impedance_correction_dtypes_v35 = [
+    ("I", Int64),
+    ("T1", Float64), ("Re(F1)", Float64), ("Im(F1)", Float64),
+    ("T2", Float64), ("Re(F2)", Float64), ("Im(F2)", Float64),
+    ("T3", Float64), ("Re(F3)", Float64), ("Im(F3)", Float64),
+    ("T4", Float64), ("Re(F4)", Float64), ("Im(F4)", Float64),
+    ("T5", Float64), ("Re(F5)", Float64), ("Im(F5)", Float64),
+    ("T6", Float64), ("Re(F6)", Float64), ("Im(F6)", Float64),
+    ("T7", Float64), ("Re(F7)", Float64), ("Im(F7)", Float64),
+    ("T8", Float64), ("Re(F8)", Float64), ("Im(F8)", Float64),
+    ("T9", Float64), ("Re(F9)", Float64), ("Im(F9)", Float64),
+    ("T10", Float64), ("Re(F10)", Float64), ("Im(F10)", Float64),
+    ("T11", Float64), ("Re(F11)", Float64), ("Im(F11)", Float64),
+    ("T12", Float64), ("Re(F12)", Float64), ("Im(F12)", Float64),
+]
+
 const _multi_term_main_dtypes = [
     ("NAME", String),
     ("NCONV", Int64),
@@ -376,6 +622,8 @@ const _multi_term_main_dtypes = [
     ("VCMOD", Float64),
     ("VCONVN", Float64),
 ]
+
+const _multi_term_main_dtypes_v35 = _multi_term_main_dtypes
 
 const _multi_term_nconv_dtypes = [
     ("IB", Int64),
@@ -396,6 +644,8 @@ const _multi_term_nconv_dtypes = [
     ("CNVCOD", Int64),
 ]
 
+const _multi_term_nconv_dtypes_v35 = _multi_term_nconv_dtypes
+
 const _multi_term_ndcbs_dtypes = [
     ("IDC", Int64),
     ("IB", Int64),
@@ -407,6 +657,8 @@ const _multi_term_ndcbs_dtypes = [
     ("OWNER", Int64),
 ]
 
+const _multi_term_ndcbs_dtypes_v35 = _multi_term_ndcbs_dtypes
+
 const _multi_term_ndcln_dtypes = [
     ("IDC", Int64),
     ("JDC", Int64),
@@ -415,6 +667,8 @@ const _multi_term_ndcln_dtypes = [
     ("RDC", Float64),
     ("LDC", Float64),
 ]
+
+const _multi_term_ndcln_dtypes_v35 = _multi_term_ndcln_dtypes
 
 const _multi_section_dtypes = [
     ("I", Int64),
@@ -432,12 +686,20 @@ const _multi_section_dtypes = [
     ("DUM9", Int64),
 ]
 
+const _multi_section_dtypes_v35 = _multi_section_dtypes
+
 const _zone_dtypes = [("I", Int64), ("ZONAME", String)]
+
+const _zone_dtypes_v35 = _zone_dtypes
 
 const _interarea_dtypes =
     [("ARFROM", Int64), ("ARTO", Int64), ("TRID", String), ("PTRAN", Float64)]
 
+const _interarea_dtypes_v35 = _interarea_dtypes
+
 const _owner_dtypes = [("I", Int64), ("OWNAME", String)]
+
+const _owner_dtypes_v35 = _owner_dtypes
 
 const _FACTS_dtypes = [
     ("NAME", String),
@@ -462,6 +724,15 @@ const _FACTS_dtypes = [
     ("REMOT", Int64),
     ("MNAME", String),
 ]
+
+const _FACTS_dtypes_v35 = vcat(
+    _FACTS_dtypes[1:19],
+    [
+        ("FCREG", Int64),
+        ("NREG", Int64),
+        ("MNAME", String),
+    ],
+)
 
 const _switched_shunt_dtypes = [
     ("I", Int64),
@@ -492,6 +763,26 @@ const _switched_shunt_dtypes = [
     ("B8", Float64),
 ]
 
+const _switched_shunt_dtypes_v35 = vcat(
+    _switched_shunt_dtypes[1],
+    [("ID", String)],
+    _switched_shunt_dtypes[2:7],
+    [
+        ("NREG", Int64),
+        ("RMPCT", Float64),
+        ("RMIDNT", String),
+        ("BINIT", Float64),
+        ("S1", Int64), ("N1", Int64), ("B1", Float64), 
+        ("S2", Int64), ("N2", Int64), ("B2", Float64), 
+        ("S3", Int64), ("N3", Int64), ("B3", Float64), 
+        ("S4", Int64), ("N4", Int64), ("B4", Float64), 
+        ("S5", Int64), ("N5", Int64), ("B5", Float64), 
+        ("S6", Int64), ("N6", Int64), ("B6", Float64), 
+        ("S7", Int64), ("N7", Int64), ("B7", Float64), 
+        ("S8", Int64), ("N8", Int64), ("B8", Float64), 
+    ],
+)
+
 # TODO: Account for multiple lines in GNE Device entries
 const _gne_device_dtypes = [
     ("NAME", String),
@@ -508,6 +799,8 @@ const _gne_device_dtypes = [
     ("INTGi", Int64),
     ("CHARi", String),
 ]
+
+const _gne_device_dtypes_v35 = _gne_device_dtypes
 
 const _induction_machine_dtypes = [
     ("I", Int64),
@@ -546,11 +839,21 @@ const _induction_machine_dtypes = [
     ("XAMULT", Float64),
 ]
 
+const _induction_machine_dtypes_v35 = _induction_machine_dtypes
+
+const _substation_dtypes_v35 = [
+    ("IS", Int64),
+    ("NAME", String),
+    ("LATITUDE", Float64),
+    ("LONGITUDE", Float64),
+    ("SGR", Float64),
+]
+
 """
 lookup array of data types for PTI file sections given by
 `field_name`, as enumerated by PSS/E Program Operation Manual.
 """
-const _pti_dtypes = Dict{String, Array}(
+const _pti_dtypes = Dict{String,Array}(
     "BUS" => _bus_dtypes,
     "LOAD" => _load_dtypes,
     "FIXED SHUNT" => _fixed_shunt_dtypes,
@@ -584,10 +887,55 @@ const _pti_dtypes = Dict{String, Array}(
     "INDUCTION MACHINE" => _induction_machine_dtypes,
 )
 
+const _pti_dtypes_v35 = Dict{String,Array}(
+    "BUS" => _bus_dtypes_v35,
+    "LOAD" => _load_dtypes_v35,
+    "FIXED SHUNT" => _fixed_shunt_dtypes_v35,
+    "GENERATOR" => _generator_dtypes_v35,
+    "BRANCH" => _branch_dtypes_v35,
+    "SWITCHING DEVICE" => _switching_dtypes_v35,
+    "TRANSFORMER" => _transformer_dtypes_v35,
+    "TRANSFORMER TWO-WINDING LINE 1" => _transformer_2_1_dtypes_v35,
+    "TRANSFORMER TWO-WINDING LINE 2" => _transformer_2_2_dtypes_v35,
+    "TRANSFORMER TWO-WINDING LINE 3" => _transformer_2_3_dtypes_v35,
+    "TRANSFORMER THREE-WINDING LINE 1" => _transformer_3_1_dtypes_v35,
+    "TRANSFORMER THREE-WINDING LINE 2" => _transformer_3_2_dtypes_v35,
+    "TRANSFORMER THREE-WINDING LINE 3" => _transformer_3_3_dtypes_v35,
+    "TRANSFORMER THREE-WINDING LINE 4" => _transformer_3_4_dtypes_v35,
+    "AREA INTERCHANGE" => _area_interchange_dtypes_v35,
+    "TWO-TERMINAL DC" => _two_terminal_line_dtypes_v35,
+    "VOLTAGE SOURCE CONVERTER" => _vsc_line_dtypes_35,
+    "VOLTAGE SOURCE CONVERTER SUBLINES" => _vsc_subline_dtypes_v35,
+    "IMPEDANCE CORRECTION" => _impedance_correction_dtypes_v35,
+    "MULTI-TERMINAL DC" => _multi_term_main_dtypes_v35,
+    "MULTI-TERMINAL DC NCONV" => _multi_term_nconv_dtypes_v35,
+    "MULTI-TERMINAL DC NDCBS" => _multi_term_ndcbs_dtypes_v35,
+    "MULTI-TERMINAL DC NDCLN" => _multi_term_ndcln_dtypes_v35,
+    "MULTI-SECTION LINE" => _multi_section_dtypes_v35,
+    "ZONE" => _zone_dtypes_v35,
+    "INTER-AREA TRANSFER" => _interarea_dtypes_v35,
+    "OWNER" => _owner_dtypes_v35,
+    "FACTS CONTROL DEVICE" => _FACTS_dtypes_v35,
+    "SWITCHED SHUNT" => _switched_shunt_dtypes_v35,
+    "CASE IDENTIFICATION" => _transaction_dtypes_v35,
+    "GNE DEVICE" => _gne_device_dtypes_v35,
+    "INDUCTION MACHINE" => _induction_machine_dtypes_v35,
+    "SUBSTATION DATA" => _substation_dtypes_v35,
+)
+
 const _default_case_identification = Dict(
     "IC" => 0,
     "SBASE" => 100.0,
     "REV" => 33,
+    "XFRRAT" => 0,
+    "NXFRAT" => 0,
+    "BASFRQ" => 60,
+)
+
+const _default_case_identification_v35 = Dict(
+    "IC" => 0,
+    "SBASE" => 100.0,
+    "REV" => 35,
     "XFRRAT" => 0,
     "NXFRAT" => 0,
     "BASFRQ" => 60,
@@ -608,6 +956,8 @@ const _default_bus = Dict(
     "NAME" => "            ",
 )
 
+const _default_bus_v35 = _default_bus
+
 const _default_load = Dict(
     "ID" => "1",
     "STATUS" => 1,
@@ -624,7 +974,19 @@ const _default_load = Dict(
     "OWNER" => nothing,
 )
 
+const _default_load_v35 = merge(
+    _default_load,
+    Dict(
+        "DGENP" => 0.0,
+        "DGENQ" => 0.0,
+        "DGENM" => 0.0,
+        "LOADTYPE" => nothing,
+    ),
+)
+
 const _default_fixed_shunt = Dict("ID" => "1", "STATUS" => 1, "GL" => 0.0, "BL" => 0.0)
+
+const _default_fixed_shunt_v35 = _default_fixed_shunt
 
 const _default_generator = Dict(
     "ID" => "1",
@@ -656,6 +1018,11 @@ const _default_generator = Dict(
     "WPF" => 1.0,
 )
 
+const _default_generator_v35 = merge(_default_generator, Dict(
+    "NREG" => 0,
+    "BASLOD" => 0,
+))
+
 const _default_branch = Dict(
     "CKT" => "1",
     "B" => 0.0,
@@ -677,6 +1044,45 @@ const _default_branch = Dict(
     "F2" => 1.0,
     "F3" => 1.0,
     "F4" => 1.0,
+)
+
+const _default_branch_v35 = merge(
+    _default_branch,
+    Dict(
+        "RATE1" => 0.0,
+        "RATE2" => 0.0,
+        "RATE3" => 0.0,
+        "RATE4" => 0.0,
+        "RATE5" => 0.0,
+        "RATE6" => 0.0,
+        "RATE7" => 0.0,
+        "RATE8" => 0.0,
+        "RATE9" => 0.0,
+        "RATE10" => 0.0,
+        "RATE11" => 0.0,
+        "RATE12" => 0.0,
+    ),
+)
+
+const _default_switching_device_v35 = Dict(
+    "CKT" => "1",
+    "RATE1" => 0.0,
+    "RATE2" => 0.0,
+    "RATE3" => 0.0,
+    "RATE4" => 0.0,
+    "RATE5" => 0.0,
+    "RATE6" => 0.0,
+    "RATE7" => 0.0,
+    "RATE8" => 0.0,
+    "RATE9" => 0.0,
+    "RATE10" => 0.0,
+    "RATE11" => 0.0,
+    "RATE12" => 0.0,
+    "STAT" => 1,
+    "NSTAT" => 1,
+    "MET" => 0.0,
+    "STYPE" => 0.0,
+    "NAME" => "",
 )
 
 const _default_transformer = Dict(
@@ -760,8 +1166,17 @@ const _default_transformer = Dict(
     "CNXA3" => 0.0,
 )
 
+const _default_transformer_v35 = merge(
+    _default_transformer,
+    Dict(
+        "VECGRP" => "                                        ",
+    ),
+)
+
 const _default_area_interchange =
     Dict("ISW" => 0, "PDES" => 0.0, "PTOL" => 10.0, "ARNAME" => "            ")
+
+const _default_area_interchange_v35 = _default_area_interchange
 
 const _default_two_terminal_dc = Dict(
     "MDC" => 0,
@@ -794,6 +1209,11 @@ const _default_two_terminal_dc = Dict(
     "XCAPI" => 0.0,
 )
 
+const _default_two_terminal_dc_v35 = merge(_default_two_terminal_dc, Dict(
+    "NDR" => 0,
+    "NDI" => 0,
+))
+
 const _default_vsc_dc = Dict(
     "MDC" => 1,
     "O1" => nothing,
@@ -820,6 +1240,8 @@ const _default_vsc_dc = Dict(
     ),
 )
 
+const _default_vsc_dc_v35 = _default_vsc_dc
+
 const _default_impedance_correction = Dict(
     "T1" => 0.0,
     "T2" => 0.0,
@@ -843,6 +1265,21 @@ const _default_impedance_correction = Dict(
     "F9" => 0.0,
     "F10" => 0.0,
     "F11" => 0.0,
+)
+
+const _default_impedance_correction_v35 = Dict(
+    "T1" => 0.0, "Re(F1)" => 0.0, "Im(F1)" => 0.0,
+    "T2" => 0.0, "Re(F2)" => 0.0, "Im(F2)" => 0.0,
+    "T3" => 0.0, "Re(F3)" => 0.0, "Im(F3)" => 0.0,
+    "T4" => 0.0, "Re(F4)" => 0.0, "Im(F4)" => 0.0,
+    "T5" => 0.0, "Re(F5)" => 0.0, "Im(F5)" => 0.0,
+    "T6" => 0.0, "Re(F6)" => 0.0, "Im(F6)" => 0.0,
+    "T7" => 0.0, "Re(F7)" => 0.0, "Im(F7)" => 0.0,
+    "T8" => 0.0, "Re(F8)" => 0.0, "Im(F8)" => 0.0,
+    "T9" => 0.0, "Re(F9)" => 0.0, "Im(F9)" => 0.0,
+    "T10" => 0.0, "Re(F10)" => 0.0, "Im(F10)" => 0.0,
+    "T11" => 0.0, "Re(F11)" => 0.0, "Im(F11)" => 0.0,
+    "T12" => 0.0, "Re(F12)" => 0.0, "Im(F12)" => 0.0,
 )
 
 const _default_multi_term_dc = Dict(
@@ -871,13 +1308,23 @@ const _default_multi_term_dc = Dict(
     "DCLN" => Dict("DCCKT" => 1, "MET" => 1, "LDC" => 0.0),
 )
 
+const _default_multi_term_dc_v35 = _default_multi_term_dc
+
 const _default_multi_section = Dict("ID" => "&1", "MET" => 1)
+
+const _default_multi_section_v35 = _default_multi_section
 
 const _default_zone = Dict("ZONAME" => "            ")
 
+const _default_zone_v35 = _default_zone
+
 const _default_interarea = Dict("TRID" => 1, "PTRAN" => 0.0)
 
+const _default_interarea_v35 = _default_interarea
+
 const _default_owner = Dict("OWNAME" => "            ")
+
+const _default_owner_v35 = _default_owner
 
 const _default_facts = Dict(
     "J" => 0,
@@ -901,6 +1348,14 @@ const _default_facts = Dict(
     "MNAME" => "",
 )
 
+const _default_facts_v35 = merge(
+    Dict(k => v for (k, v) in pairs(_default_facts) if k != "REMOT"),
+    Dict(
+        "FCREG" => 0,  # Replaces REMOT in v35
+        "NREG" => 0,
+    ),
+)
+
 const _default_switched_shunt = Dict(
     "MODSW" => 1,
     "ADJM" => 0,
@@ -911,22 +1366,23 @@ const _default_switched_shunt = Dict(
     "RMPCT" => 100.0,
     "RMIDNT" => "",
     "BINIT" => 0.0,
-    "N1" => 0,
-    "N2" => 0,
-    "N3" => 0,
-    "N4" => 0,
-    "N5" => 0,
-    "N6" => 0,
-    "N7" => 0,
-    "N8" => 0,
-    "B1" => 0.0,
-    "B2" => 0.0,
-    "B3" => 0.0,
-    "B4" => 0.0,
-    "B5" => 0.0,
-    "B6" => 0.0,
-    "B7" => 0.0,
-    "B8" => 0.0,
+    "S1" => 1, "N1" => 0, "B1" => 0.0,
+    "S2" => 1, "N2" => 0, "B2" => 0.0,
+    "S3" => 1, "N3" => 0, "B3" => 0.0,
+    "S4" => 1, "N4" => 0, "B4" => 0.0,
+    "S5" => 1, "N5" => 0, "B5" => 0.0,
+    "S6" => 1, "N6" => 0, "B6" => 0.0,
+    "S7" => 1, "N7" => 0, "B7" => 0.0,
+    "S8" => 1, "N8" => 0, "B8" => 0.0,
+)
+
+const _default_switched_shunt_v35 = merge(
+    Dict(k => v for (k, v) in pairs(_default_switched_shunt) if k != "SWREM"),
+    Dict(
+        "SWREG" => 0,
+        "ID" => "1",
+        "NAME" => "",
+    ),
 )
 
 const _default_gne_device = Dict(
@@ -941,6 +1397,8 @@ const _default_gne_device = Dict(
     "INTG" => nothing,
     "CHAR" => "1",
 )
+
+const _default_gne_device_v35 = _default_gne_device
 
 const _default_induction_machine = Dict(
     "ID" => 1,
@@ -977,6 +1435,15 @@ const _default_induction_machine = Dict(
     "XAMULT" => 1,
 )
 
+const _default_induction_machine_v35 = _default_induction_machine
+
+const _default_substation_data_v35 = Dict(
+    "NAME" => "",
+    "LATI" => 0.0,
+    "LONG" => 0.0,
+    "SGR" => 0.1,
+)
+
 const _pti_defaults = Dict(
     "BUS" => _default_bus,
     "LOAD" => _default_load,
@@ -998,6 +1465,31 @@ const _pti_defaults = Dict(
     "CASE IDENTIFICATION" => _default_case_identification,
     "GNE DEVICE" => _default_gne_device,
     "INDUCTION MACHINE" => _default_induction_machine,
+)
+
+const _pti_defaults_v35 = Dict(
+    "BUS" => _default_bus,
+    "LOAD" => _default_load,
+    "FIXED SHUNT" => _default_fixed_shunt,
+    "GENERATOR" => _default_generator,
+    "BRANCH" => _default_branch,
+    "SWITCHING DEVICE" => _default_switching_device_v35,
+    "TRANSFORMER" => _default_transformer,
+    "AREA INTERCHANGE" => _default_area_interchange,
+    "TWO-TERMINAL DC" => _default_two_terminal_dc,
+    "VOLTAGE SOURCE CONVERTER" => _default_vsc_dc,
+    "IMPEDANCE CORRECTION" => _default_impedance_correction,
+    "MULTI-TERMINAL DC" => _default_multi_term_dc,
+    "MULTI-SECTION LINE" => _default_multi_section,
+    "ZONE" => _default_zone,
+    "INTER-AREA TRANSFER" => _default_interarea,
+    "OWNER" => _default_owner,
+    "FACTS CONTROL DEVICE" => _default_facts,
+    "SWITCHED SHUNT" => _default_switched_shunt,
+    "CASE IDENTIFICATION" => _default_case_identification,
+    "GNE DEVICE" => _default_gne_device,
+    "INDUCTION MACHINE" => _default_induction_machine,
+    "SUBSTATION DATA" => _default_substation_data_v35,
 )
 
 function _correct_nothing_values!(data::Dict)
@@ -1114,7 +1606,7 @@ function _parse_elements(
     defaults::Dict,
     section::AbstractString,
 )
-    data = Dict{String, Any}()
+    data = Dict{String,Any}()
 
     if length(elements) > length(dtypes)
         @warn(
@@ -1130,7 +1622,7 @@ function _parse_elements(
 
         if dtype == String
             if startswith(element, "'") && endswith(element, "'")
-                data[field] = element[2:(end - 1)]
+                data[field] = element[2:(end-1)]
             else
                 data[field] = element
             end
@@ -1183,9 +1675,9 @@ Internal function. Parses a single "line" of data elements from a PTI file, as
 given by `elements` which is an array of the line, typically split at `,`.
 Elements are parsed into data types given by `section` and saved into `data::Dict`.
 """
-function _parse_line_element!(data::Dict, elements::Array, section::AbstractString)
+function _parse_line_element!(data::Dict, elements::Array, section::AbstractString, dtypes::Dict{String, Array})
     missing_fields = []
-    for (i, (field, dtype)) in enumerate(_pti_dtypes[section])
+    for (i, (field, dtype)) in enumerate(dtypes[section])
         if i > length(elements)
             @debug "Have run out of elements in $section at $field" _group =
                 IS.LOG_GROUP_PARSING
@@ -1249,7 +1741,7 @@ function _get_line_elements(line::AbstractString)
         )
     end
 
-    line_comment = split(line, _comment_split; limit = 2)
+    line_comment = split(line, _comment_split; limit=2)
     line = strip(line_comment[1])
     comment = length(line_comment) > 1 ? strip(line_comment[2]) : ""
 
@@ -1267,83 +1759,178 @@ file (typically given by default by `get_pti_sections()`.
 """
 function _parse_pti_data(data_io::IO)
     sections = deepcopy(_pti_sections)
+    sections_v35 = deepcopy(_pti_sections_v35)
     data_lines = readlines(data_io)
     skip_lines = 0
     skip_sublines = 0
     subsection = ""
+    is_v35 = false
 
-    pti_data = Dict{String, Array{Dict}}()
+    pti_data = Dict{String,Array{Dict}}()
 
     section = popfirst!(sections)
-    section_data = Dict{String, Any}()
+    section_v35 = popfirst!(sections_v35)
+    section_data = Dict{String,Any}()
 
-    for (line_number, line) in enumerate(data_lines)
+    if any(startswith.(data_lines, "@!"))
+        is_v35 = true
+    end
+
+    header_line_start = is_v35 ? 2 : 1
+    bus_data_start = is_v35 ? 25 : 4
+
+    current_dtypes = is_v35 ? _pti_dtypes_v35 : _pti_dtypes
+
+    line_index = 1
+    while line_index <= length(data_lines)
+        line = data_lines[line_index]
+
+        if startswith(line, "@!")
+            line_index += 1
+            continue
+        end
+
         (elements, comment) = _get_line_elements(line)
 
         first_element = strip(elements[1])
-        if line_number > 3 && length(elements) != 0 && first_element == "Q"
+
+        if is_v35 && (line_index == 3 || line_index == 4) && section_v35 == "CASE IDENTIFICATION"
+            comment_line = strip(line)
+            comment_key = line_index == 3 ? "Comment_Line_1" : "Comment_Line_2"
+            
+            if haskey(pti_data, "CASE IDENTIFICATION") && !isempty(pti_data["CASE IDENTIFICATION"])
+                pti_data["CASE IDENTIFICATION"][1][comment_key] = comment_line
+                @debug "Added $comment_key: $comment_line" _group = IS.LOG_GROUP_PARSING
+            end
+            line_index += 1
+            continue
+        end
+
+        if is_v35 && line_index >= 3 && line_index < bus_data_start
+            line_index += 1
+            continue
+        end
+
+        if line_index > (is_v35 ? bus_data_start - 1 : 3) && length(elements) != 0 && first_element == "Q"
             break
-        elseif line_number > 3 && length(elements) != 0 && first_element == "0"
-            if line_number == 4
-                section = popfirst!(sections)
+        elseif line_index > (is_v35 ? bus_data_start - 1 : 3) && length(elements) != 0 && first_element == "0"
+            if line_index == bus_data_start
+                section = is_v35 ? popfirst!(sections_v35) : popfirst!(sections)
             end
 
             if length(elements) > 1
                 @info(
-                    "At line $line_number, new section started with '0', but additional non-comment data is present. Pattern '^\\s*0\\s*[/]*.*' is reserved for section start/end.",
+                    "At line $line_index, new section started with '0', but additional non-comment data is present. Pattern '^\\s*0\\s*[/]*.*' is reserved for section start/end.",
                 )
             elseif length(comment) > 0
-                @debug "At line $line_number, switched to $section" _group =
+                @debug "At line $line_index, switched to $section" _group =
                     IS.LOG_GROUP_PARSING
             end
 
-            if !isempty(sections)
-                section = popfirst!(sections)
+            current_sections = is_v35 ? sections_v35 : sections
+            if !isempty(current_sections)
+                section = popfirst!(current_sections)
+            else
+                @debug "No more sections to process, ending parsing..." _group = IS.LOG_GROUP_PARSING
+                break
             end
-
+            
+            line_index += 1
             continue
         else
-            if line_number == 4
-                section = popfirst!(sections)
-                section_data = Dict{String, Any}()
+            if line_index == bus_data_start
+                section = is_v35 ? popfirst!(sections_v35) : popfirst!(sections)
+                section_data = Dict{String,Any}()
             end
 
             if skip_lines > 0
                 skip_lines -= 1
+                line_index += 1
                 continue
             end
 
             @debug join(["Section:", section], " ") _group = IS.LOG_GROUP_PARSING
-            if !(
+
+            if section == "IMPEDANCE CORRECTION" && is_v35
+                if startswith(line, " ") || startswith(line, "\t")
+                    line_index += 1
+                    continue
+                end
+
+                section_data = Dict{String, Any}()
+                section_data["I"] = parse(Int64, strip(elements[1]))
+                
+                all_elements = elements[2:end]
+
+                next_line_index = line_index + 1
+                while next_line_index <= length(data_lines)
+                    next_line = data_lines[next_line_index]
+                    
+                    if !startswith(strip(next_line), r"^\d+") && !startswith(next_line, "0") && !isempty(strip(next_line)) && !startswith(next_line, "@!")
+                        (continuation_elements, _) = _get_line_elements(next_line)
+                        append!(all_elements, continuation_elements)
+                        next_line_index += 1
+                    else
+                        break
+                    end
+                end
+                
+                point_index = 1
+                element_index = 1
+                while element_index <= length(all_elements) && element_index + 2 <= length(all_elements)
+                    if !isempty(strip(all_elements[element_index])) && 
+                       !isempty(strip(all_elements[element_index + 1])) && 
+                       !isempty(strip(all_elements[element_index + 2]))
+                        
+                        t_val = parse(Float64, strip(all_elements[element_index]))
+                        re_val = parse(Float64, strip(all_elements[element_index + 1]))
+                        im_val = parse(Float64, strip(all_elements[element_index + 2]))
+                        
+                        section_data["T$point_index"] = t_val
+                        section_data["Re_F$point_index"] = re_val
+                        section_data["Im_F$point_index"] = im_val
+                        
+                        point_index += 1
+                    end
+                    element_index += 3
+                end
+                
+                line_index = next_line_index
+            
+            elseif !(
                 section in [
                     "CASE IDENTIFICATION",
+                    "SWITCHING DEVICE DATA",
                     "TRANSFORMER",
                     "VOLTAGE SOURCE CONVERTER",
+                    "IMPEDANCE CORRECTION",
                     "MULTI-TERMINAL DC",
                     "TWO-TERMINAL DC",
                     "GNE DEVICE",
+                    "SUBSTATION DATA",
                 ]
             )
-                section_data = Dict{String, Any}()
+                section_data = Dict{String,Any}()
 
                 try
-                    _parse_line_element!(section_data, elements, section)
+                    _parse_line_element!(section_data, elements, section, current_dtypes)
                 catch message
                     throw(
                         @error(
-                            "Parsing failed at line $line_number: $(sprint(showerror, message))"
+                            "Parsing failed at line $line_index: $(sprint(showerror, message))"
                         )
                     )
                 end
+                line_index += 1
 
             elseif section == "CASE IDENTIFICATION"
-                if line_number == 1
+                if line_index == header_line_start
                     try
-                        _parse_line_element!(section_data, elements, section)
+                        _parse_line_element!(section_data, elements, section, current_dtypes)
                     catch message
                         throw(
                             @error(
-                                "Parsing failed at line $line_number: $(sprint(showerror, message))",
+                                "Parsing failed at line $line_index: $(sprint(showerror, message))",
                             ),
                         )
                     end
@@ -1353,16 +1940,58 @@ function _parse_pti_data(data_io::IO)
                             "Version $(section_data["REV"]) of PTI format is unsupported, parser may not function correctly.",
                         )
                     end
+                    
+                    if is_v35
+                        if haskey(pti_data, section)
+                            push!(pti_data[section], section_data)
+                        else
+                            pti_data[section] = [section_data]
+                        end
+                    end  
                 else
-                    section_data["Comment_Line_$(line_number - 1)"] = line
+                    if is_v35
+                        if line_index == 3
+                            comment_line = strip(line)
+                            if haskey(pti_data, section) && !isempty(pti_data[section])
+                                pti_data[section][1]["Comment_Line_1"] = comment_line
+                            end
+                        elseif line_index == 4
+                            comment_line = strip(line)
+                            if haskey(pti_data, section) && !isempty(pti_data[section])
+                                pti_data[section][1]["Comment_Line_2"] = comment_line
+                            end
+                        end
+                    elseif !is_v35 && line_index > header_line_start
+                        section_data["Comment_Line_$(line_index - 1)"] = strip(line)
+                    end
                 end
 
-                if line_number < 3
+                if line_index < (bus_data_start - 1)
+                    line_index += 1
                     continue
                 end
 
+                line_index += 1
+
+            elseif section == "SWITCHING DEVICE"
+                if is_v35
+                    section_data = Dict{String, Any}()
+                    try
+                        _parse_line_element!(section_data, elements, section, current_dtypes)
+                    catch message
+                        throw(
+                            @error(
+                                "Parsing failed at line $line_index: $(sprint(showerror, message))",
+                            ),
+                        )
+                    end
+                else
+                    @warn("SWITCHING DEVICE DATA section found in non-v35 file, skipping.")
+                end
+                line_index += 1
+
             elseif section == "TRANSFORMER"
-                section_data = Dict{String, Any}()
+                section_data = Dict{String,Any}()
                 if parse(Int64, _get_line_elements(line)[1][3]) == 0 # two winding transformer
                     winding = "TWO-WINDING"
                     skip_lines = 3
@@ -1386,43 +2015,45 @@ function _parse_pti_data(data_io::IO)
                             break
                         else
                             elements = _get_line_elements(
-                                data_lines[line_number + transformer_line],
+                                data_lines[line_index+transformer_line],
                             )[1]
-                            _parse_line_element!(section_data, elements, temp_section)
+                            _parse_line_element!(section_data, elements, temp_section, current_dtypes)
                         end
                     end
                 catch message
                     throw(
                         @error(
-                            "Parsing failed at line $line_number: $(sprint(showerror, message))",
+                            "Parsing failed at line $line_index: $(sprint(showerror, message))",
                         ),
                     )
                 end
+                line_index += 1
 
             elseif section == "VOLTAGE SOURCE CONVERTER"
                 if length(_get_line_elements(line)[1]) == 11
-                    section_data = Dict{String, Any}()
+                    section_data = Dict{String,Any}()
                     try
-                        _parse_line_element!(section_data, elements, section)
+                        _parse_line_element!(section_data, elements, section, current_dtypes)
                     catch message
                         throw(
                             @error(
-                                "Parsing failed at line $line_number: $(sprint(showerror, message))",
+                                "Parsing failed at line $line_index: $(sprint(showerror, message))",
                             ),
                         )
                     end
                     skip_sublines = 2
+                    line_index += 1
                     continue
 
                 elseif skip_sublines > 0
                     skip_sublines -= 1
-                    subsection_data = Dict{String, Any}()
+                    subsection_data = Dict{String,Any}()
 
                     for (field, dtype) in _pti_dtypes["$section SUBLINES"]
                         element = popfirst!(elements)
                         if element != ""
                             subsection_data[field] = parse(dtype, element)
-                        else
+                        else line_index += 1
                             subsection_data[field] = ""
                         end
                     end
@@ -1431,38 +2062,54 @@ function _parse_pti_data(data_io::IO)
                         push!(section_data["CONVERTER BUSES"], subsection_data)
                     else
                         section_data["CONVERTER BUSES"] = [subsection_data]
+                        line_index += 1
                         continue
                     end
                 end
+                line_index += 1
 
             elseif section == "TWO-TERMINAL DC"
-                section_data = Dict{String, Any}()
+                section_data = Dict{String,Any}()
                 if length(_get_line_elements(line)[1]) == 12
                     (elements, comment) = _get_line_elements(
-                        join(data_lines[line_number:(line_number + 2)], ','),
+                        join(data_lines[line_index:(line_index+2)], ','),
                     )
                     skip_lines = 2
                 end
 
                 try
-                    _parse_line_element!(section_data, elements, section)
+                    _parse_line_element!(section_data, elements, section, current_dtypes)
                 catch message
                     throw(
                         @error(
-                            "Parsing failed at line $line_number: $(sprint(showerror, message))",
+                            "Parsing failed at line $line_index: $(sprint(showerror, message))",
                         ),
                     )
                 end
+                line_index += 1
+
+            elseif section == "IMPEDANCE CORRECTION" && !is_v35
+                section_data = Dict{String, Any}()
+                try
+                    _parse_line_element!(section_data, elements, section, current_dtypes)
+                catch message
+                    throw(
+                        @error(
+                            "Parsing failed at line $line_index: $(sprint(showerror, message))",
+                        ),
+                    )
+                end
+                line_index += 1
 
             elseif section == "MULTI-TERMINAL DC"
                 if skip_sublines == 0
-                    section_data = Dict{String, Any}()
+                    section_data = Dict{String,Any}()
                     try
-                        _parse_line_element!(section_data, elements, section)
+                        _parse_line_element!(section_data, elements, section, current_dtypes)
                     catch message
                         throw(
                             @error(
-                                "Parsing failed at line $line_number: $(sprint(showerror, message))",
+                                "Parsing failed at line $line_index: $(sprint(showerror, message))",
                             ),
                         )
                     end
@@ -1470,14 +2117,17 @@ function _parse_pti_data(data_io::IO)
                     if section_data["NCONV"] > 0
                         skip_sublines = section_data["NCONV"]
                         subsection = "NCONV"
+                        line_index += 1
                         continue
                     elseif section_data["NDCBS"] > 0
                         skip_sublines = section_data["NDCBS"]
                         subsection = "NDCBS"
+                        line_index += 1
                         continue
                     elseif section_data["NDCLN"] > 0
                         skip_sublines = section_data["NDCLN"]
                         subsection = "NDCLN"
+                        line_index += 1
                         continue
                     end
                 end
@@ -1485,17 +2135,18 @@ function _parse_pti_data(data_io::IO)
                 if skip_sublines > 0
                     skip_sublines -= 1
 
-                    subsection_data = Dict{String, Any}()
+                    subsection_data = Dict{String,Any}()
                     try
                         _parse_line_element!(
                             subsection_data,
                             elements,
                             "$section $subsection",
+                            current_dtypes
                         )
                     catch message
                         throw(
                             error(
-                                "Parsing failed at line $line_number: $(sprint(showerror, message))",
+                                "Parsing failed at line $line_index: $(sprint(showerror, message))",
                             ),
                         )
                     end
@@ -1504,11 +2155,13 @@ function _parse_pti_data(data_io::IO)
                         section_data["$(subsection[2:end])"] =
                             push!(section_data["$(subsection[2:end])"], subsection_data)
                         if skip_sublines > 0 && subsection != "NDCLN"
+                            line_index += 1
                             continue
                         end
                     else
                         section_data["$(subsection[2:end])"] = [subsection_data]
                         if skip_sublines > 0 && subsection != "NDCLN"
+                            line_index += 1
                             continue
                         end
                     end
@@ -1517,22 +2170,73 @@ function _parse_pti_data(data_io::IO)
                         if subsection == "NDCBS"
                             skip_sublines = section_data["NDCLN"]
                             subsection = "NDCLN"
+                            line_index += 1
                             continue
                         elseif subsection == "NCONV"
                             skip_sublines = section_data["NDCBS"]
                             subsection = "NDCBS"
+                            line_index += 1
                             continue
                         end
                     elseif skip_sublines == 0 && subsection == "NDCLN"
                         subsection = ""
                     else
+                        line_index += 1
                         continue
                     end
                 end
+                line_index += 1
+
+            elseif section == "SUBSTATION DATA" && is_v35
+                println(line)
+                if startswith(line, "@!")
+                    line_index += 1
+                    continue
+                elseif first_element == "0" and 
+                    if contains(comment, "END OF SUBSTATION TERMINAL DATA") && !contains(comment, "BEGIN SUBSTATION DATA BLOCK")
+                        @debug "Found end of substation terminal data, checking if more blocks follow" _group = IS.LOG_GROUP_PARSING
+                    end
+                    line_index += 1
+                    continue
+                else
+                    println(line_index)
+
+                    if length(elements) == 5 && tryparse(Int64, strip(elements[1])) !== nothing
+                        @debug "Parsing substation data line: $line" _group = IS.LOG_GROUP_PARSING
+                        section_data = Dict{String, Any}()
+                        try
+                            _parse_line_element!(section_data, elements, section, current_dtypes)
+
+                            println(section_data)
+                            
+                            if haskey(pti_data, section)
+                                push!(pti_data[section], section_data)
+                            else
+                                pti_data[section] = [section_data]
+                            end
+                            
+                            @debug "Successfully parsed substation IS=$(section_data["IS"]): $(strip(section_data["NAME"]))" _group = IS.LOG_GROUP_PARSING
+                            
+                        catch message
+                            throw(@error("Parsing failed at line $line_index: $(sprint(showerror, message))"))
+                        end
+                        
+                    else
+                        @debug "Skipping non-substation line ($(length(elements)) elements): $line" _group = IS.LOG_GROUP_PARSING
+                    end
+                    
+                    line_index += 1
+                    continue
+                end
+                
+                line_index += 1
 
             elseif section == "GNE DEVICE"
                 # TODO: handle multiple lines of GNE Device
                 @info("GNE DEVICE parsing is not supported.")
+                line_index += 1
+            else 
+                line_index += 1
             end
         end
         if subsection != ""

--- a/src/parsers/pm_io/pti.jl
+++ b/src/parsers/pm_io/pti.jl
@@ -90,13 +90,24 @@ const _system_wide_dtypes_v35 = [
     ("DESC", String),
 ]
 
-const _system_wide_data_sections_v35 = Dict{String,Vector{String}}(
-    "GENERAL" => ["THRSHZ", "PQBRAK", "BLOWUP", "MAXISOLLVLS", "CAMAXREPTSLN", "CHKDUPCNTLBL"],
+const _system_wide_data_sections_v35 = Dict{String, Vector{String}}(
+    "GENERAL" =>
+        ["THRSHZ", "PQBRAK", "BLOWUP", "MAXISOLLVLS", "CAMAXREPTSLN", "CHKDUPCNTLBL"],
     "GAUSS" => ["ITMX", "ACCP", "ACCQ", "ACCM", "TOL"],
     "NEWTON" => ["ITMXN", "ACCN", "TOLN", "VCTOLQ", "VCTOLV", "DVLIM", "NDVFCT"],
     "ADJUST" => ["ADJTHR", "ACCTAP", "TAPLIM", "SWVBND", "MXTPSS", "MXSWIM"],
     "TYSL" => ["ITMXTY", "ACCTY", "TOLTY"],
-    "SOLVER" => ["METHOD", "ACTAPS", "AREAIN", "PHSHFT", "DCTAPS", "SWSHNT", "FLATST", "VARLIM", "NONDIV"],
+    "SOLVER" => [
+        "METHOD",
+        "ACTAPS",
+        "AREAIN",
+        "PHSHFT",
+        "DCTAPS",
+        "SWSHNT",
+        "FLATST",
+        "VARLIM",
+        "NONDIV",
+    ],
     "RATING" => ["IRATE", "NAME", "DESC"],
 )
 
@@ -331,17 +342,17 @@ const _transformer_3_2_dtypes_v35 = vcat(
     _transformer_3_2_dtypes[1:3],
     [
         ("RATE11", Float64),
-        ("RATE21", Float64),
-        ("RATE31", Float64),
-        ("RATE41", Float64),
-        ("RATE51", Float64),
-        ("RATE61", Float64),
-        ("RATE71", Float64),
-        ("RATE81", Float64),
-        ("RATE91", Float64),
-        ("RATE101", Float64),
+        ("RATE12", Float64),
+        ("RATE13", Float64),
+        ("RATE14", Float64),
+        ("RATE15", Float64),
+        ("RATE16", Float64),
+        ("RATE17", Float64),
+        ("RATE18", Float64),
+        ("RATE19", Float64),
+        ("RATE110", Float64),
         ("RATE111", Float64),
-        ("RATE121", Float64),
+        ("RATE112", Float64),
     ],
     _transformer_3_2_dtypes[7:8],
     [("NOD1", Int64)],
@@ -371,18 +382,18 @@ const _transformer_3_3_dtypes = [
 const _transformer_3_3_dtypes_v35 = vcat(
     _transformer_3_3_dtypes[1:3],
     [
-        ("RATE12", Float64),
+        ("RATE21", Float64),
         ("RATE22", Float64),
-        ("RATE32", Float64),
-        ("RATE42", Float64),
-        ("RATE52", Float64),
-        ("RATE62", Float64),
-        ("RATE72", Float64),
-        ("RATE82", Float64),
-        ("RATE92", Float64),
-        ("RATE102", Float64),
-        ("RATE112", Float64),
-        ("RATE122", Float64),
+        ("RATE23", Float64),
+        ("RATE24", Float64),
+        ("RATE25", Float64),
+        ("RATE26", Float64),
+        ("RATE27", Float64),
+        ("RATE28", Float64),
+        ("RATE29", Float64),
+        ("RATE210", Float64),
+        ("RATE211", Float64),
+        ("RATE212", Float64),
     ],
     _transformer_3_3_dtypes[7:8],
     [("NOD2", Int64)],
@@ -412,18 +423,18 @@ const _transformer_3_4_dtypes = [
 const _transformer_3_4_dtypes_v35 = vcat(
     _transformer_3_4_dtypes[1:3],
     [
-        ("RATE13", Float64),
-        ("RATE23", Float64),
+        ("RATE31", Float64),
+        ("RATE32", Float64),
         ("RATE33", Float64),
-        ("RATE43", Float64),
-        ("RATE53", Float64),
-        ("RATE63", Float64),
-        ("RATE73", Float64),
-        ("RATE83", Float64),
-        ("RATE93", Float64),
-        ("RATE103", Float64),
-        ("RATE113", Float64),
-        ("RATE123", Float64),
+        ("RATE34", Float64),
+        ("RATE35", Float64),
+        ("RATE36", Float64),
+        ("RATE37", Float64),
+        ("RATE38", Float64),
+        ("RATE39", Float64),
+        ("RATE310", Float64),
+        ("RATE311", Float64),
+        ("RATE312", Float64),
     ],
     _transformer_3_4_dtypes[7:8],
     [("NOD3", Int64)],
@@ -458,18 +469,18 @@ const _transformer_2_2_dtypes = [
 const _transformer_2_2_dtypes_v35 = vcat(
     _transformer_2_2_dtypes[1:3],
     [
+        ("RATE11", Float64),
+        ("RATE12", Float64),
         ("RATE13", Float64),
-        ("RATE23", Float64),
-        ("RATE33", Float64),
-        ("RATE43", Float64),
-        ("RATE53", Float64),
-        ("RATE63", Float64),
-        ("RATE73", Float64),
-        ("RATE83", Float64),
-        ("RATE93", Float64),
-        ("RATE103", Float64),
-        ("RATE113", Float64),
-        ("RATE123", Float64),
+        ("RATE14", Float64),
+        ("RATE15", Float64),
+        ("RATE16", Float64),
+        ("RATE17", Float64),
+        ("RATE18", Float64),
+        ("RATE19", Float64),
+        ("RATE110", Float64),
+        ("RATE111", Float64),
+        ("RATE112", Float64),
     ],
     _transformer_2_2_dtypes[7:8],
     [("NOD1", Int64)],
@@ -861,7 +872,7 @@ const _substation_dtypes_v35 = [
 lookup array of data types for PTI file sections given by
 `field_name`, as enumerated by PSS/E Program Operation Manual.
 """
-const _pti_dtypes = Dict{String,Array}(
+const _pti_dtypes = Dict{String, Array}(
     "BUS" => _bus_dtypes,
     "LOAD" => _load_dtypes,
     "FIXED SHUNT" => _fixed_shunt_dtypes,
@@ -895,7 +906,7 @@ const _pti_dtypes = Dict{String,Array}(
     "INDUCTION MACHINE" => _induction_machine_dtypes,
 )
 
-const _pti_dtypes_v35 = Dict{String,Array}(
+const _pti_dtypes_v35 = Dict{String, Array}(
     "BUS" => _bus_dtypes_v35,
     "LOAD" => _load_dtypes_v35,
     "FIXED SHUNT" => _fixed_shunt_dtypes_v35,
@@ -1616,7 +1627,7 @@ function _parse_elements(
     defaults::Dict,
     section::AbstractString,
 )
-    data = Dict{String,Any}()
+    data = Dict{String, Any}()
 
     if length(elements) > length(dtypes)
         @warn(
@@ -1632,7 +1643,7 @@ function _parse_elements(
 
         if dtype == String
             if startswith(element, "'") && endswith(element, "'")
-                data[field] = element[2:(end-1)]
+                data[field] = element[2:(end - 1)]
             else
                 data[field] = element
             end
@@ -1685,7 +1696,12 @@ Internal function. Parses a single "line" of data elements from a PTI file, as
 given by `elements` which is an array of the line, typically split at `,`.
 Elements are parsed into data types given by `section` and saved into `data::Dict`.
 """
-function _parse_line_element!(data::Dict, elements::Array, section::AbstractString, dtypes::Dict{String,Array})
+function _parse_line_element!(
+    data::Dict,
+    elements::Array,
+    section::AbstractString,
+    dtypes::Dict{String, Array},
+)
     missing_fields = []
     for (i, (field, dtype)) in enumerate(dtypes[section])
         if i > length(elements)
@@ -1751,7 +1767,7 @@ function _get_line_elements(line::AbstractString)
         )
     end
 
-    line_comment = split(line, _comment_split; limit=2)
+    line_comment = split(line, _comment_split; limit = 2)
     line = strip(line_comment[1])
     comment = length(line_comment) > 1 ? strip(line_comment[2]) : ""
 
@@ -1776,11 +1792,11 @@ function _parse_pti_data(data_io::IO)
     subsection = ""
     is_v35 = false
 
-    pti_data = Dict{String,Array{Dict}}()
+    pti_data = Dict{String, Array{Dict}}()
 
     section = popfirst!(sections)
     section_v35 = popfirst!(sections_v35)
-    section_data = Dict{String,Any}()
+    section_data = Dict{String, Any}()
 
     if any(startswith.(data_lines, "@!"))
         is_v35 = true
@@ -1804,11 +1820,13 @@ function _parse_pti_data(data_io::IO)
 
         first_element = strip(elements[1])
 
-        if is_v35 && (line_index == 3 || line_index == 4) && section_v35 == "CASE IDENTIFICATION"
+        if is_v35 && (line_index == 3 || line_index == 4) &&
+           section_v35 == "CASE IDENTIFICATION"
             comment_line = strip(line)
             comment_key = line_index == 3 ? "Comment_Line_1" : "Comment_Line_2"
 
-            if haskey(pti_data, "CASE IDENTIFICATION") && !isempty(pti_data["CASE IDENTIFICATION"])
+            if haskey(pti_data, "CASE IDENTIFICATION") &&
+               !isempty(pti_data["CASE IDENTIFICATION"])
                 pti_data["CASE IDENTIFICATION"][1][comment_key] = comment_line
                 @debug "Added $comment_key: $comment_line" _group = IS.LOG_GROUP_PARSING
             end
@@ -1821,9 +1839,11 @@ function _parse_pti_data(data_io::IO)
             continue
         end
 
-        if line_index > (is_v35 ? bus_data_start - 1 : 3) && length(elements) != 0 && first_element == "Q"
+        if line_index > (is_v35 ? bus_data_start - 1 : 3) && length(elements) != 0 &&
+           first_element == "Q"
             break
-        elseif line_index > (is_v35 ? bus_data_start - 1 : 3) && length(elements) != 0 && first_element == "0"
+        elseif line_index > (is_v35 ? bus_data_start - 1 : 3) && length(elements) != 0 &&
+               first_element == "0"
             if line_index == bus_data_start
                 section = is_v35 ? popfirst!(sections_v35) : popfirst!(sections)
             end
@@ -1847,7 +1867,7 @@ function _parse_pti_data(data_io::IO)
         else
             if line_index == bus_data_start
                 section = is_v35 ? popfirst!(sections_v35) : popfirst!(sections)
-                section_data = Dict{String,Any}()
+                section_data = Dict{String, Any}()
             end
 
             if skip_lines > 0
@@ -1870,12 +1890,11 @@ function _parse_pti_data(data_io::IO)
                 (elements, comment) = _get_line_elements(line)
                 first_element = strip(elements[1])
 
-                section_data = Dict{String,Any}()
+                section_data = Dict{String, Any}()
 
                 if tryparse(Int64, first_element) === nothing
                     line_index += 1
                     continue
-
                 end
 
                 section_data["I"] = parse(Int64, strip(elements[1]))
@@ -1903,10 +1922,11 @@ function _parse_pti_data(data_io::IO)
 
                 point_index = 1
                 element_index = 1
-                while element_index <= length(all_elements) && element_index + 2 <= length(all_elements)
+                while element_index <= length(all_elements) &&
+                    element_index + 2 <= length(all_elements)
                     t_str = strip(all_elements[element_index])
-                    re_str = strip(all_elements[element_index+1])
-                    im_str = strip(all_elements[element_index+2])
+                    re_str = strip(all_elements[element_index + 1])
+                    im_str = strip(all_elements[element_index + 2])
 
                     if !isempty(t_str) && !isempty(re_str) && !isempty(im_str)
                         t_val = parse(Float64, t_str)
@@ -1945,7 +1965,7 @@ function _parse_pti_data(data_io::IO)
                     "SUBSTATION DATA",
                 ]
             )
-                section_data = Dict{String,Any}()
+                section_data = Dict{String, Any}()
 
                 try
                     _parse_line_element!(section_data, elements, section, current_dtypes)
@@ -1961,7 +1981,12 @@ function _parse_pti_data(data_io::IO)
             elseif section == "CASE IDENTIFICATION"
                 if line_index == header_line_start
                     try
-                        _parse_line_element!(section_data, elements, section, current_dtypes)
+                        _parse_line_element!(
+                            section_data,
+                            elements,
+                            section,
+                            current_dtypes,
+                        )
                     catch message
                         throw(
                             @error(
@@ -2010,9 +2035,14 @@ function _parse_pti_data(data_io::IO)
 
             elseif section == "SWITCHING DEVICE"
                 if is_v35
-                    section_data = Dict{String,Any}()
+                    section_data = Dict{String, Any}()
                     try
-                        _parse_line_element!(section_data, elements, section, current_dtypes)
+                        _parse_line_element!(
+                            section_data,
+                            elements,
+                            section,
+                            current_dtypes,
+                        )
                     catch message
                         throw(
                             @error(
@@ -2026,7 +2056,7 @@ function _parse_pti_data(data_io::IO)
                 line_index += 1
 
             elseif section == "TRANSFORMER"
-                section_data = Dict{String,Any}()
+                section_data = Dict{String, Any}()
                 if parse(Int64, _get_line_elements(line)[1][3]) == 0 # two winding transformer
                     winding = "TWO-WINDING"
                     skip_lines = 3
@@ -2050,9 +2080,14 @@ function _parse_pti_data(data_io::IO)
                             break
                         else
                             elements = _get_line_elements(
-                                data_lines[line_index+transformer_line],
+                                data_lines[line_index + transformer_line],
                             )[1]
-                            _parse_line_element!(section_data, elements, temp_section, current_dtypes)
+                            _parse_line_element!(
+                                section_data,
+                                elements,
+                                temp_section,
+                                current_dtypes,
+                            )
                         end
                     end
                 catch message
@@ -2066,9 +2101,14 @@ function _parse_pti_data(data_io::IO)
 
             elseif section == "VOLTAGE SOURCE CONVERTER"
                 if length(_get_line_elements(line)[1]) == 11
-                    section_data = Dict{String,Any}()
+                    section_data = Dict{String, Any}()
                     try
-                        _parse_line_element!(section_data, elements, section, current_dtypes)
+                        _parse_line_element!(
+                            section_data,
+                            elements,
+                            section,
+                            current_dtypes,
+                        )
                     catch message
                         throw(
                             @error(
@@ -2082,7 +2122,7 @@ function _parse_pti_data(data_io::IO)
 
                 elseif skip_sublines > 0
                     skip_sublines -= 1
-                    subsection_data = Dict{String,Any}()
+                    subsection_data = Dict{String, Any}()
 
                     for (field, dtype) in _pti_dtypes["$section SUBLINES"]
                         element = popfirst!(elements)
@@ -2105,10 +2145,10 @@ function _parse_pti_data(data_io::IO)
                 line_index += 1
 
             elseif section == "TWO-TERMINAL DC"
-                section_data = Dict{String,Any}()
+                section_data = Dict{String, Any}()
                 if length(_get_line_elements(line)[1]) == 12
                     (elements, comment) = _get_line_elements(
-                        join(data_lines[line_index:(line_index+2)], ','),
+                        join(data_lines[line_index:(line_index + 2)], ','),
                     )
                     skip_lines = 2
                 end
@@ -2125,7 +2165,7 @@ function _parse_pti_data(data_io::IO)
                 line_index += 1
 
             elseif section == "IMPEDANCE CORRECTION" && !is_v35
-                section_data = Dict{String,Any}()
+                section_data = Dict{String, Any}()
                 try
                     _parse_line_element!(section_data, elements, section, current_dtypes)
                 catch message
@@ -2139,9 +2179,14 @@ function _parse_pti_data(data_io::IO)
 
             elseif section == "MULTI-TERMINAL DC"
                 if skip_sublines == 0
-                    section_data = Dict{String,Any}()
+                    section_data = Dict{String, Any}()
                     try
-                        _parse_line_element!(section_data, elements, section, current_dtypes)
+                        _parse_line_element!(
+                            section_data,
+                            elements,
+                            section,
+                            current_dtypes,
+                        )
                     catch message
                         throw(
                             @error(
@@ -2171,13 +2216,13 @@ function _parse_pti_data(data_io::IO)
                 if skip_sublines > 0
                     skip_sublines -= 1
 
-                    subsection_data = Dict{String,Any}()
+                    subsection_data = Dict{String, Any}()
                     try
                         _parse_line_element!(
                             subsection_data,
                             elements,
                             "$section $subsection",
-                            current_dtypes
+                            current_dtypes,
                         )
                     catch message
                         throw(
@@ -2233,29 +2278,38 @@ function _parse_pti_data(data_io::IO)
                         if occursin(",'", first_part)
                             comma_quote_pos = findfirst(",'", first_part)
                             if comma_quote_pos !== nothing
-                                is_part = first_part[1:comma_quote_pos[1]-1]
-                                name_part = first_part[comma_quote_pos[1]+1:end]
+                                is_part = first_part[1:(comma_quote_pos[1] - 1)]
+                                name_part = first_part[(comma_quote_pos[1] + 1):end]
 
                                 corrected_elements = [
                                     is_part,
                                     name_part,
                                     elements[2],
                                     elements[3],
-                                    elements[4]
+                                    elements[4],
                                 ]
                                 if length(corrected_elements) == 5 &&
                                    occursin('\'', corrected_elements[2]) &&
-                                   tryparse(Float64, strip(corrected_elements[3])) !== nothing &&
-                                   tryparse(Float64, strip(corrected_elements[4])) !== nothing &&
-                                   tryparse(Float64, strip(corrected_elements[5])) !== nothing
-
-                                    @debug "Parsing substation data line: $line" _group = IS.LOG_GROUP_PARSING
-                                    section_data = Dict{String,Any}()
+                                   tryparse(Float64, strip(corrected_elements[3])) !==
+                                   nothing &&
+                                   tryparse(Float64, strip(corrected_elements[4])) !==
+                                   nothing &&
+                                   tryparse(Float64, strip(corrected_elements[5])) !==
+                                   nothing
+                                    @debug "Parsing substation data line: $line" _group =
+                                        IS.LOG_GROUP_PARSING
+                                    section_data = Dict{String, Any}()
                                     try
-                                        _parse_line_element!(section_data, corrected_elements, section, current_dtypes)
+                                        _parse_line_element!(
+                                            section_data,
+                                            corrected_elements,
+                                            section,
+                                            current_dtypes,
+                                        )
 
                                         if haskey(section_data, "NAME")
-                                            section_data["NAME"] = strip(section_data["NAME"])
+                                            section_data["NAME"] =
+                                                strip(section_data["NAME"])
                                         end
 
                                         if haskey(pti_data, section)
@@ -2264,7 +2318,11 @@ function _parse_pti_data(data_io::IO)
                                             pti_data[section] = [section_data]
                                         end
                                     catch message
-                                        throw(@error("Parsing failed at line $line_index: $(sprint(showerror, message))"))
+                                        throw(
+                                            @error(
+                                                "Parsing failed at line $line_index: $(sprint(showerror, message))"
+                                            )
+                                        )
                                     end
                                 end
                             end
@@ -2275,10 +2333,14 @@ function _parse_pti_data(data_io::IO)
                            tryparse(Float64, strip(elements[3])) !== nothing &&
                            tryparse(Float64, strip(elements[4])) !== nothing &&
                            tryparse(Float64, strip(elements[5])) !== nothing
-
-                        section_data = Dict{String,Any}()
+                        section_data = Dict{String, Any}()
                         try
-                            _parse_line_element!(section_data, elements, section, current_dtypes)
+                            _parse_line_element!(
+                                section_data,
+                                elements,
+                                section,
+                                current_dtypes,
+                            )
 
                             if haskey(section_data, "NAME")
                                 section_data["NAME"] = strip(section_data["NAME"])
@@ -2290,7 +2352,11 @@ function _parse_pti_data(data_io::IO)
                                 pti_data[section] = [section_data]
                             end
                         catch message
-                            throw(@error("Parsing failed at line $line_index: $(sprint(showerror, message))"))
+                            throw(
+                                @error(
+                                    "Parsing failed at line $line_index: $(sprint(showerror, message))"
+                                )
+                            )
                         end
                     end
 

--- a/src/parsers/pm_io/pti.jl
+++ b/src/parsers/pm_io/pti.jl
@@ -1878,19 +1878,20 @@ function _parse_pti_data(data_io::IO)
 
             if section == "IMPEDANCE CORRECTION" && is_v35
                 temporal_ic_elements = Vector{Vector{String}}()
-                
+
                 while line_index <= length(data_lines)
                     line = data_lines[line_index]
-                    
+
                     if startswith(line, "0 /") || startswith(line, "Q")
                         if !isempty(temporal_ic_elements)
                             last_entry_elements = temporal_ic_elements[end]
-                            
+
                             section_data_final = Dict{String, Any}()
-                            section_data_final["I"] = parse(Int64, strip(last_entry_elements[1]))
-                            
+                            section_data_final["I"] =
+                                parse(Int64, strip(last_entry_elements[1]))
+
                             processing_elements = last_entry_elements[2:end]
-                            
+
                             point_index = 1
                             element_index = 1
                             while element_index <= length(processing_elements) &&
@@ -1922,7 +1923,7 @@ function _parse_pti_data(data_io::IO)
                         end
                         break
                     end
-                    
+
                     if startswith(line, "@!")
                         line_index += 1
                         continue
@@ -1946,12 +1947,12 @@ function _parse_pti_data(data_io::IO)
 
                     if !isempty(temporal_ic_elements)
                         last_entry_elements = temporal_ic_elements[end]
-                        
+
                         section_data_prev = Dict{String, Any}()
                         section_data_prev["I"] = parse(Int64, strip(last_entry_elements[1]))
-                        
+
                         processing_elements = last_entry_elements[2:end]
-                        
+
                         point_index = 1
                         element_index = 1
                         while element_index <= length(processing_elements) &&
@@ -2411,8 +2412,9 @@ function _parse_pti_data(data_io::IO)
             @debug "appending data" _group = IS.LOG_GROUP_PARSING
         end
 
-        if haskey(pti_data, section) 
-            if section == "IMPEDANCE CORRECTION" && pti_data["CASE IDENTIFICATION"][1]["REV"] == 35
+        if haskey(pti_data, section)
+            if section == "IMPEDANCE CORRECTION" &&
+               pti_data["CASE IDENTIFICATION"][1]["REV"] == 35
                 continue
             else
                 push!(pti_data[section], section_data)

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -179,7 +179,7 @@ function _impedance_correction_table_lookup(data::Dict)
     for (table_number, table_data) in data["impedance_correction"]
         table_number = parse(Int64, table_number)
         x = table_data["tap_or_angle"]
-        y = table_data["scaling_factor_real"]
+        y = table_data["scaling_factor"]
 
         if length(x) == length(y)
             pwl_data = PiecewiseLinearData([(x[i], y[i]) for i in eachindex(x)])
@@ -202,12 +202,11 @@ function _impedance_correction_table_lookup(data::Dict)
                 )
             end
         else
-            # throw(
-            #     DataFormatError(
-            #         "Impedance correction mismatch at table $table_number: tap/angle and scaling count differs.",
-            #     ),
-            # )
-            @warn "Impedance correction mismatch at table $table_number: tap/angle and scaling count differs. Skipping this table."
+            throw(
+                DataFormatError(
+                    "Impedance correction mismatch at table $table_number: tap/angle and scaling count differs.",
+                ),
+            )
         end
     end
 

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -1558,13 +1558,13 @@ function make_switched_shunt(name::String, d::Dict, bus::ACBus)
         :number_of_steps => d["step_number"],
         :Y_increase => d["y_increment"],
         :admittance_limits => d["admittance_limits"],
-        :ext => d["ext"]
+        :ext => d["ext"],
     )
-    
+
     if haskey(d, "initial_status")
         params[:initial_status] = d["initial_status"]
     end
-    
+
     return SwitchedAdmittance(; params...)
 end
 


### PR DESCRIPTION
- Current parser is extracting correctly substation location data for parse_pti and parse_psse
- Handle of multi-line Re/Im of IC data for v35.
- Add to ext new parameters of version v35.
- Update Load and Switched Shunt structs to handle old and current file versions.
