### PR TITLE
Fix bugs found in V35 PJM file

### DIFF
--- a/src/parsers/pm_io/psse.jl
+++ b/src/parsers/pm_io/psse.jl
@@ -2007,13 +2007,18 @@ function sort_values_by_key_prefix_v35(imp_correction::Dict{String, <:Any}, pref
         )
     ]
 
-    first_non_zero_index = findfirst(x -> x != 0.0, reverse(sorted_values))
-    if first_non_zero_index !== nothing
-        sorted_values = sorted_values[1:(length(sorted_values) - first_non_zero_index + 1)]
-    end
+    # Remove trailing zeros in IC data that indicate end of entry (0.00000,0.00000,0.00000)
+    # Acoording to PSSE DataFormat Section 1.18. TIC Tables
+    # Check if the last entry is all zeros across (T, Re(F), Im(F))
+    while !isempty(sorted_values)
+        last_index = length(sorted_values)
+        keys_to_check = ["T$last_index", "Re(F$last_index)", "Im(F$last_index)"]
 
-    if length(sorted_values) < 2
-        push!(sorted_values, 0.0)
+        if all(k -> haskey(imp_correction, k) && imp_correction[k] == 0.0, keys_to_check)
+            pop!(sorted_values)
+        else
+            break
+        end
     end
 
     return sorted_values

--- a/src/parsers/pm_io/psse.jl
+++ b/src/parsers/pm_io/psse.jl
@@ -2012,6 +2012,10 @@ function sort_values_by_key_prefix_v35(imp_correction::Dict{String, <:Any}, pref
         sorted_values = sorted_values[1:(length(sorted_values) - first_non_zero_index + 1)]
     end
 
+    if length(sorted_values) < 2
+        push!(sorted_values, 0.0)
+    end
+
     return sorted_values
 end
 
@@ -2034,7 +2038,8 @@ function _psse2pm_impedance_correction!(pm_data::Dict, pti_data::Dict, import_al
                     sort_values_by_key_prefix_v35(imp_correction, "Re(F")
                 sub_data["scaling_factor_imag"] =
                     sort_values_by_key_prefix_v35(imp_correction, "Im(F")
-                sub_data["tap_or_angle"] = sort_values_by_key_prefix(imp_correction, "T")
+                sub_data["tap_or_angle"] =
+                    sort_values_by_key_prefix_v35(imp_correction, "T")
             else
                 sub_data["scaling_factor"] = sort_values_by_key_prefix(imp_correction, "F")
                 sub_data["tap_or_angle"] = sort_values_by_key_prefix(imp_correction, "T")

--- a/src/parsers/pm_io/psse.jl
+++ b/src/parsers/pm_io/psse.jl
@@ -648,6 +648,7 @@ function _psse2pm_shunt!(pm_data::Dict, pti_data::Dict, import_all::Bool)
                 sub_data["ext"]["NREG"] = pop!(switched_shunt, "NREG")
             elseif pm_data["source_version"] ∈ ("32", "33")
                 sub_data["ext"]["SWREM"] = switched_shunt["SWREM"]
+                sub_data["initial_status"] = ones(Int, length(sub_data["y_increment"]))
             else
                 error("Unsupported PSS(R)E source version: $(pm_data["source_version"])")
             end

--- a/src/parsers/pm_io/psse.jl
+++ b/src/parsers/pm_io/psse.jl
@@ -1417,7 +1417,11 @@ function _psse2pm_transformer!(pm_data::Dict, pti_data::Dict, import_all::Bool)
                 for prefix in TRANSFORMER3W_PARAMETER_NAMES
                     for i in 1:length(WINDING_NAMES)
                         key = "$prefix$i"
-                        sub_data["ext"][key] = transformer[key]
+                        if pm_data["source_version"] ∈ ("32", "33")
+                            sub_data["ext"][key] = transformer[key]
+                        else
+                            continue
+                        end
                     end
                 end
 

--- a/src/parsers/pm_io/pti.jl
+++ b/src/parsers/pm_io/pti.jl
@@ -2035,9 +2035,12 @@ function _parse_pti_data(data_io::IO)
                                 im_str = strip(processing_elements[element_index + 2])
 
                                 if !isempty(t_str) && !isempty(re_str) && !isempty(im_str)
-                                    section_data_final["T$point_index"] = parse(Float64, t_str)
-                                    section_data_final["Re(F$point_index)"] = parse(Float64, re_str)
-                                    section_data_final["Im(F$point_index)"] = parse(Float64, im_str)
+                                    section_data_final["T$point_index"] =
+                                        parse(Float64, t_str)
+                                    section_data_final["Re(F$point_index)"] =
+                                        parse(Float64, re_str)
+                                    section_data_final["Im(F$point_index)"] =
+                                        parse(Float64, im_str)
                                     point_index += 1
                                 end
                                 element_index += 3
@@ -2091,8 +2094,10 @@ function _parse_pti_data(data_io::IO)
 
                             if !isempty(t_str) && !isempty(re_str) && !isempty(im_str)
                                 section_data_prev["T$point_index"] = parse(Float64, t_str)
-                                section_data_prev["Re(F$point_index)"] = parse(Float64, re_str)
-                                section_data_prev["Im(F$point_index)"] = parse(Float64, im_str)
+                                section_data_prev["Re(F$point_index)"] =
+                                    parse(Float64, re_str)
+                                section_data_prev["Im(F$point_index)"] =
+                                    parse(Float64, im_str)
                                 point_index += 1
                             end
                             element_index += 3

--- a/src/parsers/pm_io/pti.jl
+++ b/src/parsers/pm_io/pti.jl
@@ -2035,16 +2035,10 @@ function _parse_pti_data(data_io::IO)
                                 im_str = strip(processing_elements[element_index + 2])
 
                                 if !isempty(t_str) && !isempty(re_str) && !isempty(im_str)
-                                    t_val = parse(Float64, t_str)
-                                    re_val = parse(Float64, re_str)
-                                    im_val = parse(Float64, im_str)
-
-                                    if !(t_val == 0.0 && re_val == 0.0 && im_val == 0.0)
-                                        section_data_final["T$point_index"] = t_val
-                                        section_data_final["Re(F$point_index)"] = re_val
-                                        section_data_final["Im(F$point_index)"] = im_val
-                                        point_index += 1
-                                    end
+                                    section_data_final["T$point_index"] = parse(Float64, t_str)
+                                    section_data_final["Re(F$point_index)"] = parse(Float64, re_str)
+                                    section_data_final["Im(F$point_index)"] = parse(Float64, im_str)
+                                    point_index += 1
                                 end
                                 element_index += 3
                             end
@@ -2096,16 +2090,10 @@ function _parse_pti_data(data_io::IO)
                             im_str = strip(processing_elements[element_index + 2])
 
                             if !isempty(t_str) && !isempty(re_str) && !isempty(im_str)
-                                t_val = parse(Float64, t_str)
-                                re_val = parse(Float64, re_str)
-                                im_val = parse(Float64, im_str)
-
-                                if !(t_val == 0.0 && re_val == 0.0 && im_val == 0.0)
-                                    section_data_prev["T$point_index"] = t_val
-                                    section_data_prev["Re(F$point_index)"] = re_val
-                                    section_data_prev["Im(F$point_index)"] = im_val
-                                    point_index += 1
-                                end
+                                section_data_prev["T$point_index"] = parse(Float64, t_str)
+                                section_data_prev["Re(F$point_index)"] = parse(Float64, re_str)
+                                section_data_prev["Im(F$point_index)"] = parse(Float64, im_str)
+                                point_index += 1
                             end
                             element_index += 3
                         end

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -237,6 +237,10 @@ function _impedance_correction_table_lookup(data::Dict)
         y = table_data["scaling_factor"]
 
         if length(x) == length(y)
+            if length(x) < 2
+                @warn "Skipping impedance correction entry due to insufficient data points ($(length(x)) < 2): $(x)"
+                continue
+            end
             pwl_data = PiecewiseLinearData([(x[i], y[i]) for i in eachindex(x)])
             table_type =
                 if (

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -237,12 +237,6 @@ function _impedance_correction_table_lookup(data::Dict)
         y = table_data["scaling_factor"]
 
         if length(x) == length(y)
-            # Check for sufficient data points, function_data in IS.jl requires at least 2 points
-            # to build the PiecewiseLinearData, this will fail for single entries in PSSE files
-            if length(x) < 2
-                @warn "Skipping impedance correction entry due to insufficient data points ($(length(x)) < 2): $(x)"
-                continue
-            end
             pwl_data = PiecewiseLinearData([(x[i], y[i]) for i in eachindex(x)])
             table_type =
                 if (
@@ -1577,18 +1571,33 @@ function make_tap_transformer(
     ext = haskey(d, "ext") ? d["ext"] : Dict{String, Any}()
     control_objective_formatter =
         get(kwargs, :transformer_control_objective_formatter, nothing)
-    control_objective =
-        if control_objective_formatter !== nothing
-            control_objective_formatter(name)
-        else
-            get(d, "COD1", -99)
-        end
+    control_objective = if control_objective_formatter !== nothing
+        result = control_objective_formatter(name)
+        result !== nothing ? result : get(d, "COD1", -99)
+    else
+        get(d, "COD1", -99)
+    end
     resistance_formatter = get(kwargs, :transformer_resistance_formatter, nothing)
-    r = resistance_formatter !== nothing ? resistance_formatter(name) : d["br_r"]
+    r = if resistance_formatter !== nothing
+        result = resistance_formatter(name)
+        result !== nothing ? result : d["br_r"]
+    else
+        d["br_r"]
+    end
     reactance_formatter = get(kwargs, :transformer_reactance_formatter, nothing)
-    x = reactance_formatter !== nothing ? reactance_formatter(name) : d["br_x"]
+    x = if reactance_formatter !== nothing
+        result = reactance_formatter(name)
+        result !== nothing ? result : d["br_x"]
+    else
+        d["br_x"]
+    end
     tap_formatter = get(kwargs, :transformer_tap_formatter, nothing)
-    tap = tap_formatter !== nothing ? tap_formatter(name) : d["tap"]
+    tap = if tap_formatter !== nothing
+        result = tap_formatter(name)
+        result !== nothing ? result : d["tap"]
+    else
+        d["tap"]
+    end
 
     return TapTransformer(;
         name = name,
@@ -1631,12 +1640,12 @@ function make_phase_shifting_transformer(
     ext = haskey(d, "ext") ? d["ext"] : Dict{String, Any}()
     control_objective_formatter =
         get(kwargs, :transformer_control_objective_formatter, nothing)
-    control_objective =
-        if control_objective_formatter !== nothing
-            control_objective_formatter(name)
-        else
-            get(d, "COD1", -99)
-        end
+    control_objective = if control_objective_formatter !== nothing
+        result = control_objective_formatter(name)
+        result !== nothing ? result : get(d, "COD1", -99)
+    else
+        get(d, "COD1", -99)
+    end
     resistance_formatter = get(kwargs, :transformer_resistance_formatter, nothing)
     r = resistance_formatter !== nothing ? resistance_formatter(name) : d["br_r"]
     reactance_formatter = get(kwargs, :transformer_reactance_formatter, nothing)

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -237,6 +237,10 @@ function _impedance_correction_table_lookup(data::Dict)
         y = table_data["scaling_factor"]
 
         if length(x) == length(y)
+            if !issorted(x)
+                @warn "Skipping impedance correction entry due to non-ascending x-coordinates: $(x)"
+                continue
+            end
             pwl_data = PiecewiseLinearData([(x[i], y[i]) for i in eachindex(x)])
             table_type =
                 if (

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -237,8 +237,10 @@ function _impedance_correction_table_lookup(data::Dict)
         y = table_data["scaling_factor"]
 
         if length(x) == length(y)
-            if !issorted(x)
-                @warn "Skipping impedance correction entry due to non-ascending x-coordinates: $(x)"
+            # Check for sufficient data points, function_data in IS.jl requires at least 2 points
+            # to build the PiecewiseLinearData, this will fail for single entries in PSSE files
+            if length(x) < 2
+                @warn "Skipping impedance correction entry due to insufficient data points ($(length(x)) < 2): $(x)"
                 continue
             end
             pwl_data = PiecewiseLinearData([(x[i], y[i]) for i in eachindex(x)])


### PR DESCRIPTION
- The V35 PJM files were missing the OWNER data, which were manually fixed.
- The 3w parameters were missing a conditional to be added to the ext.
- The IC data in PJM file is a bit different from the ones we've been working with, requiring an extra step to handle it with the parser.

closes #1536 
