### PR TITLE
get_power returns constant power

### DIFF
--- a/src/models/supplemental_accessors.jl
+++ b/src/models/supplemental_accessors.jl
@@ -166,3 +166,9 @@ function get_α_tertiary(t::Transformer3W)
         return get_tertiary_group_number(t).value * -(π / 6)
     end
 end
+
+# this way, we can handle all constant power contributions using the same function call.
+get_active_power(l::StandardLoad) = l.constant_active_power
+get_reactive_power(l::StandardLoad) = l.constant_reactive_power
+get_active_power(l::InterruptibleStandardLoad) = l.constant_active_power
+get_reactive_power(l::InterruptibleStandardLoad) = l.constant_reactive_power


### PR DESCRIPTION
Add a supplemental accessor, so that there's a uniform interface and we can handle all constant power contributions by calling `get_{re}active_power(device)`.