### PR TITLE
Don't add dummy buses to system

### DIFF
--- a/src/parsers/pm_io/psse.jl
+++ b/src/parsers/pm_io/psse.jl
@@ -1566,6 +1566,9 @@ function _psse2pm_multisection_line!(pm_data::Dict, pti_data::Dict, import_all::
 
             dummy_buses =
                 Dict(k => v for (k, v) in multisec_line if startswith(k, "DUM") && v != "")
+            for (k, v) in dummy_buses
+                pm_data["bus"][v]["skip_add"] = true
+            end
             sub_data["ext"] = dummy_buses
 
             # Check if the multisection line is available based on branch status

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -424,8 +424,10 @@ function read_bus!(sys::System, data::Dict; kwargs...)
         )
 
         bus_number_to_bus[bus.number] = bus
-
-        add_component!(sys, bus; skip_validation = SKIP_PM_VALIDATION)
+        # Multi-section dummy buses are in the dict, but should not be added to System
+        if !haskey(d, "skip_add")
+            add_component!(sys, bus; skip_validation = SKIP_PM_VALIDATION)
+        end
     end
 
     if data["source_type"] == "pti" && haskey(data, "interarea_transfer")
@@ -1359,7 +1361,6 @@ function read_multisection_line!(
     end
 
     branch_data = data["branch"]
-
     for (_, d) in data["multisection_line"]
         bus_f = bus_number_to_bus[d["f_bus"]]
         bus_t = bus_number_to_bus[d["t_bus"]]


### PR DESCRIPTION
Adds a field to the bus PowerModels dictionary to indicate a bus should be skipped when building the system. This is used for dummy buses that are part of multi-section lines. 
Closes #1429 