### PR TITLE
3WT bug fixes

### DIFF
--- a/src/models/components.jl
+++ b/src/models/components.jl
@@ -366,7 +366,7 @@ function _get_multiplier(
     base_mva::Float64,
     ::Val{:ohm},
 )
-    return _get_winding_base_power(c, field) / base_mva
+    return base_mva / _get_winding_base_power(c, field)
 end
 
 # NATURAL_UNITS
@@ -392,7 +392,7 @@ function _get_multiplier(
     base_mva::Float64,
     ::Val{:siemens},
 )
-    return base_mva / _get_winding_base_power(c, field)
+    return _get_winding_base_power(c, field) / base_mva
 end
 
 # NATURAL_UNITS

--- a/src/parsers/pm_io/psse.jl
+++ b/src/parsers/pm_io/psse.jl
@@ -1336,15 +1336,31 @@ function _psse2pm_transformer!(pm_data::Dict, pti_data::Dict, import_all::Bool)
                     sub_data["primary_turns_ratio"] = windv1
                     sub_data["secondary_turns_ratio"] = windv2
                     sub_data["tertiary_turns_ratio"] = windv3
-                else
+                elseif transformer["CW"] == 2
                     sub_data["primary_turns_ratio"] =
                         transformer["WINDV1"] / sub_data["base_voltage_primary"]
                     sub_data["secondary_turns_ratio"] =
                         transformer["WINDV2"] / sub_data["base_voltage_secondary"]
                     sub_data["tertiary_turns_ratio"] =
                         transformer["WINDV3"] / sub_data["base_voltage_tertiary"]
+                else
+                    @assert transformer["CW"] == 3
+                    sub_data["primary_turns_ratio"] =
+                        windv1 * (
+                            sub_data["base_voltage_primary"] /
+                            _get_bus_value(transformer["I"], "base_kv", pm_data)
+                        )
+                    sub_data["secondary_turns_ratio"] =
+                        windv2 * (
+                            sub_data["base_voltage_secondary"] /
+                            _get_bus_value(transformer["J"], "base_kv", pm_data)
+                        )
+                    sub_data["tertiary_turns_ratio"] =
+                        windv3 * (
+                            sub_data["base_voltage_tertiary"] /
+                            _get_bus_value(transformer["K"], "base_kv", pm_data)
+                        )
                 end
-
                 sub_data["circuit"] = strip(transformer["CKT"])
 
                 sub_data["ext"] = Dict{String, Any}(

--- a/src/parsers/pm_io/psse.jl
+++ b/src/parsers/pm_io/psse.jl
@@ -1284,15 +1284,14 @@ function _psse2pm_transformer!(pm_data::Dict, pti_data::Dict, import_all::Bool)
                             (transformer["MAG2"] / Z_base_sys_1) * Z_base_device_1
                     end
                 else # CM=2: MAG1 are no load loss in Watts and MAG2 is the exciting current in pu, in device base.
+                    @assert transformer["CM"] == 2
                     G_pu = 1e-6 * transformer["MAG1"] / sub_data["base_power_12"]
                     B_pu = sqrt(transformer["MAG2"]^2 - G_pu^2)
                     sub_data["g"] = G_pu
                     sub_data["b"] = B_pu
                 end
-                sub_data["g"] = transformer["MAG1"] # M. conductance MAG1 is saved in "g"
                 # If CM = 1 & MAG2 != 0 -> MAG2 < 0
                 # If CM = 2 & MAG2 != 0 -> MAG2 > 0
-                sub_data["b"] = transformer["MAG2"] # M. susceptance MAG2 is saved in "b"
 
                 sub_data["primary_correction_table"] = transformer["TAB1"]
                 sub_data["secondary_correction_table"] = transformer["TAB2"]


### PR DESCRIPTION
This address four separate issues related to three winding transformers

1. The base power multiplier for ohms and siemens was the reciprocal 
2. The primary, secondary, and tertiary impedances were computed when each of the respective values was in a different base. Now the computation occurs in system base, and then is scaled to the appropriate winding base power.
3. g and b were overwritten.
4. scaling of the turns ratio for `CW==2` and `CW==3` were not handled separately. 

These changes get us to 97.7% passing ybus entries for the EI