### PR TITLE
Fix bug in InterruptibleStandardLoad parsing

### DIFF
--- a/src/models/supplemental_accessors.jl
+++ b/src/models/supplemental_accessors.jl
@@ -110,6 +110,14 @@ function get_max_active_power(d::StandardLoad)
     return total_load
 end
 
+function get_max_active_power(d::InterruptibleStandardLoad)
+    total_load = get_max_constant_active_power(d)
+    # TODO: consider voltage
+    total_load += get_max_impedance_active_power(d)
+    total_load += get_max_current_active_power(d)
+    return total_load
+end
+
 function get_from_to_flow_limit(a::AreaInterchange)
     return get_flow_limits(a).from_to
 end

--- a/test/test_parse_psse.jl
+++ b/test/test_parse_psse.jl
@@ -426,6 +426,20 @@ end
     @test length(get_components(x -> get_bustype(x) == ACBusTypes.PQ, ACBus, sys)) == 9
 end
 
+@testset "Test PSSE interruptible loads parsing" begin
+    sys = build_system(
+        PSSEParsingTestSystems,
+        "pti_case14_with_interruptible_loads_sys";
+        force_build = true,
+    )
+    isl = collect(get_components(InterruptibleStandardLoad, sys))[1]
+    @test length(collect(get_components(InterruptibleStandardLoad, sys))) == 4
+    @test get_available(isl) == true
+    @test isl isa InterruptibleStandardLoad
+    @test get_constant_active_power(isl) == 0.11485
+    @test get_max_active_power(isl) == 0.11485
+end
+
 @testset "Test conversion zero impedance branch to switch" begin
     sys = build_system(
         PSSEParsingTestSystems,


### PR DESCRIPTION
This could be fixed using a Union to handle SL and ISL or set it as a separate function for ISL.
